### PR TITLE
feat: add indented code block option

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,15 +90,17 @@ CommonMark parity. Run `cargo test --test commonmark_spec -- --ignored
 
 **MDX support** (opt-in via `mdx` feature): Segment and render `.mdx` files without a JavaScript toolchain. Covers 90%+ of real-world MDX patterns in Next.js, Docusaurus, and Astro.
 
-Fine-grained options let you turn on exactly what you need:
+Fine-grained parser options let you turn on exactly what you need:
 
 ```text
 allow_html · allow_link_refs · tables · strikethrough · highlight · superscript · subscript · task_lists
 autolink_literals · disallowed_raw_html · footnotes · front_matter
-heading_ids · math · callouts
+heading_ids · math · callouts · indented_code_blocks
 ```
 
 Syntax note: ferromark uses `~~text~~` for strikethrough, `~text~` for subscript, and `^text^` for superscript. Single-tilde strikethrough is intentionally not supported.
+
+Set `indented_code_blocks: false` for presentation-oriented dialects that require fenced code blocks. Would-be indented code falls back to normal paragraph content, including inside list items, block quotes, and footnote definitions; fenced code blocks remain enabled.
 
 ## Markdown profiles
 
@@ -211,7 +213,7 @@ let output = render(input);
 // output.front_matter — Some("title: Hello\n")
 ```
 
-Use `render_with_options()` for custom Markdown settings (heading IDs, math, footnotes, etc.).
+Use `render_with_options()` for custom Markdown settings (heading IDs, math, footnotes, indented code block handling, etc.).
 
 ### Component — ready-to-use JSX module
 

--- a/src/block/parser.rs
+++ b/src/block/parser.rs
@@ -573,7 +573,7 @@ impl<'a> BlockParser<'a> {
         }
 
         // Check for indented code block (4+ spaces, not in paragraph)
-        if indent >= 4 && !self.in_paragraph {
+        if self.options.indented_code_blocks && indent >= 4 && !self.in_paragraph {
             self.start_indented_code(indent, events);
             return;
         }
@@ -943,7 +943,7 @@ impl<'a> BlockParser<'a> {
         }
 
         // Check for indented code block (4+ spaces, not in paragraph)
-        if indent >= 4 && !self.in_paragraph {
+        if self.options.indented_code_blocks && indent >= 4 && !self.in_paragraph {
             self.start_indented_code(indent, events);
             return;
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -133,6 +133,11 @@ pub struct Options {
     pub math: bool,
     /// Enable GitHub-style callouts/admonitions (`> [!NOTE]`, `> [!WARNING]`, etc.).
     pub callouts: bool,
+    /// Enable CommonMark indented code blocks (4+ leading spaces outside paragraphs).
+    ///
+    /// Disable this for presentation-oriented dialects that require fenced code blocks
+    /// and use indentation for their own block semantics.
+    pub indented_code_blocks: bool,
 }
 
 /// A curated Markdown feature set for common usage levels.
@@ -186,6 +191,7 @@ impl Default for Options {
             heading_ids: true,
             math: false,
             callouts: true,
+            indented_code_blocks: true,
         }
     }
 }
@@ -210,6 +216,7 @@ impl From<Profile> for Options {
                 heading_ids: false,
                 math: false,
                 callouts: false,
+                indented_code_blocks: true,
             },
             Profile::Extended => Self::default(),
             Profile::Full => Self {
@@ -229,6 +236,7 @@ impl From<Profile> for Options {
                 heading_ids: true,
                 math: true,
                 callouts: true,
+                indented_code_blocks: true,
             },
         }
     }

--- a/tests/indented_code_options_tests.rs
+++ b/tests/indented_code_options_tests.rs
@@ -1,0 +1,67 @@
+use ferromark::{Options, to_html, to_html_with_options};
+
+fn without_indented_code(input: &str) -> String {
+    to_html_with_options(
+        input,
+        &Options {
+            indented_code_blocks: false,
+            ..Options::default()
+        },
+    )
+}
+
+#[test]
+fn indented_code_blocks_remain_enabled_by_default() {
+    assert_eq!(
+        to_html("    fn main() {}\n"),
+        "<pre><code>fn main() {}\n</code></pre>\n"
+    );
+}
+
+#[test]
+fn top_level_indented_code_falls_back_to_paragraph_when_disabled() {
+    assert_eq!(
+        without_indented_code("    fn main() {}\n"),
+        "<p>fn main() {}</p>\n"
+    );
+}
+
+#[test]
+fn fenced_code_blocks_still_work_when_indented_code_is_disabled() {
+    assert_eq!(
+        without_indented_code("```rust\nfn main() {}\n```\n"),
+        "<pre><code class=\"language-rust\">fn main() {}\n</code></pre>\n"
+    );
+}
+
+#[test]
+fn nested_list_indented_code_falls_back_to_paragraph_when_disabled() {
+    assert_eq!(
+        without_indented_code("- item\n\n        nested\n"),
+        "<ul>\n<li>\n<p>item</p>\n<p>nested</p>\n</li>\n</ul>\n"
+    );
+}
+
+#[test]
+fn blockquote_indented_code_falls_back_to_paragraph_when_disabled() {
+    assert_eq!(
+        without_indented_code("> quote\n>\n>     nested\n"),
+        "<blockquote>\n<p>quote</p>\n<p>nested</p>\n</blockquote>\n"
+    );
+}
+
+#[test]
+fn footnote_indented_code_falls_back_to_paragraph_when_disabled() {
+    let result = to_html_with_options(
+        "[^1]: note\n\n        nested\n\nText[^1].\n",
+        &Options {
+            footnotes: true,
+            indented_code_blocks: false,
+            ..Options::default()
+        },
+    );
+
+    assert!(result.contains("<p>note</p>"));
+    assert!(result.contains("<p>nested <a href=\"#user-content-fnref-1\""));
+    assert!(!result.contains("<pre><code>nested"));
+}


### PR DESCRIPTION
## Summary
- add an explicit `Options::indented_code_blocks` parser option, enabled by default
- when disabled, would-be indented code falls back to paragraph content while fenced code blocks keep working
- document and test top-level, list, blockquote, and footnote-definition behavior

Fixes #17.

## Validation
- `cargo fmt --check`
- `cargo test`
- `cargo clippy --lib --tests --all-features -- -D warnings`

Note: `cargo clippy --all-targets --all-features -- -D warnings` currently fails on an existing example doc-comment lint in `examples/mdx_segment.rs`, unrelated to this change.
