### PR TITLE
docs: add Sebastian Software README branding

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # ferromark
 
+[![Powered by Sebastian Software](https://img.shields.io/badge/Powered%20by-Sebastian%20Software-00718d?style=flat-square)](https://oss.sebastian-software.com)
 [![CI](https://github.com/sebastian-software/ferromark/actions/workflows/ci.yml/badge.svg)](https://github.com/sebastian-software/ferromark/actions/workflows/ci.yml)
 [![crates.io](https://img.shields.io/crates/v/ferromark.svg)](https://crates.io/crates/ferromark)
 [![docs.rs](https://docs.rs/ferromark/badge.svg)](https://docs.rs/ferromark)
@@ -548,4 +549,19 @@ src/
 
 ## License
 
-MIT -- Copyright 2026 Sebastian Software GmbH, Mainz, Germany
+MIT
+
+---
+
+<!-- sebastian-software-branding:start -->
+<p align="center">
+  <a href="https://oss.sebastian-software.com">
+    <img src="https://sebastian-brand.vercel.app/sebastian-software/logo-software.svg" alt="Sebastian Software" width="240" />
+  </a>
+</p>
+
+<p align="center">
+  <a href="https://oss.sebastian-software.com">Open Source at Sebastian Software</a><br />
+  Copyright &copy; 2026 Sebastian Software GmbH
+</p>
+<!-- sebastian-software-branding:end -->


### PR DESCRIPTION
Adds a consistent Sebastian Software brand badge near the existing README badge/header area and a shared footer linking to https://oss.sebastian-software.com.\n\nThis keeps the open-source project READMEs visually aligned across the organization while preserving each README's existing structure.\n\nFollow-ups applied from review:\n- Badge placement now follows each project's existing badge/header layout.\n- Footer separator has a blank line before it.\n- Links target the .com OSS site for the English version.\n- Footer copyright years are mapped from the relevant project history: 2026.\n- Footer logo uses the hosted Sebastian Brand asset.