### PR TITLE
feat: add subscript and superscript syntax

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## Unreleased
+
+### Features
+
+* add optional superscript (`^text^`) and subscript (`~text~`) inline extensions
+* tighten strikethrough syntax to `~~text~~` only
+
+### Notes
+
+* single-tilde strikethrough is no longer supported; `~text~` is reserved for subscript when the feature is enabled
+
 ## [0.1.2](https://github.com/sebastian-software/ferromark/compare/ferromark-v0.1.1...ferromark-v0.1.2) (2026-02-09)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,16 +1,5 @@
 # Changelog
 
-## Unreleased
-
-### Features
-
-* add optional superscript (`^text^`) and subscript (`~text~`) inline extensions
-* tighten strikethrough syntax to `~~text~~` only
-
-### Notes
-
-* single-tilde strikethrough is no longer supported; `~text~` is reserved for subscript when the feature is enabled
-
 ## [0.1.2](https://github.com/sebastian-software/ferromark/compare/ferromark-v0.1.1...ferromark-v0.1.2) (2026-02-09)
 
 

--- a/README.md
+++ b/README.md
@@ -53,17 +53,19 @@ The fixtures are synthetic wiki-style documents with paragraphs, lists, code blo
 
 **All five GFM extensions**: Tables, strikethrough, task lists, autolink literals, disallowed raw HTML.
 
-**Beyond GFM**: Footnotes, front matter extraction (`---`/`+++`), heading IDs (GitHub-compatible slugs), math spans (`$`/`$$`), highlight/mark syntax (`==text==`), and callouts (`> [!NOTE]`, `> [!WARNING]`, ...).
+**Beyond GFM**: Footnotes, front matter extraction (`---`/`+++`), heading IDs (GitHub-compatible slugs), math spans (`$`/`$$`), highlight/mark syntax (`==text==`), superscript (`^text^`), subscript (`~text~`), and callouts (`> [!NOTE]`, `> [!WARNING]`, ...).
 
 **MDX support** (opt-in via `mdx` feature): Segment and render `.mdx` files without a JavaScript toolchain. Covers 90%+ of real-world MDX patterns in Next.js, Docusaurus, and Astro.
 
-13 feature flags to turn on exactly what you need:
+15 feature flags to turn on exactly what you need:
 
 ```text
-allow_html · allow_link_refs · tables · strikethrough · highlight · task_lists
+allow_html · allow_link_refs · tables · strikethrough · highlight · superscript · subscript · task_lists
 autolink_literals · disallowed_raw_html · footnotes · front_matter
 heading_ids · math · callouts
 ```
+
+Syntax note: ferromark uses `~~text~~` for strikethrough, `~text~` for subscript, and `^text^` for superscript. Single-tilde strikethrough is intentionally not supported.
 
 ## Trade-offs
 
@@ -212,7 +214,7 @@ Input bytes (&[u8])
 What makes this fast in practice:
 
 - **Block scanning** runs on `memchr` for line boundaries. Container state is a compact stack, not a tree.
-- **Inline parsing** has three phases: collect delimiter marks, resolve precedence (code spans, math, links, emphasis, strikethrough), emit. No backtracking.
+- **Inline parsing** has three phases: collect delimiter marks, resolve precedence (code spans, math, links, emphasis, strikethrough, subscript, superscript, highlight), emit. No backtracking.
 - **Emphasis resolution** uses the CommonMark modulo-3 rule with a delimiter stack instead of expensive rescans.
 - **SIMD scanning** (NEON on ARM) detects special characters in inline content.
 - **Zero-copy references**: events carry `Range` pointers into the input, not copied strings.
@@ -378,7 +380,7 @@ Ferromark optimization backlog: [docs/arch/ARCH-PLAN-001-performance-opportuniti
       <td align="center">🟨</td>
       <td align="center">🟩</td>
     </tr>
-    <tr><td colspan="5"><small>comrak has the broadest catalog; ferromark implements all 5 GFM extensions plus footnotes, front matter, heading IDs, math, and callouts; pulldown-cmark supports common GFM features; md4c supports common GFM features.</small></td></tr>
+    <tr><td colspan="5"><small>comrak has the broadest catalog; ferromark implements all 5 GFM extensions plus footnotes, front matter, heading IDs, math, highlight, subscript, superscript, and callouts; pulldown-cmark supports common GFM features; md4c supports common GFM features.</small></td></tr>
     <tr>
       <td><b>Spec compliance (CommonMark)</b></td>
       <td align="center">🟩</td>
@@ -394,7 +396,7 @@ Ferromark optimization backlog: [docs/arch/ARCH-PLAN-001-performance-opportuniti
       <td align="center">🟨</td>
       <td align="center">🟨</td>
     </tr>
-    <tr><td colspan="5"><small>Fine-grained flags let you disable features to reduce work. md4c has many flags; ferromark has 13 options; pulldown-cmark and comrak use option structs.</small></td></tr>
+    <tr><td colspan="5"><small>Fine-grained flags let you disable features to reduce work. md4c has many flags; ferromark has 15 options; pulldown-cmark and comrak use option structs.</small></td></tr>
     <tr>
       <td><b>Raw HTML control</b></td>
       <td align="center">🟩</td>
@@ -525,6 +527,8 @@ src/
 │   ├── code_span.rs
 │   ├── emphasis.rs      # Modulo-3 stack optimization
 │   ├── strikethrough.rs # GFM strikethrough resolution
+│   ├── subscript.rs     # Subscript resolution (~text~)
+│   ├── superscript.rs   # Superscript resolution (^text^)
 │   ├── math.rs          # Math span resolution ($/$$ delimiters)
 │   └── links.rs         # Link/image/autolink parsing
 ├── mdx/            # MDX segmenter + renderer (feature = "mdx")

--- a/docs/arch/ADR-0008-inline-markup-syntax-alignment.md
+++ b/docs/arch/ADR-0008-inline-markup-syntax-alignment.md
@@ -1,0 +1,65 @@
+# ADR-0008: Inline Markup Syntax Alignment for Highlight, Superscript, and Subscript
+
+**Status:** Accepted
+**Date:** 2026-03-12
+
+## Context
+
+ferromark already supports opt-in `==text==` highlight syntax and currently treats both `~text~` and `~~text~~` as strikethrough. We want to add opt-in superscript and subscript without carrying an ambiguous tilde grammar long-term.
+
+The main conflict is subscript: the most common cross-parser syntax is `~text~`, but that collides directly with single-tilde strikethrough. GitHub Flavored Markdown permits both one-tilde and two-tilde strikethrough, while Pandoc and several extension ecosystems use a more internally consistent trio:
+
+- `~~text~~` for strikethrough
+- `~text~` for subscript
+- `^text^` for superscript
+
+## Decision
+
+ferromark will align these inline syntaxes as follows:
+
+| Syntax | Meaning | Option | Default |
+|---|---|---|---|
+| `~~text~~` | Strikethrough | `strikethrough` | `true` |
+| `~text~` | Subscript | `subscript` | `false` |
+| `^text^` | Superscript | `superscript` | `false` |
+| `==text==` | Highlight | `highlight` | `false` |
+
+### Compatibility choice
+
+ferromark deliberately drops single-tilde strikethrough support. This is a conscious divergence from the GFM specification in favor of a cleaner combined inline grammar and better interoperability with parsers and extension stacks that support all three constructs together.
+
+### Options model
+
+Each feature remains independently controllable in `Options`. No aggregate "extended CommonMark" flag is introduced in this change.
+
+### Performance model
+
+Optional inline extensions should remain effectively free when disabled. The parser should preserve specialized fast paths for the default configuration rather than threading additional runtime checks through the hottest scan loops.
+
+## Consequences
+
+- `~text~` is no longer strikethrough in ferromark.
+- Existing users who relied on single-tilde strikethrough must switch to `~~text~~`.
+- Subscript can be added without syntax ambiguity.
+- Superscript and subscript stay opt-in and benchmarkable independently.
+- Documentation must explicitly call out the GFM divergence so the behavior is transparent.
+
+## Documentation requirements
+
+- Update README feature lists, option examples, and syntax examples.
+- Add changelog notes describing the single-tilde strikethrough change.
+- Add tests that show the new literal behavior for `~text~` when `subscript` is disabled.
+- Note the rationale and external references in the PR description.
+
+## References
+
+- GFM Spec
+  https://github.github.io/gfm/
+- Pandoc Manual
+  https://pandoc.org/MANUAL.html
+- markdown-it ecosystem plugins
+  https://mdit-plugins.github.io/sub.html
+  https://github.com/markdown-it/markdown-it-sup
+- PyMdown Extensions
+  https://facelessuser.github.io/pymdown-extensions/extensions/tilde/
+  https://facelessuser.github.io/pymdown-extensions/extensions/caret/

--- a/docs/plans/2026-03-12-inline-markup-trio-design.md
+++ b/docs/plans/2026-03-12-inline-markup-trio-design.md
@@ -1,0 +1,75 @@
+# Inline Markup Trio Design
+
+**Date:** 2026-03-12
+**Status:** Approved
+
+## Summary
+
+Implement `highlight`, `superscript`, and `subscript` as separate optional inline extensions in one PR, while tightening strikethrough to `~~text~~` only.
+
+## Goals
+
+- Add `^text^` superscript support behind its own option.
+- Add `~text~` subscript support behind its own option.
+- Keep `==text==` highlight as its own option.
+- Eliminate the long-term syntax conflict between subscript and single-tilde strikethrough.
+- Keep disabled-path performance effectively neutral.
+- Make the behavioral change explicit in docs and release notes.
+
+## Non-goals
+
+- No aggregate preset flag in this change.
+- No attempt to remain fully compatible with GFM single-tilde strikethrough.
+- No iA Presenter import mode or syntax aliasing.
+
+## Chosen syntax
+
+- `~~text~~` -> `<del>`
+- `~text~` -> `<sub>`
+- `^text^` -> `<sup>`
+- `==text==` -> `<mark>`
+
+## Why this design
+
+This matches the cleanest ecosystem-wide trio used by Pandoc and common Markdown extension stacks. It avoids a permanent ambiguity around `~...~` and keeps each extension independently measurable and debuggable.
+
+The main tradeoff is a deliberate divergence from GFM's allowance for single-tilde strikethrough. We accept that tradeoff because ferromark is still early and the combined syntax system is stronger and easier to explain.
+
+## API shape
+
+Add two new booleans to `Options`:
+
+- `superscript: bool`
+- `subscript: bool`
+
+Keep:
+
+- `strikethrough: bool`
+- `highlight: bool`
+
+No preset helper is added in this change.
+
+## Parsing model
+
+- Keep the current three-phase inline architecture.
+- Resolve code spans and math before these extensions.
+- Resolve links before emphasis-like formatting where required by existing precedence.
+- Treat `superscript`, `subscript`, `strikethrough`, and `highlight` as separate delimiter grammars.
+- Keep default-path scanning specialized so disabled features do not add meaningful cost.
+
+## Documentation scope
+
+- ADR for the syntax choice and GFM divergence
+- README updates
+- changelog note
+- PR description note
+- feature examples and non-examples in tests
+
+## Validation
+
+- targeted parser tests for each syntax
+- conflict tests around `~text~`, `~~text~~`, `^text^`, and nesting
+- `cargo test`
+- `cargo clippy --all-targets -- -D warnings`
+- `cargo fmt --check`
+- branch vs `main` benchmark spot-checks for the disabled path

--- a/docs/plans/2026-03-12-inline-markup-trio-implementation-plan.md
+++ b/docs/plans/2026-03-12-inline-markup-trio-implementation-plan.md
@@ -1,0 +1,61 @@
+# Inline Markup Trio Implementation Plan
+
+**Date:** 2026-03-12
+
+## Scope
+
+One PR covering:
+
+- `superscript`
+- `subscript`
+- strikethrough tightening to `~~...~~`
+- documentation and benchmarks
+
+## Steps
+
+1. Extend `Options`
+
+- Add `superscript: bool`
+- Add `subscript: bool`
+- Update defaults and examples
+
+2. Update inline events and renderer
+
+- Add `SuperscriptStart` / `SuperscriptEnd`
+- Add `SubscriptStart` / `SubscriptEnd`
+- Render to `<sup>` and `<sub>`
+
+3. Add resolvers
+
+- Add a superscript resolver for `^...^`
+- Add a subscript resolver for `~...~`
+- Tighten strikethrough resolver to `~~...~~` only
+
+4. Preserve fast paths
+
+- Keep specialized mark collection/scanner paths for the default configuration
+- Avoid extra runtime conditionals in the default hot path
+
+5. Add tests
+
+- new superscript tests
+- new subscript tests
+- updated strikethrough tests
+- precedence and disabled-mode tests
+
+6. Update documentation
+
+- README
+- CHANGELOG
+- ADR references in PR description
+
+7. Benchmark
+
+- compare disabled-path throughput against `main`
+- run at least one tilde/caret-heavy synthetic workload
+
+## Risk focus
+
+- precedence interactions with emphasis, code spans, math, and links
+- accidental regressions in existing strikethrough behavior
+- hidden overhead in the disabled default path

--- a/src/inline/event.rs
+++ b/src/inline/event.rs
@@ -21,10 +21,18 @@ pub enum InlineEvent {
     /// End of strong emphasis.
     StrongEnd,
 
-    /// Start of strikethrough (`~~text~~` or `~text~`).
+    /// Start of strikethrough (`~~text~~`).
     StrikethroughStart,
     /// End of strikethrough.
     StrikethroughEnd,
+    /// Start of subscript (`~text~`).
+    SubscriptStart,
+    /// End of subscript.
+    SubscriptEnd,
+    /// Start of superscript (`^text^`).
+    SuperscriptStart,
+    /// End of superscript.
+    SuperscriptEnd,
     /// Start of highlight/mark (`==text==`).
     HighlightStart,
     /// End of highlight/mark.

--- a/src/inline/marks.rs
+++ b/src/inline/marks.rs
@@ -151,6 +151,7 @@ pub static SPECIAL_CHARS: [bool; 256] = {
     table[b'_' as usize] = true; // Emphasis
     table[b'~' as usize] = true; // Strikethrough
     table[b'=' as usize] = true; // Highlight
+    table[b'^' as usize] = true; // Superscript
     table[b'$' as usize] = true; // Math span
     table[b'\\' as usize] = true; // Escape
     table[b'\n' as usize] = true; // Line break
@@ -162,22 +163,35 @@ pub static SPECIAL_CHARS: [bool; 256] = {
 
 /// Scan text and collect marks for the default inline syntax set.
 pub fn collect_marks(text: &[u8], buffer: &mut MarkBuffer) {
-    collect_marks_impl::<false>(text, buffer);
+    collect_marks_impl::<false, false>(text, buffer);
 }
 
 /// Scan text and collect marks with highlight support enabled.
 pub fn collect_marks_highlight(text: &[u8], buffer: &mut MarkBuffer) {
-    collect_marks_impl::<true>(text, buffer);
+    collect_marks_impl::<true, false>(text, buffer);
 }
 
-fn collect_marks_impl<const HIGHLIGHT: bool>(text: &[u8], buffer: &mut MarkBuffer) {
+/// Scan text and collect marks with superscript support enabled.
+pub fn collect_marks_superscript(text: &[u8], buffer: &mut MarkBuffer) {
+    collect_marks_impl::<false, true>(text, buffer);
+}
+
+/// Scan text and collect marks with highlight and superscript enabled.
+pub fn collect_marks_highlight_superscript(text: &[u8], buffer: &mut MarkBuffer) {
+    collect_marks_impl::<true, true>(text, buffer);
+}
+
+fn collect_marks_impl<const HIGHLIGHT: bool, const SUPERSCRIPT: bool>(
+    text: &[u8],
+    buffer: &mut MarkBuffer,
+) {
     buffer.clear();
 
     let mut pos = 0;
     let len = text.len();
 
     while pos < len {
-        let Some(next) = next_special::<HIGHLIGHT>(text, pos) else {
+        let Some(next) = next_special::<HIGHLIGHT, SUPERSCRIPT>(text, pos) else {
             break;
         };
         pos = next;
@@ -221,8 +235,12 @@ fn collect_marks_impl<const HIGHLIGHT: bool>(text: &[u8], buffer: &mut MarkBuffe
                 }
             }
 
-            b'*' | b'_' | b'~' | b'=' => {
+            b'*' | b'_' | b'~' | b'=' | b'^' => {
                 if b == b'=' && !HIGHLIGHT {
+                    pos += 1;
+                    continue;
+                }
+                if b == b'^' && !SUPERSCRIPT {
                     pos += 1;
                     continue;
                 }
@@ -234,9 +252,13 @@ fn collect_marks_impl<const HIGHLIGHT: bool>(text: &[u8], buffer: &mut MarkBuffe
                 }
 
                 // Determine opener/closer status based on surrounding Unicode chars
-                // Tildes and equals use *-style rules (not underscore-style)
+                // Tildes, carets, and equals use *-style rules (not underscore-style)
                 let flags = compute_emphasis_flags_with_context(
-                    if ch == b'~' || ch == b'=' { b'*' } else { ch },
+                    if ch == b'~' || ch == b'=' || ch == b'^' {
+                        b'*'
+                    } else {
+                        ch
+                    },
                     text,
                     start,
                     pos,
@@ -365,13 +387,16 @@ fn collect_marks_impl<const HIGHLIGHT: bool>(text: &[u8], buffer: &mut MarkBuffe
 }
 
 #[inline]
-fn next_special<const HIGHLIGHT: bool>(text: &[u8], start: usize) -> Option<usize> {
+fn next_special<const HIGHLIGHT: bool, const SUPERSCRIPT: bool>(
+    text: &[u8],
+    start: usize,
+) -> Option<usize> {
     let pos = {
         #[cfg(all(target_arch = "aarch64", target_feature = "neon"))]
         {
             let mut pos = start;
             if let Some(found) =
-                unsafe { simd::next_mark_special_simd::<HIGHLIGHT>(text, &mut pos) }
+                unsafe { simd::next_mark_special_simd::<HIGHLIGHT, SUPERSCRIPT>(text, &mut pos) }
             {
                 return Some(found);
             }
@@ -396,6 +421,11 @@ fn next_special<const HIGHLIGHT: bool>(text: &[u8], start: usize) -> Option<usiz
     }
     if let Some(i) = memchr::memchr(b'$', slice) {
         best = Some(best.map_or(i, |b| b.min(i)));
+    }
+    if SUPERSCRIPT {
+        if let Some(i) = memchr::memchr(b'^', slice) {
+            best = Some(best.map_or(i, |b| b.min(i)));
+        }
     }
     if HIGHLIGHT {
         if let Some(i) = memchr::memchr(b'=', slice) {

--- a/src/inline/mod.rs
+++ b/src/inline/mod.rs
@@ -14,6 +14,8 @@ pub mod marks;
 mod math;
 mod simd;
 mod strikethrough;
+mod subscript;
+mod superscript;
 
 pub use event::InlineEvent;
 pub use links::AutolinkLiteralKind;
@@ -28,10 +30,15 @@ use links::{
     Autolink, AutolinkLiteral, Link, RefLink, find_autolink_literals_into, find_autolinks_into,
     resolve_links_into, resolve_reference_links_into,
 };
-use marks::{Mark, MarkBuffer, collect_marks, collect_marks_highlight, flags};
+use marks::{
+    Mark, MarkBuffer, collect_marks, collect_marks_highlight, collect_marks_highlight_superscript,
+    collect_marks_superscript, flags,
+};
 use math::{MathSpan, resolve_math_spans};
 use memchr::memchr;
 use strikethrough::{StrikethroughMatch, resolve_strikethrough_into};
+use subscript::{SubscriptMatch, resolve_subscript_into};
+use superscript::{SuperscriptMatch, resolve_superscript_into};
 
 /// Inline parser state.
 pub struct InlineParser {
@@ -59,6 +66,8 @@ pub struct InlineParser {
     emphasis_stacks: EmphasisStacks,
     emphasis_matches: Vec<EmphasisMatch>,
     strikethrough_matches: Vec<StrikethroughMatch>,
+    subscript_matches: Vec<SubscriptMatch>,
+    superscript_matches: Vec<SuperscriptMatch>,
     highlight_matches: Vec<HighlightMatch>,
     al_code_span_ranges: Vec<(u32, u32)>,
     al_link_ranges: Vec<(u32, u32)>,
@@ -97,6 +106,8 @@ impl InlineParser {
             emphasis_stacks: EmphasisStacks::default(),
             emphasis_matches: Vec::with_capacity(16),
             strikethrough_matches: Vec::with_capacity(8),
+            subscript_matches: Vec::with_capacity(8),
+            superscript_matches: Vec::with_capacity(8),
             highlight_matches: Vec::with_capacity(8),
             al_code_span_ranges: Vec::with_capacity(8),
             al_link_ranges: Vec::with_capacity(8),
@@ -118,11 +129,11 @@ impl InlineParser {
         events: &mut Vec<InlineEvent>,
     ) {
         self.parse_with_options(
-            text, link_refs, allow_html, true, false, true, false, None, events,
+            text, link_refs, allow_html, true, false, false, false, true, false, None, events,
         );
     }
 
-    /// Parse inline content with full GFM options.
+    /// Parse inline content with configurable inline extensions.
     #[allow(clippy::too_many_arguments)]
     pub fn parse_with_options(
         &mut self,
@@ -131,13 +142,19 @@ impl InlineParser {
         allow_html: bool,
         strikethrough: bool,
         highlight: bool,
+        superscript: bool,
+        subscript: bool,
         autolink_literals: bool,
         math: bool,
         footnote_store: Option<&FootnoteStore>,
         events: &mut Vec<InlineEvent>,
     ) {
-        let has_specials = if highlight {
+        let has_specials = if highlight && superscript {
+            has_inline_specials_highlight_superscript(text)
+        } else if highlight {
             has_inline_specials_highlight(text)
+        } else if superscript {
+            has_inline_specials_superscript(text)
         } else {
             has_inline_specials(text)
         };
@@ -155,8 +172,12 @@ impl InlineParser {
         // Phase 1: Collect marks
         self.mark_buffer.reserve_for_text(text.len());
         if has_specials {
-            if highlight {
+            if highlight && superscript {
+                collect_marks_highlight_superscript(text, &mut self.mark_buffer);
+            } else if highlight {
                 collect_marks_highlight(text, &mut self.mark_buffer);
+            } else if superscript {
+                collect_marks_superscript(text, &mut self.mark_buffer);
             } else {
                 collect_marks(text, &mut self.mark_buffer);
             }
@@ -222,7 +243,7 @@ impl InlineParser {
         });
 
         // Fourth: collect bracket positions and detect inline delimiter candidates in one pass
-        let (has_emphasis_marks, has_strikethrough_marks, has_highlight_marks) =
+        let (has_emphasis_marks, has_tilde_marks, has_highlight_marks, has_superscript_marks) =
             Self::collect_brackets_and_scan_emphasis(
                 self.mark_buffer.marks(),
                 &mut self.open_brackets,
@@ -326,7 +347,7 @@ impl InlineParser {
         };
 
         // Sixth: strikethrough (after emphasis, since they share the mark buffer)
-        if has_strikethrough_marks && strikethrough {
+        if has_tilde_marks && strikethrough {
             resolve_strikethrough_into(
                 self.mark_buffer.marks_mut(),
                 &self.link_boundaries,
@@ -337,7 +358,35 @@ impl InlineParser {
         }
         let strikethrough_matches = self.strikethrough_matches.as_slice();
 
-        // Seventh: highlight/mark (after emphasis/strikethrough)
+        // Seventh: subscript (after strikethrough, since they share `~`)
+        if has_tilde_marks && subscript {
+            resolve_subscript_into(
+                self.mark_buffer.marks_mut(),
+                text,
+                &self.link_boundaries,
+                &self.link_dest_ranges,
+                &mut self.subscript_matches,
+            );
+        } else {
+            self.subscript_matches.clear();
+        }
+        let subscript_matches = self.subscript_matches.as_slice();
+
+        // Eighth: superscript
+        if has_superscript_marks && superscript {
+            resolve_superscript_into(
+                self.mark_buffer.marks_mut(),
+                text,
+                &self.link_boundaries,
+                &self.link_dest_ranges,
+                &mut self.superscript_matches,
+            );
+        } else {
+            self.superscript_matches.clear();
+        }
+        let superscript_matches = self.superscript_matches.as_slice();
+
+        // Ninth: highlight/mark
         if has_highlight_marks && highlight {
             resolve_highlight_into(
                 self.mark_buffer.marks_mut(),
@@ -351,7 +400,7 @@ impl InlineParser {
         }
         let highlight_matches = self.highlight_matches.as_slice();
 
-        // Eighth: autolink literals (bare URLs, www, emails)
+        // Tenth: autolink literals (bare URLs, www, emails)
         if may_have_autolinks {
             // Build code span ranges for overlap checking (reuse Vec)
             self.al_code_span_ranges.clear();
@@ -382,7 +431,7 @@ impl InlineParser {
             self.autolink_literals.clear();
         }
 
-        // Ninth: footnote references (`[^label]`)
+        // Eleventh: footnote references (`[^label]`)
         self.footnote_refs.clear();
         if let Some(fn_store) = footnote_store {
             Self::resolve_footnote_refs(
@@ -406,6 +455,8 @@ impl InlineParser {
             &self.math_spans,
             emphasis_matches,
             strikethrough_matches,
+            subscript_matches,
+            superscript_matches,
             highlight_matches,
             &self.autolink_literals,
             resolved_links,
@@ -504,12 +555,12 @@ impl InlineParser {
     }
 
     /// Collect bracket positions for link parsing.
-    /// Returns (has_emphasis_marks, has_strikethrough_marks, has_highlight_marks).
+    /// Returns (has_emphasis_marks, has_tilde_marks, has_highlight_marks, has_superscript_marks).
     fn collect_brackets_and_scan_emphasis(
         marks: &[Mark],
         open_brackets: &mut Vec<(u32, bool)>,
         close_brackets: &mut Vec<u32>,
-    ) -> (bool, bool, bool) {
+    ) -> (bool, bool, bool, bool) {
         let estimated = (marks.len() / 4).max(4);
         open_brackets.clear();
         close_brackets.clear();
@@ -517,16 +568,19 @@ impl InlineParser {
         close_brackets.reserve(estimated);
 
         let mut has_emphasis_marks = false;
-        let mut has_strikethrough_marks = false;
+        let mut has_tilde_marks = false;
         let mut has_highlight_marks = false;
+        let mut has_superscript_marks = false;
         for mark in marks {
             if mark.flags & flags::IN_CODE == 0 {
                 if mark.ch == b'*' || mark.ch == b'_' {
                     has_emphasis_marks = true;
                 } else if mark.ch == b'~' {
-                    has_strikethrough_marks = true;
+                    has_tilde_marks = true;
                 } else if mark.ch == b'=' {
                     has_highlight_marks = true;
+                } else if mark.ch == b'^' {
+                    has_superscript_marks = true;
                 }
             }
             // Skip brackets inside code spans
@@ -548,8 +602,9 @@ impl InlineParser {
         }
         (
             has_emphasis_marks,
-            has_strikethrough_marks,
+            has_tilde_marks,
             has_highlight_marks,
+            has_superscript_marks,
         )
     }
 
@@ -562,6 +617,8 @@ impl InlineParser {
         math_spans: &[MathSpan],
         emphasis_matches: &[EmphasisMatch],
         strikethrough_matches: &[StrikethroughMatch],
+        subscript_matches: &[SubscriptMatch],
+        superscript_matches: &[SuperscriptMatch],
         highlight_matches: &[HighlightMatch],
         autolink_literals: &[AutolinkLiteral],
         resolved_links: &[Link],
@@ -594,6 +651,8 @@ impl InlineParser {
             + html_spans.len()
             + (emphasis_matches.len() * 2)
             + (strikethrough_matches.len() * 2)
+            + (subscript_matches.len() * 2)
+            + (superscript_matches.len() * 2)
             + (highlight_matches.len() * 2);
         emit_points.clear();
         emit_points.reserve(estimated_events.max(8));
@@ -819,6 +878,34 @@ impl InlineParser {
             });
         }
 
+        // Add subscript events
+        for m in subscript_matches {
+            emit_points.push(EmitPoint {
+                pos: m.opener_start,
+                kind: EmitKind::SubscriptStart,
+                end: m.opener_end,
+            });
+            emit_points.push(EmitPoint {
+                pos: m.closer_start,
+                kind: EmitKind::SubscriptEnd,
+                end: m.closer_end,
+            });
+        }
+
+        // Add superscript events
+        for m in superscript_matches {
+            emit_points.push(EmitPoint {
+                pos: m.opener_start,
+                kind: EmitKind::SuperscriptStart,
+                end: m.opener_end,
+            });
+            emit_points.push(EmitPoint {
+                pos: m.closer_start,
+                kind: EmitKind::SuperscriptEnd,
+                end: m.closer_end,
+            });
+        }
+
         // Add highlight events
         for m in highlight_matches {
             emit_points.push(EmitPoint {
@@ -918,6 +1005,8 @@ impl InlineParser {
                         | EmitKind::StrongEnd
                         | EmitKind::EmphasisEnd
                         | EmitKind::StrikethroughEnd
+                        | EmitKind::SubscriptEnd
+                        | EmitKind::SuperscriptEnd
                         | EmitKind::HighlightEnd
                         | EmitKind::LinkEnd
                         | EmitKind::ImageEnd
@@ -1023,6 +1112,24 @@ impl InlineParser {
                 }
                 EmitKind::StrikethroughEnd => {
                     events.push(InlineEvent::StrikethroughEnd);
+                    skip_until = point.end;
+                }
+                EmitKind::SubscriptStart => {
+                    events.push(InlineEvent::SubscriptStart);
+                    pos = point.end;
+                    skip_until = point.end;
+                }
+                EmitKind::SubscriptEnd => {
+                    events.push(InlineEvent::SubscriptEnd);
+                    skip_until = point.end;
+                }
+                EmitKind::SuperscriptStart => {
+                    events.push(InlineEvent::SuperscriptStart);
+                    pos = point.end;
+                    skip_until = point.end;
+                }
+                EmitKind::SuperscriptEnd => {
+                    events.push(InlineEvent::SuperscriptEnd);
                     skip_until = point.end;
                 }
                 EmitKind::HighlightStart => {
@@ -1172,7 +1279,7 @@ impl InlineParser {
 fn has_inline_specials(input: &[u8]) -> bool {
     #[cfg(all(target_arch = "aarch64", target_feature = "neon"))]
     {
-        if let Some(result) = unsafe { simd::has_inline_specials_simd::<false>(input) } {
+        if let Some(result) = unsafe { simd::has_inline_specials_simd::<false, false>(input) } {
             return result;
         }
     }
@@ -1191,13 +1298,51 @@ fn has_inline_specials(input: &[u8]) -> bool {
 fn has_inline_specials_highlight(input: &[u8]) -> bool {
     #[cfg(all(target_arch = "aarch64", target_feature = "neon"))]
     {
-        if let Some(result) = unsafe { simd::has_inline_specials_simd::<true>(input) } {
+        if let Some(result) = unsafe { simd::has_inline_specials_simd::<true, false>(input) } {
             return result;
         }
     }
     for &b in input {
         match b {
             b'*' | b'_' | b'`' | b'[' | b']' | b'<' | b'\\' | b'\n' | b'~' | b'$' | b'=' => {
+                return true;
+            }
+            _ => {}
+        }
+    }
+    false
+}
+
+#[inline]
+fn has_inline_specials_superscript(input: &[u8]) -> bool {
+    #[cfg(all(target_arch = "aarch64", target_feature = "neon"))]
+    {
+        if let Some(result) = unsafe { simd::has_inline_specials_simd::<false, true>(input) } {
+            return result;
+        }
+    }
+    for &b in input {
+        match b {
+            b'*' | b'_' | b'`' | b'[' | b']' | b'<' | b'\\' | b'\n' | b'~' | b'$' | b'^' => {
+                return true;
+            }
+            _ => {}
+        }
+    }
+    false
+}
+
+#[inline]
+fn has_inline_specials_highlight_superscript(input: &[u8]) -> bool {
+    #[cfg(all(target_arch = "aarch64", target_feature = "neon"))]
+    {
+        if let Some(result) = unsafe { simd::has_inline_specials_simd::<true, true>(input) } {
+            return result;
+        }
+    }
+    for &b in input {
+        match b {
+            b'*' | b'_' | b'`' | b'[' | b']' | b'<' | b'\\' | b'\n' | b'~' | b'$' | b'=' | b'^' => {
                 return true;
             }
             _ => {}
@@ -1294,6 +1439,10 @@ enum EmitKind {
     StrongEnd,
     StrikethroughStart,
     StrikethroughEnd,
+    SubscriptStart,
+    SubscriptEnd,
+    SuperscriptStart,
+    SuperscriptEnd,
     HighlightStart,
     HighlightEnd,
     Escape(u8),

--- a/src/inline/mod.rs
+++ b/src/inline/mod.rs
@@ -311,14 +311,30 @@ impl InlineParser {
         self.autolink_ranges
             .extend(self.autolinks.iter().map(|al| (al.start, al.end)));
 
-        // Fifth: emphasis (lowest precedence)
+        // Fifth: footnote references (`[^label]`)
+        self.footnote_refs.clear();
+        if let Some(fn_store) = footnote_store {
+            Self::resolve_footnote_refs(
+                text,
+                &self.open_brackets,
+                &self.close_brackets,
+                resolved_links,
+                resolved_ref_links,
+                &self.code_spans,
+                fn_store,
+                &mut self.footnote_refs,
+            );
+        }
+
+        // Sixth: emphasis (lowest precedence)
         // Pass link and autolink boundaries so emphasis can't cross them
         self.link_boundaries.clear();
         self.link_boundaries.reserve(
             resolved_links.len()
                 + resolved_ref_links.len()
                 + self.autolinks.len()
-                + self.html_spans.len(),
+                + self.html_spans.len()
+                + self.footnote_refs.len(),
         );
         self.link_boundaries
             .extend(resolved_links.iter().map(|l| (l.start, l.text_end)));
@@ -333,6 +349,10 @@ impl InlineParser {
         for span in &self.html_spans {
             self.link_boundaries.push((span.start, span.end));
         }
+        // Also include resolved footnote references
+        for fref in &self.footnote_refs {
+            self.link_boundaries.push((fref.start, fref.end));
+        }
         let emphasis_matches = if has_emphasis_marks {
             resolve_emphasis_with_stacks_into(
                 self.mark_buffer.marks_mut(),
@@ -346,7 +366,7 @@ impl InlineParser {
             &[]
         };
 
-        // Sixth: strikethrough (after emphasis, since they share the mark buffer)
+        // Seventh: strikethrough (after emphasis, since they share the mark buffer)
         if has_tilde_marks && strikethrough {
             resolve_strikethrough_into(
                 self.mark_buffer.marks_mut(),
@@ -358,7 +378,7 @@ impl InlineParser {
         }
         let strikethrough_matches = self.strikethrough_matches.as_slice();
 
-        // Seventh: subscript (after strikethrough, since they share `~`)
+        // Eighth: subscript (after strikethrough, since they share `~`)
         if has_tilde_marks && subscript {
             resolve_subscript_into(
                 self.mark_buffer.marks_mut(),
@@ -372,7 +392,7 @@ impl InlineParser {
         }
         let subscript_matches = self.subscript_matches.as_slice();
 
-        // Eighth: superscript
+        // Ninth: superscript
         if has_superscript_marks && superscript {
             resolve_superscript_into(
                 self.mark_buffer.marks_mut(),
@@ -386,7 +406,7 @@ impl InlineParser {
         }
         let superscript_matches = self.superscript_matches.as_slice();
 
-        // Ninth: highlight/mark
+        // Tenth: highlight/mark
         if has_highlight_marks && highlight {
             resolve_highlight_into(
                 self.mark_buffer.marks_mut(),
@@ -400,7 +420,7 @@ impl InlineParser {
         }
         let highlight_matches = self.highlight_matches.as_slice();
 
-        // Tenth: autolink literals (bare URLs, www, emails)
+        // Eleventh: autolink literals (bare URLs, www, emails)
         if may_have_autolinks {
             // Build code span ranges for overlap checking (reuse Vec)
             self.al_code_span_ranges.clear();
@@ -429,21 +449,6 @@ impl InlineParser {
             );
         } else {
             self.autolink_literals.clear();
-        }
-
-        // Eleventh: footnote references (`[^label]`)
-        self.footnote_refs.clear();
-        if let Some(fn_store) = footnote_store {
-            Self::resolve_footnote_refs(
-                text,
-                &self.open_brackets,
-                &self.close_brackets,
-                resolved_links,
-                resolved_ref_links,
-                &self.code_spans,
-                fn_store,
-                &mut self.footnote_refs,
-            );
         }
 
         // Phase 3: Emit events

--- a/src/inline/simd.rs
+++ b/src/inline/simd.rs
@@ -104,7 +104,6 @@ pub unsafe fn next_mark_special_simd<const HIGHLIGHT: bool, const SUPERSCRIPT: b
                 // Find first match within the chunk.
                 for i in 0..16 {
                     if is_mark_special::<HIGHLIGHT, SUPERSCRIPT>(text[p + i]) {
-                        *pos = p + 16;
                         return Some(p + i);
                     }
                 }

--- a/src/inline/simd.rs
+++ b/src/inline/simd.rs
@@ -24,34 +24,42 @@ unsafe fn mask_has_any(mask: uint8x16_t) -> bool {
 
 #[cfg(all(target_arch = "aarch64", target_feature = "neon"))]
 #[inline]
-fn is_inline_special<const HIGHLIGHT: bool>(b: u8) -> bool {
+fn is_inline_special<const HIGHLIGHT: bool, const SUPERSCRIPT: bool>(b: u8) -> bool {
     matches!(
         b,
         b'*' | b'_' | b'`' | b'[' | b']' | b'<' | b'\\' | b'\n' | b'~' | b'$'
     ) || (HIGHLIGHT && b == b'=')
+        || (SUPERSCRIPT && b == b'^')
 }
 
 #[cfg(all(target_arch = "aarch64", target_feature = "neon"))]
 #[inline]
-fn is_mark_special<const HIGHLIGHT: bool>(b: u8) -> bool {
+fn is_mark_special<const HIGHLIGHT: bool, const SUPERSCRIPT: bool>(b: u8) -> bool {
     matches!(
         b,
         b'`' | b'*' | b'_' | b'\\' | b'\n' | b'[' | b']' | b'<' | b'~' | b'$'
     ) || (HIGHLIGHT && b == b'=')
+        || (SUPERSCRIPT && b == b'^')
 }
 
 /// SIMD-accelerated check for inline specials.
 /// Returns Some(result) if SIMD path was used, otherwise None.
 #[cfg(all(target_arch = "aarch64", target_feature = "neon"))]
 #[target_feature(enable = "neon")]
-pub unsafe fn has_inline_specials_simd<const HIGHLIGHT: bool>(input: &[u8]) -> Option<bool> {
+pub unsafe fn has_inline_specials_simd<const HIGHLIGHT: bool, const SUPERSCRIPT: bool>(
+    input: &[u8],
+) -> Option<bool> {
     let len = input.len();
     let mut pos = 0usize;
     while pos + 16 <= len {
         unsafe {
             let v = vld1q_u8(input.as_ptr().add(pos));
-            let mask = if HIGHLIGHT {
+            let mask = if HIGHLIGHT && SUPERSCRIPT {
+                any_eq_mask(v, b"*_`[]<\\\n~$=^")
+            } else if HIGHLIGHT {
                 any_eq_mask(v, b"*_`[]<\\\n~$=")
+            } else if SUPERSCRIPT {
+                any_eq_mask(v, b"*_`[]<\\\n~$^")
             } else {
                 any_eq_mask(v, b"*_`[]<\\\n~$")
             };
@@ -63,7 +71,7 @@ pub unsafe fn has_inline_specials_simd<const HIGHLIGHT: bool>(input: &[u8]) -> O
     }
     // Fallback for tail.
     for &b in &input[pos..] {
-        if is_inline_special::<HIGHLIGHT>(b) {
+        if is_inline_special::<HIGHLIGHT, SUPERSCRIPT>(b) {
             return Some(true);
         }
     }
@@ -74,7 +82,7 @@ pub unsafe fn has_inline_specials_simd<const HIGHLIGHT: bool>(input: &[u8]) -> O
 /// Advances `pos` to the end of SIMD-scanned region if no hit.
 #[cfg(all(target_arch = "aarch64", target_feature = "neon"))]
 #[target_feature(enable = "neon")]
-pub unsafe fn next_mark_special_simd<const HIGHLIGHT: bool>(
+pub unsafe fn next_mark_special_simd<const HIGHLIGHT: bool, const SUPERSCRIPT: bool>(
     text: &[u8],
     pos: &mut usize,
 ) -> Option<usize> {
@@ -83,15 +91,19 @@ pub unsafe fn next_mark_special_simd<const HIGHLIGHT: bool>(
     while p + 16 <= len {
         unsafe {
             let v = vld1q_u8(text.as_ptr().add(p));
-            let mask = if HIGHLIGHT {
+            let mask = if HIGHLIGHT && SUPERSCRIPT {
+                any_eq_mask(v, b"`*_\\\n[]<~$=^")
+            } else if HIGHLIGHT {
                 any_eq_mask(v, b"`*_\\\n[]<~$=")
+            } else if SUPERSCRIPT {
+                any_eq_mask(v, b"`*_\\\n[]<~$^")
             } else {
                 any_eq_mask(v, b"`*_\\\n[]<~$")
             };
             if mask_has_any(mask) {
                 // Find first match within the chunk.
                 for i in 0..16 {
-                    if is_mark_special::<HIGHLIGHT>(text[p + i]) {
+                    if is_mark_special::<HIGHLIGHT, SUPERSCRIPT>(text[p + i]) {
                         *pos = p + 16;
                         return Some(p + i);
                     }
@@ -106,13 +118,15 @@ pub unsafe fn next_mark_special_simd<const HIGHLIGHT: bool>(
 
 #[cfg(not(all(target_arch = "aarch64", target_feature = "neon")))]
 #[allow(dead_code)]
-pub fn has_inline_specials_simd<const HIGHLIGHT: bool>(_input: &[u8]) -> Option<bool> {
+pub fn has_inline_specials_simd<const HIGHLIGHT: bool, const SUPERSCRIPT: bool>(
+    _input: &[u8],
+) -> Option<bool> {
     None
 }
 
 #[cfg(not(all(target_arch = "aarch64", target_feature = "neon")))]
 #[allow(dead_code)]
-pub fn next_mark_special_simd<const HIGHLIGHT: bool>(
+pub fn next_mark_special_simd<const HIGHLIGHT: bool, const SUPERSCRIPT: bool>(
     _text: &[u8],
     _pos: &mut usize,
 ) -> Option<usize> {

--- a/src/inline/subscript.rs
+++ b/src/inline/subscript.rs
@@ -1,44 +1,42 @@
-//! Strikethrough resolution (`~~text~~`).
+//! Subscript resolution (`~text~`).
 //!
-//! Matches double-tilde runs as opener/closer pairs.
-//! Uses same flanking rules as `*` emphasis (already computed in mark collection).
+//! Matches single-tilde runs as opener/closer pairs.
+//! Uses the same flanking rules as `*` emphasis (already computed in mark collection).
 
 use super::marks::{Mark, flags};
 
-/// A matched strikethrough pair.
+/// A matched subscript pair.
 #[derive(Debug, Clone, Copy)]
-pub struct StrikethroughMatch {
+pub struct SubscriptMatch {
     pub opener_start: u32,
     pub opener_end: u32,
     pub closer_start: u32,
     pub closer_end: u32,
 }
 
-/// Resolve strikethrough marks. Matches double-tilde opener/closer runs greedily
+/// Resolve subscript marks. Matches single-tilde pairs greedily
 /// (innermost first, left to right).
-pub fn resolve_strikethrough_into(
+pub fn resolve_subscript_into(
     marks: &mut [Mark],
+    text: &[u8],
     link_boundaries: &[(u32, u32)],
-    matches: &mut Vec<StrikethroughMatch>,
+    link_dest_ranges: &[(u32, u32)],
+    matches: &mut Vec<SubscriptMatch>,
 ) {
     matches.clear();
 
-    // Collect indices of tilde marks that can open
     let mut openers: Vec<usize> = Vec::new();
 
     for i in 0..marks.len() {
         let mark = &marks[i];
-        if mark.ch != b'~' || mark.flags & flags::IN_CODE != 0 {
+        if mark.ch != b'~' || mark.flags & flags::IN_CODE != 0 || mark.len() != 1 {
             continue;
         }
-
-        let run_len = mark.len();
-        if run_len != 2 {
+        if pos_in_ranges(mark.pos, link_dest_ranges) {
             continue;
         }
 
         if mark.can_close() {
-            // Try to find a matching opener (most recent with same run length)
             let mut found = None;
             for j in (0..openers.len()).rev() {
                 let opener_idx = openers[j];
@@ -46,13 +44,18 @@ pub fn resolve_strikethrough_into(
                 if opener.is_resolved() {
                     continue;
                 }
-                if opener.len() != run_len {
-                    continue;
-                }
-                // Must be in same link boundary
                 if !same_link_boundary(opener.pos, mark.pos, link_boundaries) {
                     continue;
                 }
+                if pos_in_ranges(opener.pos, link_dest_ranges) {
+                    continue;
+                }
+
+                let content = &text[opener.end as usize..mark.pos as usize];
+                if content.is_empty() || content.iter().all(|b| matches!(b, b' ' | b'\t' | b'\n')) {
+                    continue;
+                }
+
                 found = Some(j);
                 break;
             }
@@ -62,18 +65,15 @@ pub fn resolve_strikethrough_into(
                 let opener = &marks[opener_idx];
                 let closer = &marks[i];
 
-                matches.push(StrikethroughMatch {
+                matches.push(SubscriptMatch {
                     opener_start: opener.pos,
                     opener_end: opener.end,
                     closer_start: closer.pos,
                     closer_end: closer.end,
                 });
 
-                // Remove openers between opener and closer (they can't match anymore)
-                // and remove the matched opener
                 marks[opener_idx].resolve();
                 marks[i].resolve();
-                // Remove the matched opener and any openers between it and closer
                 openers.truncate(opener_stack_idx);
             } else if mark.can_open() {
                 openers.push(i);
@@ -85,8 +85,11 @@ pub fn resolve_strikethrough_into(
 }
 
 fn same_link_boundary(a: u32, b: u32, boundaries: &[(u32, u32)]) -> bool {
-    // Both must be in the same link boundary (or both outside any)
     let a_boundary = boundaries.iter().position(|&(s, e)| a >= s && a < e);
     let b_boundary = boundaries.iter().position(|&(s, e)| b >= s && b < e);
     a_boundary == b_boundary
+}
+
+fn pos_in_ranges(pos: u32, ranges: &[(u32, u32)]) -> bool {
+    ranges.iter().any(|&(start, end)| pos >= start && pos < end)
 }

--- a/src/inline/superscript.rs
+++ b/src/inline/superscript.rs
@@ -1,44 +1,42 @@
-//! Strikethrough resolution (`~~text~~`).
+//! Superscript resolution (`^text^`).
 //!
-//! Matches double-tilde runs as opener/closer pairs.
-//! Uses same flanking rules as `*` emphasis (already computed in mark collection).
+//! Matches single-caret runs as opener/closer pairs.
+//! Uses the same flanking rules as `*` emphasis (already computed in mark collection).
 
 use super::marks::{Mark, flags};
 
-/// A matched strikethrough pair.
+/// A matched superscript pair.
 #[derive(Debug, Clone, Copy)]
-pub struct StrikethroughMatch {
+pub struct SuperscriptMatch {
     pub opener_start: u32,
     pub opener_end: u32,
     pub closer_start: u32,
     pub closer_end: u32,
 }
 
-/// Resolve strikethrough marks. Matches double-tilde opener/closer runs greedily
+/// Resolve superscript marks. Matches single-caret pairs greedily
 /// (innermost first, left to right).
-pub fn resolve_strikethrough_into(
+pub fn resolve_superscript_into(
     marks: &mut [Mark],
+    text: &[u8],
     link_boundaries: &[(u32, u32)],
-    matches: &mut Vec<StrikethroughMatch>,
+    link_dest_ranges: &[(u32, u32)],
+    matches: &mut Vec<SuperscriptMatch>,
 ) {
     matches.clear();
 
-    // Collect indices of tilde marks that can open
     let mut openers: Vec<usize> = Vec::new();
 
     for i in 0..marks.len() {
         let mark = &marks[i];
-        if mark.ch != b'~' || mark.flags & flags::IN_CODE != 0 {
+        if mark.ch != b'^' || mark.flags & flags::IN_CODE != 0 || mark.len() != 1 {
             continue;
         }
-
-        let run_len = mark.len();
-        if run_len != 2 {
+        if pos_in_ranges(mark.pos, link_dest_ranges) {
             continue;
         }
 
         if mark.can_close() {
-            // Try to find a matching opener (most recent with same run length)
             let mut found = None;
             for j in (0..openers.len()).rev() {
                 let opener_idx = openers[j];
@@ -46,13 +44,18 @@ pub fn resolve_strikethrough_into(
                 if opener.is_resolved() {
                     continue;
                 }
-                if opener.len() != run_len {
-                    continue;
-                }
-                // Must be in same link boundary
                 if !same_link_boundary(opener.pos, mark.pos, link_boundaries) {
                     continue;
                 }
+                if pos_in_ranges(opener.pos, link_dest_ranges) {
+                    continue;
+                }
+
+                let content = &text[opener.end as usize..mark.pos as usize];
+                if content.is_empty() || content.iter().all(|b| matches!(b, b' ' | b'\t' | b'\n')) {
+                    continue;
+                }
+
                 found = Some(j);
                 break;
             }
@@ -62,18 +65,15 @@ pub fn resolve_strikethrough_into(
                 let opener = &marks[opener_idx];
                 let closer = &marks[i];
 
-                matches.push(StrikethroughMatch {
+                matches.push(SuperscriptMatch {
                     opener_start: opener.pos,
                     opener_end: opener.end,
                     closer_start: closer.pos,
                     closer_end: closer.end,
                 });
 
-                // Remove openers between opener and closer (they can't match anymore)
-                // and remove the matched opener
                 marks[opener_idx].resolve();
                 marks[i].resolve();
-                // Remove the matched opener and any openers between it and closer
                 openers.truncate(opener_stack_idx);
             } else if mark.can_open() {
                 openers.push(i);
@@ -85,8 +85,11 @@ pub fn resolve_strikethrough_into(
 }
 
 fn same_link_boundary(a: u32, b: u32, boundaries: &[(u32, u32)]) -> bool {
-    // Both must be in the same link boundary (or both outside any)
     let a_boundary = boundaries.iter().position(|&(s, e)| a >= s && a < e);
     let b_boundary = boundaries.iter().position(|&(s, e)| b >= s && b < e);
     a_boundary == b_boundary
+}
+
+fn pos_in_ranges(pos: u32, ranges: &[(u32, u32)]) -> bool {
+    ranges.iter().any(|&(start, end)| pos >= start && pos < end)
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,6 +47,10 @@ pub struct Options {
     pub strikethrough: bool,
     /// Enable highlight/mark extension (`==text==`).
     pub highlight: bool,
+    /// Enable superscript extension (`^text^`).
+    pub superscript: bool,
+    /// Enable subscript extension (`~text~`).
+    pub subscript: bool,
     /// Enable GFM task list extension (`[ ]` / `[x]`).
     pub task_lists: bool,
     /// Enable GFM autolink literals extension (bare URLs, www, emails).
@@ -73,6 +77,8 @@ impl Default for Options {
             tables: true,
             strikethrough: true,
             highlight: false,
+            superscript: false,
+            subscript: false,
             task_lists: true,
             autolink_literals: false,
             disallowed_raw_html: true,
@@ -692,6 +698,8 @@ fn render_block_event(
                     options.allow_html,
                     options.strikethrough,
                     options.highlight,
+                    options.superscript,
+                    options.subscript,
                     options.autolink_literals,
                     options.math,
                     footnote_store,
@@ -761,6 +769,8 @@ fn render_block_event(
                     options.allow_html,
                     options.strikethrough,
                     options.highlight,
+                    options.superscript,
+                    options.subscript,
                     options.autolink_literals,
                     options.math,
                     footnote_store,
@@ -843,6 +853,8 @@ fn render_block_event(
                     options.allow_html,
                     options.strikethrough,
                     options.highlight,
+                    options.superscript,
+                    options.subscript,
                     options.autolink_literals,
                     options.math,
                     footnote_store,
@@ -1041,6 +1053,8 @@ fn render_block_event(
                     options.allow_html,
                     options.strikethrough,
                     options.highlight,
+                    options.superscript,
+                    options.subscript,
                     options.autolink_literals,
                     options.math,
                     footnote_store,
@@ -1193,6 +1207,26 @@ fn render_inline_event(
         InlineEvent::StrikethroughEnd => {
             if !in_image {
                 writer.write_str("</del>");
+            }
+        }
+        InlineEvent::SubscriptStart => {
+            if !in_image {
+                writer.write_str("<sub>");
+            }
+        }
+        InlineEvent::SubscriptEnd => {
+            if !in_image {
+                writer.write_str("</sub>");
+            }
+        }
+        InlineEvent::SuperscriptStart => {
+            if !in_image {
+                writer.write_str("<sup>");
+            }
+        }
+        InlineEvent::SuperscriptEnd => {
+            if !in_image {
+                writer.write_str("</sup>");
             }
         }
         InlineEvent::HighlightStart => {

--- a/tests/gfm_strikethrough_tests.rs
+++ b/tests/gfm_strikethrough_tests.rs
@@ -1,11 +1,11 @@
 use ferromark::{Options, to_html, to_html_with_options};
 
-// cmark-gfm extension spec tests
+// ferromark strikethrough syntax tests
 
 #[test]
-fn single_tilde_strikethrough() {
+fn single_tilde_is_literal() {
     let result = to_html("A proper ~strikethrough~.");
-    assert_eq!(result, "<p>A proper <del>strikethrough</del>.</p>\n");
+    assert_eq!(result, "<p>A proper ~strikethrough~.</p>\n");
 }
 
 #[test]
@@ -23,7 +23,7 @@ fn unmatched_single_tilde_closing() {
 #[test]
 fn nested_tilde_in_strikethrough() {
     let result = to_html("This ~is ~ legit~ isn't ~ legit.");
-    assert_eq!(result, "<p>This <del>is ~ legit</del> isn't ~ legit.</p>\n");
+    assert_eq!(result, "<p>This ~is ~ legit~ isn't ~ legit.</p>\n");
 }
 
 #[test]
@@ -38,7 +38,7 @@ fn five_tildes_not_strikethrough() {
 #[test]
 fn one_and_two_tildes() {
     let result = to_html("~one~ ~~two~~ ~~~three~~~");
-    assert_eq!(result, "<p><del>one</del> <del>two</del> ~~~three~~~</p>\n");
+    assert_eq!(result, "<p>~one~ <del>two</del> ~~~three~~~</p>\n");
 }
 
 #[test]

--- a/tests/subscript_tests.rs
+++ b/tests/subscript_tests.rs
@@ -1,0 +1,99 @@
+use ferromark::{Options, to_html_with_options};
+
+fn subscript_html(input: &str) -> String {
+    to_html_with_options(
+        input,
+        &Options {
+            subscript: true,
+            heading_ids: false,
+            ..Options::default()
+        },
+    )
+}
+
+fn no_subscript_html(input: &str) -> String {
+    to_html_with_options(
+        input,
+        &Options {
+            subscript: false,
+            heading_ids: false,
+            ..Options::default()
+        },
+    )
+}
+
+#[test]
+fn basic_subscript() {
+    assert_eq!(subscript_html("H~2~O"), "<p>H<sub>2</sub>O</p>\n");
+}
+
+#[test]
+fn subscript_in_paragraph() {
+    assert_eq!(
+        subscript_html("before ~sub~ after"),
+        "<p>before <sub>sub</sub> after</p>\n"
+    );
+}
+
+#[test]
+fn subscript_with_emphasis_inside() {
+    assert_eq!(
+        subscript_html("~**bold**~"),
+        "<p><sub><strong>bold</strong></sub></p>\n"
+    );
+}
+
+#[test]
+fn subscript_disabled() {
+    assert_eq!(no_subscript_html("H~2~O"), "<p>H~2~O</p>\n");
+}
+
+#[test]
+fn subscript_does_not_parse_as_strikethrough() {
+    assert_eq!(no_subscript_html("~sub~"), "<p>~sub~</p>\n");
+}
+
+#[test]
+fn unmatched_subscript_is_literal() {
+    assert_eq!(subscript_html("~sub"), "<p>~sub</p>\n");
+    assert_eq!(subscript_html("sub~"), "<p>sub~</p>\n");
+}
+
+#[test]
+fn empty_subscript_is_literal() {
+    assert_eq!(subscript_html("~~"), "<p>~~</p>\n");
+}
+
+#[test]
+fn whitespace_only_subscript_is_literal() {
+    assert_eq!(subscript_html("~  ~"), "<p>~  ~</p>\n");
+}
+
+#[test]
+fn code_span_wins_over_subscript() {
+    assert_eq!(subscript_html("`~x~`"), "<p><code>~x~</code></p>\n");
+}
+
+#[test]
+fn links_work_inside_subscript() {
+    assert_eq!(
+        subscript_html("~[link](https://example.com)~"),
+        "<p><sub><a href=\"https://example.com\">link</a></sub></p>\n"
+    );
+}
+
+#[test]
+fn subscript_works_inside_link_text() {
+    assert_eq!(
+        subscript_html("[~x~](https://example.com)"),
+        "<p><a href=\"https://example.com\"><sub>x</sub></a></p>\n"
+    );
+}
+
+#[test]
+fn subscript_does_not_parse_in_link_destinations() {
+    assert_eq!(
+        subscript_html("[link](https://example.com/~x~)"),
+        "<p><a href=\"https://example.com/~x~\">link</a></p>\n"
+    );
+}

--- a/tests/subscript_tests.rs
+++ b/tests/subscript_tests.rs
@@ -97,3 +97,11 @@ fn subscript_does_not_parse_in_link_destinations() {
         "<p><a href=\"https://example.com/~x~\">link</a></p>\n"
     );
 }
+
+#[test]
+fn subscript_and_strikethrough_coexist() {
+    assert_eq!(
+        subscript_html("H~2~O and ~~deleted~~"),
+        "<p>H<sub>2</sub>O and <del>deleted</del></p>\n"
+    );
+}

--- a/tests/superscript_tests.rs
+++ b/tests/superscript_tests.rs
@@ -1,0 +1,94 @@
+use ferromark::{Options, to_html_with_options};
+
+fn superscript_html(input: &str) -> String {
+    to_html_with_options(
+        input,
+        &Options {
+            superscript: true,
+            heading_ids: false,
+            ..Options::default()
+        },
+    )
+}
+
+fn no_superscript_html(input: &str) -> String {
+    to_html_with_options(
+        input,
+        &Options {
+            superscript: false,
+            heading_ids: false,
+            ..Options::default()
+        },
+    )
+}
+
+#[test]
+fn basic_superscript() {
+    assert_eq!(superscript_html("2^10^"), "<p>2<sup>10</sup></p>\n");
+}
+
+#[test]
+fn superscript_in_paragraph() {
+    assert_eq!(
+        superscript_html("before ^sup^ after"),
+        "<p>before <sup>sup</sup> after</p>\n"
+    );
+}
+
+#[test]
+fn superscript_with_emphasis_inside() {
+    assert_eq!(
+        superscript_html("^**bold**^"),
+        "<p><sup><strong>bold</strong></sup></p>\n"
+    );
+}
+
+#[test]
+fn superscript_disabled() {
+    assert_eq!(no_superscript_html("2^10^"), "<p>2^10^</p>\n");
+}
+
+#[test]
+fn unmatched_superscript_is_literal() {
+    assert_eq!(superscript_html("^sup"), "<p>^sup</p>\n");
+    assert_eq!(superscript_html("sup^"), "<p>sup^</p>\n");
+}
+
+#[test]
+fn empty_superscript_is_literal() {
+    assert_eq!(superscript_html("^^"), "<p>^^</p>\n");
+}
+
+#[test]
+fn whitespace_only_superscript_is_literal() {
+    assert_eq!(superscript_html("^  ^"), "<p>^  ^</p>\n");
+}
+
+#[test]
+fn code_span_wins_over_superscript() {
+    assert_eq!(superscript_html("`^x^`"), "<p><code>^x^</code></p>\n");
+}
+
+#[test]
+fn links_work_inside_superscript() {
+    assert_eq!(
+        superscript_html("^[link](https://example.com)^"),
+        "<p><sup><a href=\"https://example.com\">link</a></sup></p>\n"
+    );
+}
+
+#[test]
+fn superscript_works_inside_link_text() {
+    assert_eq!(
+        superscript_html("[^x^](https://example.com)"),
+        "<p><a href=\"https://example.com\"><sup>x</sup></a></p>\n"
+    );
+}
+
+#[test]
+fn superscript_does_not_parse_in_link_destinations() {
+    assert_eq!(
+        superscript_html("[link](https://example.com/^x^)"),
+        "<p><a href=\"https://example.com/^x^\">link</a></p>\n"
+    );
+}

--- a/tests/superscript_tests.rs
+++ b/tests/superscript_tests.rs
@@ -92,3 +92,19 @@ fn superscript_does_not_parse_in_link_destinations() {
         "<p><a href=\"https://example.com/^x^\">link</a></p>\n"
     );
 }
+
+#[test]
+fn superscript_does_not_break_footnote_refs() {
+    let result = to_html_with_options(
+        "[^fn] and 2^2^\n\n[^fn]: Footnote",
+        &Options {
+            superscript: true,
+            footnotes: true,
+            heading_ids: false,
+            ..Options::default()
+        },
+    );
+
+    assert!(result.contains("<sup>2</sup>"), "{result}");
+    assert!(result.contains("data-footnote-ref>1</a></sup>"), "{result}");
+}


### PR DESCRIPTION
## Summary
- add opt-in `superscript` and `subscript` inline extensions
- align the combined syntax set to `~~text~~`, `~text~`, and `^text^`
- document the deliberate single-tilde strikethrough break in the ADR, README, changelog, and tests

## Details
- add dedicated inline resolvers and events for subscript (`<sub>`) and superscript (`<sup>`)
- tighten strikethrough to double tildes only so `~text~` can be reserved for subscript
- specialize mark scanning and SIMD detection for the `superscript` path so the default disabled path stays effectively neutral
- update README feature lists, project structure, and changelog notes for the new syntax set
- add focused tests for subscript, superscript, and the new strikethrough behavior, including links, code spans, disabled mode, and literal fallback cases

Closes #11.
Closes #12.

## Validation
- `cargo test`
- `cargo clippy --all-targets -- -D warnings`
- `cargo fmt --check`
- in-process benchmark re-check against local `main` for disabled-path overhead:
  - `commonmark-50k.md` x200: `50.0 ms` vs `50.2 ms` on `main`
  - `/tmp/caret-heavy.md` x3: `2.158 s` vs `2.144 s` on `main`

These spot-checks indicate no material regression on the default disabled path.
