### PR TITLE
bench: add comprehensive performance profiling

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,7 @@ serde_json = "1.0"
 [features]
 default = []
 mdx = []
+profiling = []
 
 [[example]]
 name = "mdx_segment"

--- a/benchmarks/pulldown-comparison/.gitignore
+++ b/benchmarks/pulldown-comparison/.gitignore
@@ -1,1 +1,2 @@
 /target
+/results

--- a/benchmarks/pulldown-comparison/Cargo.lock
+++ b/benchmarks/pulldown-comparison/Cargo.lock
@@ -196,6 +196,8 @@ dependencies = [
  "criterion",
  "ferromark",
  "pulldown-cmark",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/benchmarks/pulldown-comparison/Cargo.toml
+++ b/benchmarks/pulldown-comparison/Cargo.toml
@@ -8,12 +8,22 @@ publish = false
 [dependencies]
 ferromark = { path = "../.." }
 pulldown-cmark = "=0.13.4"
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+
+[features]
+default = []
+profiling = ["ferromark/profiling"]
 
 [dev-dependencies]
 criterion = { version = "0.5", features = ["html_reports"] }
 
 [[bench]]
 name = "comparison"
+harness = false
+
+[[bench]]
+name = "profiling"
 harness = false
 
 [profile.bench]

--- a/benchmarks/pulldown-comparison/README.md
+++ b/benchmarks/pulldown-comparison/README.md
@@ -34,3 +34,56 @@ cargo bench --manifest-path benchmarks/pulldown-comparison/Cargo.toml -- \
 
 The dependency is pinned to pulldown-cmark 0.13.4. Published runs must also
 record the Ferromark commit, Rust/LLVM version, machine, and Criterion settings.
+
+## Comprehensive profiling
+
+This crate also owns the profiling harness so parity options have one source of
+truth. It pins Rust 1.93.0 locally and keeps generated results under the ignored
+`results/` directory.
+
+List every parser, configuration, and corpus selector:
+
+```bash
+cd benchmarks/pulldown-comparison
+cargo run --release --bin profile_driver -- --list
+```
+
+Run one allocation-counted release diagnostic:
+
+```bash
+scripts/run-diagnostic.sh \
+  ferromark extended-secure commonmark-50k 10 portable release
+```
+
+Use `counters` instead of `release` to include feature-gated block, inline,
+event, mark, capacity, and paragraph-copy counters. Counter builds are diagnostic
+only and must not be compared to normal release throughput.
+
+Allocation counters cover parser-internal work inside the measured render loop.
+Corpus construction, warmup, environment discovery, and JSON serialization run
+outside the counter window.
+
+Run the bounded primary matrix:
+
+```bash
+scripts/run-primary-matrix.sh 5 portable
+```
+
+The CPU mode must be named explicitly:
+
+- `portable`: `target-cpu=generic`, used for portable source comparisons;
+- `apple-m1`: the repository's existing Apple Silicon baseline plus NEON;
+- `native`: a local hardware ceiling, never a portable claim;
+- `pgo`: requires `PGO_PROFDATA` and remains separate from non-PGO results.
+
+Capture a long-running CPU profile with one of the locally available tools:
+
+```bash
+scripts/capture-cpu-profile.sh sample extended-secure commonmark-50k 30 portable
+scripts/capture-cpu-profile.sh samply extended-secure commonmark-50k 30 portable
+scripts/capture-cpu-profile.sh xctrace extended-secure commonmark-50k 30 portable
+```
+
+Use AC power and stable machine conditions. Screening runs use at least 80
+Criterion samples, a 5-second measurement window, and a 3-second warmup.
+Promising or surprising results require three alternating-order repetitions.

--- a/benchmarks/pulldown-comparison/benches/profiling.rs
+++ b/benchmarks/pulldown-comparison/benches/profiling.rs
@@ -1,0 +1,96 @@
+use criterion::{BenchmarkId, Criterion, Throughput, black_box, criterion_group, criterion_main};
+use ferromark_pulldown_comparison::{
+    Corpus, ParserKind, RunConfig, render_ferromark_config_into, render_pulldown_config_into,
+};
+
+fn bench_lane(c: &mut Criterion, corpus: Corpus, configuration: RunConfig, parsers: &[ParserKind]) {
+    let data = corpus.materialize();
+    let input = data.input();
+    let mut group = c.benchmark_group(format!(
+        "profiling/{}/{}",
+        corpus.as_str(),
+        configuration.as_str()
+    ));
+    group.throughput(Throughput::Bytes(input.len() as u64));
+
+    for parser in parsers {
+        match parser {
+            ParserKind::Ferromark => {
+                let mut output = Vec::with_capacity(input.len() + input.len() / 4);
+                group.bench_function(BenchmarkId::from_parameter(parser.as_str()), |b| {
+                    b.iter(|| {
+                        render_ferromark_config_into(
+                            black_box(input),
+                            configuration,
+                            black_box(&mut output),
+                        );
+                        black_box(output.len());
+                    });
+                });
+            }
+            ParserKind::PulldownCmark => {
+                let mut output = String::with_capacity(input.len() + input.len() / 4);
+                group.bench_function(BenchmarkId::from_parameter(parser.as_str()), |b| {
+                    b.iter(|| {
+                        render_pulldown_config_into(
+                            black_box(input),
+                            configuration,
+                            black_box(&mut output),
+                        )
+                        .expect("pulldown benchmark uses only parity configurations");
+                        black_box(output.len());
+                    });
+                });
+            }
+        }
+    }
+    group.finish();
+}
+
+fn profiling_benches(c: &mut Criterion) {
+    let both = [ParserKind::Ferromark, ParserKind::PulldownCmark];
+    for corpus in [
+        Corpus::CommonMark5K,
+        Corpus::CommonMark20K,
+        Corpus::CommonMark50K,
+        Corpus::Mixed250K,
+    ] {
+        bench_lane(c, corpus, RunConfig::CommonMark, &both);
+    }
+
+    for configuration in [
+        RunConfig::EssentialsSecure,
+        RunConfig::ExtendedSecure,
+        RunConfig::FullSecure,
+    ] {
+        bench_lane(
+            c,
+            Corpus::CommonMark50K,
+            configuration,
+            &[ParserKind::Ferromark],
+        );
+    }
+
+    for corpus in [
+        Corpus::Simple,
+        Corpus::Code,
+        Corpus::SafeUrls,
+        Corpus::UnsafeUrls,
+        Corpus::References,
+        Corpus::Tables,
+        Corpus::Containers,
+        Corpus::Delimiters,
+        Corpus::Html,
+        Corpus::UnicodeEntities,
+    ] {
+        bench_lane(
+            c,
+            corpus,
+            RunConfig::ExtendedSecure,
+            &[ParserKind::Ferromark],
+        );
+    }
+}
+
+criterion_group!(benches, profiling_benches);
+criterion_main!(benches);

--- a/benchmarks/pulldown-comparison/rust-toolchain.toml
+++ b/benchmarks/pulldown-comparison/rust-toolchain.toml
@@ -1,0 +1,4 @@
+[toolchain]
+channel = "1.93.0"
+profile = "minimal"
+components = ["clippy", "rustfmt"]

--- a/benchmarks/pulldown-comparison/scripts/capture-cpu-profile.sh
+++ b/benchmarks/pulldown-comparison/scripts/capture-cpu-profile.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+tool="${1:-sample}"
+config="${2:-extended-secure}"
+corpus="${3:-commonmark-50k}"
+seconds="${4:-30}"
+cpu_mode="${5:-portable}"
+
+case "$cpu_mode" in
+  portable)
+    rustflags="-C target-cpu=generic"
+    ;;
+  apple-m1)
+    rustflags="-C target-cpu=apple-m1 -C target-feature=+neon"
+    ;;
+  native)
+    rustflags="-C target-cpu=native"
+    ;;
+  *)
+    echo "cpu mode must be portable, apple-m1, or native" >&2
+    exit 1
+    ;;
+esac
+
+script_dir=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+crate_dir=$(cd -- "$script_dir/.." && pwd)
+results_dir="$crate_dir/results"
+mkdir -p "$results_dir"
+cd "$crate_dir"
+
+RUSTFLAGS="$rustflags" CARGO_PROFILE_RELEASE_DEBUG=true CARGO_PROFILE_RELEASE_STRIP=false \
+  cargo build --locked --release --bin profile_driver
+
+binary="$crate_dir/target/release/profile_driver"
+timestamp=$(date -u +%Y%m%dT%H%M%SZ)
+base="$results_dir/${timestamp}-ferromark-${config}-${corpus}-${cpu_mode}"
+arguments=(
+  --parser ferromark
+  --config "$config"
+  --corpus "$corpus"
+  --seconds "$seconds"
+  --json "$base.json"
+)
+
+case "$tool" in
+  sample)
+    "$binary" "${arguments[@]}" > "$base.stdout" &
+    pid=$!
+    sleep 1
+    sample "$pid" "$((seconds - 1))" -mayDie -fullPaths -file "$base.sample.txt"
+    wait "$pid"
+    ;;
+  samply)
+    samply record --save-only --output "$base.samply.json.gz" -- \
+      "$binary" "${arguments[@]}"
+    ;;
+  xctrace)
+    xctrace record --template "Time Profiler" --output "$base.trace" --launch -- \
+      "$binary" "${arguments[@]}"
+    ;;
+  *)
+    echo "tool must be sample, samply, or xctrace" >&2
+    exit 1
+    ;;
+esac
+
+echo "Profile base: $base"

--- a/benchmarks/pulldown-comparison/scripts/run-diagnostic.sh
+++ b/benchmarks/pulldown-comparison/scripts/run-diagnostic.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+parser="${1:-ferromark}"
+config="${2:-commonmark}"
+corpus="${3:-commonmark-50k}"
+seconds="${4:-10}"
+cpu_mode="${5:-portable}"
+instrumentation="${6:-release}"
+
+case "$cpu_mode" in
+  portable)
+    rustflags="-C target-cpu=generic"
+    ;;
+  apple-m1)
+    rustflags="-C target-cpu=apple-m1 -C target-feature=+neon"
+    ;;
+  native)
+    rustflags="-C target-cpu=native"
+    ;;
+  pgo)
+    if [[ -z "${PGO_PROFDATA:-}" || ! -f "${PGO_PROFDATA:-}" ]]; then
+      echo "pgo mode requires PGO_PROFDATA to name an existing .profdata file" >&2
+      exit 1
+    fi
+    rustflags="-C profile-use=${PGO_PROFDATA} -C llvm-args=-pgo-warn-missing-function"
+    ;;
+  *)
+    echo "cpu mode must be portable, apple-m1, native, or pgo" >&2
+    exit 1
+    ;;
+esac
+
+case "$instrumentation" in
+  release)
+    ;;
+  counters)
+    ;;
+  *)
+    echo "instrumentation must be release or counters" >&2
+    exit 1
+    ;;
+esac
+
+script_dir=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+crate_dir=$(cd -- "$script_dir/.." && pwd)
+results_dir="$crate_dir/results"
+mkdir -p "$results_dir"
+
+timestamp=$(date -u +%Y%m%dT%H%M%SZ)
+result="$results_dir/${timestamp}-${parser}-${config}-${corpus}-${cpu_mode}-${instrumentation}.json"
+
+cd "$crate_dir"
+if [[ "$instrumentation" == "counters" ]]; then
+  FERROMARK_CPU_MODE="$cpu_mode" RUSTFLAGS="$rustflags" \
+    cargo run --locked --release --features profiling --bin profile_driver -- \
+    --parser "$parser" \
+    --config "$config" \
+    --corpus "$corpus" \
+    --seconds "$seconds" \
+    --json "$result"
+else
+  FERROMARK_CPU_MODE="$cpu_mode" RUSTFLAGS="$rustflags" \
+    cargo run --locked --release --bin profile_driver -- \
+    --parser "$parser" \
+    --config "$config" \
+    --corpus "$corpus" \
+    --seconds "$seconds" \
+    --json "$result"
+fi
+
+echo "Result: $result"

--- a/benchmarks/pulldown-comparison/scripts/run-primary-matrix.sh
+++ b/benchmarks/pulldown-comparison/scripts/run-primary-matrix.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+seconds="${1:-5}"
+cpu_mode="${2:-portable}"
+script_dir=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+
+for corpus in commonmark-5k commonmark-20k commonmark-50k mixed-250k; do
+  "$script_dir/run-diagnostic.sh" ferromark commonmark "$corpus" "$seconds" "$cpu_mode" release
+  "$script_dir/run-diagnostic.sh" pulldown-cmark commonmark "$corpus" "$seconds" "$cpu_mode" release
+done
+
+for config in essentials-secure extended-secure full-secure; do
+  "$script_dir/run-diagnostic.sh" ferromark "$config" commonmark-50k "$seconds" "$cpu_mode" release
+done
+
+for corpus in simple code safe-urls unsafe-urls references tables containers delimiters html unicode-entities; do
+  "$script_dir/run-diagnostic.sh" ferromark extended-secure "$corpus" "$seconds" "$cpu_mode" release
+done
+
+"$script_dir/run-diagnostic.sh" ferromark extended-secure commonmark-50k "$seconds" "$cpu_mode" counters

--- a/benchmarks/pulldown-comparison/src/allocation.rs
+++ b/benchmarks/pulldown-comparison/src/allocation.rs
@@ -1,0 +1,146 @@
+use std::{
+    alloc::{GlobalAlloc, Layout, System},
+    sync::atomic::{AtomicBool, AtomicU64, Ordering},
+};
+
+use serde::Serialize;
+
+static ACTIVE: AtomicBool = AtomicBool::new(false);
+static ALLOCATIONS: AtomicU64 = AtomicU64::new(0);
+static REALLOCATIONS: AtomicU64 = AtomicU64::new(0);
+static DEALLOCATIONS: AtomicU64 = AtomicU64::new(0);
+static ALLOCATED_BYTES: AtomicU64 = AtomicU64::new(0);
+static DEALLOCATED_BYTES: AtomicU64 = AtomicU64::new(0);
+
+/// Allocation counters captured inside one explicit measurement window.
+#[derive(Debug, Clone, Copy, Default, Serialize)]
+pub struct AllocationSnapshot {
+    /// Successful allocation calls.
+    pub allocations: u64,
+    /// Successful reallocation calls.
+    pub reallocations: u64,
+    /// Deallocation calls.
+    pub deallocations: u64,
+    /// Requested bytes across allocations and reallocations.
+    pub allocated_bytes: u64,
+    /// Released bytes reported by deallocation layouts.
+    pub deallocated_bytes: u64,
+}
+
+/// System allocator wrapper used only by the diagnostic binary.
+pub struct CountingAllocator;
+
+// SAFETY: Every operation delegates to `System` with the original pointer and
+// layout. The additional atomics only observe successful operations.
+unsafe impl GlobalAlloc for CountingAllocator {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        // SAFETY: Forwarded unchanged to the system allocator.
+        let pointer = unsafe { System.alloc(layout) };
+        if !pointer.is_null() && ACTIVE.load(Ordering::Relaxed) {
+            ALLOCATIONS.fetch_add(1, Ordering::Relaxed);
+            ALLOCATED_BYTES.fetch_add(layout.size() as u64, Ordering::Relaxed);
+        }
+        pointer
+    }
+
+    unsafe fn dealloc(&self, pointer: *mut u8, layout: Layout) {
+        if ACTIVE.load(Ordering::Relaxed) {
+            DEALLOCATIONS.fetch_add(1, Ordering::Relaxed);
+            DEALLOCATED_BYTES.fetch_add(layout.size() as u64, Ordering::Relaxed);
+        }
+        // SAFETY: Forwarded unchanged to the system allocator.
+        unsafe { System.dealloc(pointer, layout) };
+    }
+
+    unsafe fn realloc(&self, pointer: *mut u8, layout: Layout, new_size: usize) -> *mut u8 {
+        // SAFETY: Forwarded unchanged to the system allocator.
+        let new_pointer = unsafe { System.realloc(pointer, layout, new_size) };
+        if !new_pointer.is_null() && ACTIVE.load(Ordering::Relaxed) {
+            REALLOCATIONS.fetch_add(1, Ordering::Relaxed);
+            ALLOCATED_BYTES.fetch_add(new_size as u64, Ordering::Relaxed);
+            DEALLOCATED_BYTES.fetch_add(layout.size() as u64, Ordering::Relaxed);
+        }
+        new_pointer
+    }
+}
+
+/// RAII guard that enables counters until it is dropped.
+pub struct MeasurementWindow {
+    _private: (),
+}
+
+impl MeasurementWindow {
+    /// Reset all counters and open a measurement window.
+    pub fn start() -> Self {
+        ACTIVE.store(false, Ordering::SeqCst);
+        reset();
+        ACTIVE.store(true, Ordering::SeqCst);
+        Self { _private: () }
+    }
+
+    /// Close the window and return its counters.
+    pub fn finish(self) -> AllocationSnapshot {
+        ACTIVE.store(false, Ordering::SeqCst);
+        let snapshot = snapshot();
+        std::mem::forget(self);
+        snapshot
+    }
+}
+
+impl Drop for MeasurementWindow {
+    fn drop(&mut self) {
+        ACTIVE.store(false, Ordering::SeqCst);
+    }
+}
+
+fn reset() {
+    ALLOCATIONS.store(0, Ordering::Relaxed);
+    REALLOCATIONS.store(0, Ordering::Relaxed);
+    DEALLOCATIONS.store(0, Ordering::Relaxed);
+    ALLOCATED_BYTES.store(0, Ordering::Relaxed);
+    DEALLOCATED_BYTES.store(0, Ordering::Relaxed);
+}
+
+fn snapshot() -> AllocationSnapshot {
+    AllocationSnapshot {
+        allocations: ALLOCATIONS.load(Ordering::Relaxed),
+        reallocations: REALLOCATIONS.load(Ordering::Relaxed),
+        deallocations: DEALLOCATIONS.load(Ordering::Relaxed),
+        allocated_bytes: ALLOCATED_BYTES.load(Ordering::Relaxed),
+        deallocated_bytes: DEALLOCATED_BYTES.load(Ordering::Relaxed),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn measurement_window_should_count_direct_allocator_calls() {
+        let layout = Layout::from_size_align(64, 8).expect("valid layout");
+        let window = MeasurementWindow::start();
+        // SAFETY: The pointer is deallocated with the same allocator and layout.
+        let pointer = unsafe { CountingAllocator.alloc(layout) };
+        assert!(!pointer.is_null());
+        // SAFETY: The successful allocation used the same allocator and layout.
+        unsafe { CountingAllocator.dealloc(pointer, layout) };
+        let result = window.finish();
+
+        assert_eq!(result.allocations, 1);
+    }
+
+    #[test]
+    fn disabled_window_should_ignore_direct_allocator_calls() {
+        let layout = Layout::from_size_align(64, 8).expect("valid layout");
+        let initial = MeasurementWindow::start();
+        let _ = initial.finish();
+        // SAFETY: The pointer is deallocated with the same allocator and layout.
+        let pointer = unsafe { CountingAllocator.alloc(layout) };
+        assert!(!pointer.is_null());
+        // SAFETY: The successful allocation used the same allocator and layout.
+        unsafe { CountingAllocator.dealloc(pointer, layout) };
+
+        let verification = MeasurementWindow::start().finish();
+        assert_eq!(verification.allocations, 0);
+    }
+}

--- a/benchmarks/pulldown-comparison/src/bin/profile_driver.rs
+++ b/benchmarks/pulldown-comparison/src/bin/profile_driver.rs
@@ -1,0 +1,290 @@
+use std::{
+    env,
+    error::Error,
+    fs,
+    hint::black_box,
+    path::PathBuf,
+    process::ExitCode,
+    str::FromStr,
+    time::{Duration, Instant},
+};
+
+use ferromark_pulldown_comparison::{
+    Corpus, CountingAllocator, MeasurementWindow, ParserKind, RunConfig, RunMetadata,
+    RunMeasurement, render_ferromark_config_into, render_pulldown_config_into,
+};
+
+#[global_allocator]
+static ALLOCATOR: CountingAllocator = CountingAllocator;
+
+struct Arguments {
+    parser: ParserKind,
+    configuration: RunConfig,
+    corpus: Corpus,
+    limit: Limit,
+    warmup_iterations: u64,
+    json_path: Option<PathBuf>,
+}
+
+enum Limit {
+    Iterations(u64),
+    Duration(Duration),
+}
+
+struct Measurement {
+    iterations: u64,
+    elapsed: Duration,
+    output_bytes: usize,
+    output_capacity: usize,
+    allocations: ferromark_pulldown_comparison::AllocationSnapshot,
+    pipeline: Option<serde_json::Value>,
+}
+
+fn main() -> ExitCode {
+    match run() {
+        Ok(()) => ExitCode::SUCCESS,
+        Err(error) => {
+            eprintln!("error: {error}");
+            ExitCode::FAILURE
+        }
+    }
+}
+
+fn run() -> Result<(), Box<dyn Error>> {
+    let Some(arguments) = parse_arguments()? else {
+        return Ok(());
+    };
+    if !arguments.configuration.supports(arguments.parser) {
+        return Err(format!(
+            "configuration `{}` is not supported by `{}`",
+            arguments.configuration, arguments.parser
+        )
+        .into());
+    }
+
+    let corpus = arguments.corpus.materialize();
+    let measurement = match arguments.parser {
+        ParserKind::Ferromark => measure_ferromark(&arguments, corpus.input()),
+        ParserKind::PulldownCmark => measure_pulldown(&arguments, corpus.input())?,
+    };
+    let metadata = RunMetadata::new(
+        arguments.parser,
+        arguments.configuration,
+        corpus.corpus(),
+        RunMeasurement {
+            input_bytes: corpus.input().len(),
+            output_bytes: measurement.output_bytes,
+            iterations: measurement.iterations,
+            elapsed_ns: measurement.elapsed.as_nanos(),
+            output_capacity: measurement.output_capacity,
+            allocations: measurement.allocations,
+            pipeline: measurement.pipeline,
+        },
+    );
+    let json = serde_json::to_string_pretty(&metadata)?;
+    if let Some(path) = arguments.json_path {
+        fs::write(path, format!("{json}\n"))?;
+    }
+    println!("{json}");
+    Ok(())
+}
+
+fn measure_ferromark(arguments: &Arguments, input: &str) -> Measurement {
+    let mut output = Vec::with_capacity(input.len() + input.len() / 4);
+    for _ in 0..arguments.warmup_iterations {
+        render_ferromark_config_into(input, arguments.configuration, &mut output);
+    }
+
+    reset_pipeline();
+    let window = MeasurementWindow::start();
+    let start = Instant::now();
+    let iterations = run_loop(&arguments.limit, || {
+        render_ferromark_config_into(black_box(input), arguments.configuration, &mut output);
+        black_box(output.len());
+    });
+    let elapsed = start.elapsed();
+    let allocations = window.finish();
+    let pipeline = pipeline_snapshot();
+    Measurement {
+        iterations,
+        elapsed,
+        output_bytes: output.len(),
+        output_capacity: output.capacity(),
+        allocations,
+        pipeline,
+    }
+}
+
+fn measure_pulldown(arguments: &Arguments, input: &str) -> Result<Measurement, Box<dyn Error>> {
+    let mut output = String::with_capacity(input.len() + input.len() / 4);
+    for _ in 0..arguments.warmup_iterations {
+        render_pulldown_config_into(input, arguments.configuration, &mut output)?;
+    }
+
+    reset_pipeline();
+    let window = MeasurementWindow::start();
+    let start = Instant::now();
+    let mut render_error = None;
+    let iterations = run_loop(&arguments.limit, || {
+        if let Err(error) =
+            render_pulldown_config_into(black_box(input), arguments.configuration, &mut output)
+        {
+            render_error = Some(error);
+        }
+        black_box(output.len());
+    });
+    let elapsed = start.elapsed();
+    let allocations = window.finish();
+    if let Some(error) = render_error {
+        return Err(error.into());
+    }
+    Ok(Measurement {
+        iterations,
+        elapsed,
+        output_bytes: output.len(),
+        output_capacity: output.capacity(),
+        allocations,
+        pipeline: None,
+    })
+}
+
+#[cfg(feature = "profiling")]
+fn reset_pipeline() {
+    ferromark::profiling::reset();
+}
+
+#[cfg(not(feature = "profiling"))]
+fn reset_pipeline() {}
+
+#[cfg(feature = "profiling")]
+fn pipeline_snapshot() -> Option<serde_json::Value> {
+    let counters = ferromark::profiling::snapshot();
+    Some(serde_json::json!({
+        "documents": counters.documents,
+        "block_events": counters.block_events,
+        "block_text_events": counters.block_text_events,
+        "block_container_events": counters.block_container_events,
+        "block_table_events": counters.block_table_events,
+        "block_code_events": counters.block_code_events,
+        "max_block_event_capacity": counters.max_block_event_capacity,
+        "inline_parses": counters.inline_parses,
+        "inline_input_bytes": counters.inline_input_bytes,
+        "inline_events": counters.inline_events,
+        "inline_text_events": counters.inline_text_events,
+        "inline_link_events": counters.inline_link_events,
+        "inline_html_events": counters.inline_html_events,
+        "inline_marks": counters.inline_marks,
+        "inline_emit_points": counters.inline_emit_points,
+        "inline_fast_paths": counters.inline_fast_paths,
+        "max_inline_event_capacity": counters.max_inline_event_capacity,
+        "max_mark_capacity": counters.max_mark_capacity,
+        "max_emit_point_capacity": counters.max_emit_point_capacity,
+        "paragraph_copied_bytes": counters.paragraph_copied_bytes,
+    }))
+}
+
+#[cfg(not(feature = "profiling"))]
+fn pipeline_snapshot() -> Option<serde_json::Value> {
+    None
+}
+
+fn run_loop(limit: &Limit, mut iteration: impl FnMut()) -> u64 {
+    match limit {
+        Limit::Iterations(iterations) => {
+            for _ in 0..*iterations {
+                iteration();
+            }
+            *iterations
+        }
+        Limit::Duration(duration) => {
+            let deadline = Instant::now() + *duration;
+            let mut iterations = 0;
+            while Instant::now() < deadline {
+                iteration();
+                iterations += 1;
+            }
+            iterations
+        }
+    }
+}
+
+fn parse_arguments() -> Result<Option<Arguments>, Box<dyn Error>> {
+    let mut parser = ParserKind::Ferromark;
+    let mut configuration = RunConfig::CommonMark;
+    let mut corpus = Corpus::CommonMark50K;
+    let mut limit = Limit::Duration(Duration::from_secs(30));
+    let mut warmup_iterations = 10;
+    let mut json_path = None;
+    let mut arguments = env::args().skip(1);
+
+    while let Some(argument) = arguments.next() {
+        match argument.as_str() {
+            "--parser" => parser = ParserKind::from_str(&next_value(&mut arguments, "--parser")?)?,
+            "--config" => {
+                configuration = RunConfig::from_str(&next_value(&mut arguments, "--config")?)?;
+            }
+            "--corpus" => corpus = Corpus::from_str(&next_value(&mut arguments, "--corpus")?)?,
+            "--iterations" => {
+                limit = Limit::Iterations(next_value(&mut arguments, "--iterations")?.parse()?);
+            }
+            "--seconds" => {
+                limit = Limit::Duration(Duration::from_secs(
+                    next_value(&mut arguments, "--seconds")?.parse()?,
+                ));
+            }
+            "--warmup-iterations" => {
+                warmup_iterations = next_value(&mut arguments, "--warmup-iterations")?.parse()?;
+            }
+            "--json" => json_path = Some(PathBuf::from(next_value(&mut arguments, "--json")?)),
+            "--list" => {
+                print_selectors();
+                return Ok(None);
+            }
+            "--help" | "-h" => {
+                print_help();
+                return Ok(None);
+            }
+            _ => return Err(format!("unknown argument `{argument}`").into()),
+        }
+    }
+
+    Ok(Some(Arguments {
+        parser,
+        configuration,
+        corpus,
+        limit,
+        warmup_iterations,
+        json_path,
+    }))
+}
+
+fn next_value(
+    arguments: &mut impl Iterator<Item = String>,
+    option: &str,
+) -> Result<String, Box<dyn Error>> {
+    arguments
+        .next()
+        .ok_or_else(|| format!("missing value for `{option}`").into())
+}
+
+fn print_selectors() {
+    println!("parsers: ferromark, pulldown-cmark");
+    println!(
+        "configurations: {}",
+        RunConfig::ALL.map(RunConfig::as_str).join(", ")
+    );
+    let corpus_names = Corpus::ALL
+        .into_iter()
+        .chain([Corpus::Extended])
+        .map(Corpus::as_str)
+        .collect::<Vec<_>>()
+        .join(", ");
+    println!("corpora: {corpus_names}");
+}
+
+fn print_help() {
+    println!(
+        "profile_driver [--parser NAME] [--config NAME] [--corpus NAME] \
+         [--seconds N | --iterations N] [--warmup-iterations N] [--json PATH]"
+    );
+}

--- a/benchmarks/pulldown-comparison/src/corpus.rs
+++ b/benchmarks/pulldown-comparison/src/corpus.rs
@@ -1,0 +1,214 @@
+use std::{borrow::Cow, fmt, str::FromStr};
+
+const COMMONMARK_5K: &str = include_str!("../../../benches/fixtures/commonmark-5k.md");
+const COMMONMARK_20K: &str = include_str!("../../../benches/fixtures/commonmark-20k.md");
+const COMMONMARK_50K: &str = include_str!("../../../benches/fixtures/commonmark-50k.md");
+const TABLES_5K: &str = include_str!("../../../benches/fixtures/tables-5k.md");
+
+/// Named input corpus used by profiling and diagnostic runs.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Corpus {
+    /// Existing approximately 5 KB CommonMark fixture.
+    CommonMark5K,
+    /// Existing approximately 20 KB CommonMark fixture.
+    CommonMark20K,
+    /// Existing approximately 50 KB CommonMark fixture.
+    CommonMark50K,
+    /// Repeated mixed fixture for scaling and buffer-growth measurements.
+    Mixed250K,
+    /// Plain prose with little markup.
+    Simple,
+    /// Fenced and inline-code-heavy input.
+    Code,
+    /// Safe absolute and relative links.
+    SafeUrls,
+    /// Unsafe and obfuscated URL schemes.
+    UnsafeUrls,
+    /// Reference definitions and reference links.
+    References,
+    /// Table-heavy input.
+    Tables,
+    /// Nested lists and blockquotes.
+    Containers,
+    /// Inline delimiter-heavy input.
+    Delimiters,
+    /// Raw HTML-heavy input.
+    Html,
+    /// Unicode text and HTML entities.
+    UnicodeEntities,
+    /// Shared extended-feature input.
+    Extended,
+}
+
+impl Corpus {
+    /// All corpus selectors accepted by the diagnostic runner.
+    pub const ALL: [Self; 14] = [
+        Self::CommonMark5K,
+        Self::CommonMark20K,
+        Self::CommonMark50K,
+        Self::Mixed250K,
+        Self::Simple,
+        Self::Code,
+        Self::SafeUrls,
+        Self::UnsafeUrls,
+        Self::References,
+        Self::Tables,
+        Self::Containers,
+        Self::Delimiters,
+        Self::Html,
+        Self::UnicodeEntities,
+    ];
+
+    /// Stable command-line and metadata name.
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::CommonMark5K => "commonmark-5k",
+            Self::CommonMark20K => "commonmark-20k",
+            Self::CommonMark50K => "commonmark-50k",
+            Self::Mixed250K => "mixed-250k",
+            Self::Simple => "simple",
+            Self::Code => "code",
+            Self::SafeUrls => "safe-urls",
+            Self::UnsafeUrls => "unsafe-urls",
+            Self::References => "references",
+            Self::Tables => "tables",
+            Self::Containers => "containers",
+            Self::Delimiters => "delimiters",
+            Self::Html => "html",
+            Self::UnicodeEntities => "unicode-entities",
+            Self::Extended => "extended",
+        }
+    }
+
+    /// Materialize the corpus outside any measurement window.
+    pub fn materialize(self) -> CorpusData {
+        let content = match self {
+            Self::CommonMark5K => Cow::Borrowed(COMMONMARK_5K),
+            Self::CommonMark20K => Cow::Borrowed(COMMONMARK_20K),
+            Self::CommonMark50K => Cow::Borrowed(COMMONMARK_50K),
+            Self::Mixed250K => Cow::Owned(repeat_to_at_least(COMMONMARK_50K, 250_000)),
+            Self::Simple => Cow::Owned(repeat_to_at_least(
+                "Ordinary prose stays deliberately uneventful so fixed parser and rendering costs remain visible.\n\n",
+                20_000,
+            )),
+            Self::Code => Cow::Owned(repeat_to_at_least(
+                "```rust\nfn measured(value: usize) -> usize { value + 1 }\n```\n\nUse `measured(41)` in this paragraph.\n\n",
+                20_000,
+            )),
+            Self::SafeUrls => Cow::Owned(repeat_to_at_least(
+                "[absolute](https://example.com/a%20path?q=one&v=two) [relative](/docs/start) <mailto:team@example.com>\n\n",
+                20_000,
+            )),
+            Self::UnsafeUrls => Cow::Owned(repeat_to_at_least(
+                "[script](javascript:alert(1)) [entity](javas&#99;ript:alert(1)) [data](data:text/html,test)\n\n",
+                20_000,
+            )),
+            Self::References => Cow::Owned(reference_corpus()),
+            Self::Tables => Cow::Borrowed(TABLES_5K),
+            Self::Containers => Cow::Owned(repeat_to_at_least(
+                "> - first item\n>   - nested item\n>     1. ordered child\n>     2. second child\n>\n> continuation\n\n",
+                20_000,
+            )),
+            Self::Delimiters => Cow::Owned(repeat_to_at_least(
+                "***strong emphasis*** ~~strike~~ `code` [link](https://example.com) _a **b** c_ $x+y$\n\n",
+                20_000,
+            )),
+            Self::Html => Cow::Owned(repeat_to_at_least(
+                "<section data-kind=\"sample\"><strong>raw</strong> & content</section>\n\nInline <span title=\"x\">HTML</span>.\n\n",
+                20_000,
+            )),
+            Self::UnicodeEntities => Cow::Owned(repeat_to_at_least(
+                "Grüße aus München — 東京 — مرحبا — café &amp; tea &#x1F980; [é](https://example.com/über uns)\n\n",
+                20_000,
+            )),
+            Self::Extended => Cow::Owned(repeat_to_at_least(
+                "The result is ^squared^ with $a+b=c$ and a note.[^n]\n\n> [!NOTE]\n> Shared extended syntax.\n\n[^n]: Footnote text.\n\n",
+                20_000,
+            )),
+        };
+        CorpusData {
+            corpus: self,
+            content,
+        }
+    }
+}
+
+impl fmt::Display for Corpus {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(self.as_str())
+    }
+}
+
+impl FromStr for Corpus {
+    type Err = String;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        Self::ALL
+            .into_iter()
+            .chain([Self::Extended])
+            .find(|corpus| corpus.as_str() == value)
+            .ok_or_else(|| format!("unknown corpus `{value}`"))
+    }
+}
+
+/// Materialized corpus data owned outside the measurement window.
+pub struct CorpusData {
+    corpus: Corpus,
+    content: Cow<'static, str>,
+}
+
+impl CorpusData {
+    /// Corpus selector represented by this data.
+    pub const fn corpus(&self) -> Corpus {
+        self.corpus
+    }
+
+    /// Markdown input.
+    pub fn input(&self) -> &str {
+        &self.content
+    }
+}
+
+fn repeat_to_at_least(section: &str, minimum_bytes: usize) -> String {
+    let repeats = minimum_bytes.div_ceil(section.len());
+    section.repeat(repeats)
+}
+
+fn reference_corpus() -> String {
+    let mut output = String::with_capacity(24_000);
+    for index in 0..256 {
+        output.push_str("Read [the reference][ref-");
+        output.push_str(&index.to_string());
+        output.push_str("] and [another][ref-");
+        output.push_str(&index.to_string());
+        output.push_str("].\n\n");
+    }
+    for index in 0..256 {
+        output.push_str("[ref-");
+        output.push_str(&index.to_string());
+        output.push_str("]: https://example.com/reference/");
+        output.push_str(&index.to_string());
+        output.push('\n');
+    }
+    output
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn scaling_corpus_should_reach_minimum_size() {
+        assert!(Corpus::Mixed250K.materialize().input().len() >= 250_000);
+    }
+
+    #[test]
+    fn every_corpus_should_be_non_empty() {
+        assert!(
+            Corpus::ALL
+                .into_iter()
+                .chain([Corpus::Extended])
+                .all(|corpus| !corpus.materialize().input().is_empty())
+        );
+    }
+}

--- a/benchmarks/pulldown-comparison/src/lib.rs
+++ b/benchmarks/pulldown-comparison/src/lib.rs
@@ -1,7 +1,16 @@
 //! Focused, md4c-independent ferromark versus pulldown-cmark harness.
 
+mod allocation;
+mod corpus;
+mod metadata;
+mod model;
+
 use ferromark::{Options as FerromarkOptions, RenderPolicy};
 use pulldown_cmark::{Options as PulldownOptions, Parser, html};
+
+pub use corpus::{Corpus, CorpusData};
+pub use metadata::{EnvironmentMetadata, RunMeasurement, RunMetadata};
+pub use model::{ParserKind, RunConfig};
 
 /// Exact shared feature configurations used by comparison benchmarks.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -74,3 +83,28 @@ pub fn render_pulldown_into(input: &str, config: ParityConfig, output: &mut Stri
     output.clear();
     html::push_html(output, Parser::new_ext(input, pulldown_options(config)));
 }
+
+/// Render one diagnostic configuration with Ferromark.
+pub fn render_ferromark_config_into(input: &str, config: RunConfig, output: &mut Vec<u8>) {
+    output.clear();
+    ferromark::to_html_into_with_options(input, output, &config.ferromark_options());
+}
+
+/// Render one diagnostic parity configuration with pulldown-cmark.
+///
+/// # Errors
+///
+/// Returns an error when a Ferromark-only product profile is selected.
+pub fn render_pulldown_config_into(
+    input: &str,
+    config: RunConfig,
+    output: &mut String,
+) -> Result<(), &'static str> {
+    let Some(options) = config.pulldown_options() else {
+        return Err("pulldown-cmark only supports parity configurations");
+    };
+    output.clear();
+    html::push_html(output, Parser::new_ext(input, options));
+    Ok(())
+}
+pub use allocation::{AllocationSnapshot, CountingAllocator, MeasurementWindow};

--- a/benchmarks/pulldown-comparison/src/metadata.rs
+++ b/benchmarks/pulldown-comparison/src/metadata.rs
@@ -1,0 +1,143 @@
+use std::{env, process::Command};
+
+use serde::Serialize;
+
+use crate::{AllocationSnapshot, Corpus, ParserKind, RunConfig};
+
+/// Build and machine metadata retained with every profiling result.
+#[derive(Debug, Serialize)]
+pub struct EnvironmentMetadata {
+    /// Current git commit, if available.
+    pub git_commit: String,
+    /// Whether tracked or untracked files differ from the commit.
+    pub git_dirty: bool,
+    /// Complete `rustc -Vv` output.
+    pub rustc: String,
+    /// Rust compilation target architecture and operating system.
+    pub target: String,
+    /// Effective `RUSTFLAGS` visible to the runner.
+    pub rustflags: String,
+    /// Explicit CPU/compiler mode selected by the orchestration script.
+    pub cpu_mode: String,
+    /// Operating system description.
+    pub operating_system: String,
+}
+
+impl EnvironmentMetadata {
+    /// Collect environment metadata outside the measured execution window.
+    pub fn collect() -> Self {
+        Self {
+            git_commit: command_output("git", &["rev-parse", "HEAD"]),
+            git_dirty: !command_output("git", &["status", "--porcelain"]).is_empty(),
+            rustc: command_output("rustc", &["-Vv"]),
+            target: format!("{}-{}", env::consts::ARCH, env::consts::OS),
+            rustflags: env::var("RUSTFLAGS").unwrap_or_default(),
+            cpu_mode: env::var("FERROMARK_CPU_MODE").unwrap_or_else(|_| "unspecified".into()),
+            operating_system: command_output("uname", &["-a"]),
+        }
+    }
+}
+
+/// Machine-readable summary for one diagnostic run.
+#[derive(Debug, Serialize)]
+pub struct RunMetadata {
+    /// Build and machine context.
+    pub environment: EnvironmentMetadata,
+    /// Selected parser.
+    pub parser: String,
+    /// Selected feature and trust configuration.
+    pub configuration: String,
+    /// Stable corpus identifier.
+    pub corpus: String,
+    /// Markdown input size.
+    pub input_bytes: usize,
+    /// Produced output size from the last iteration.
+    pub output_bytes: usize,
+    /// Number of measured iterations.
+    pub iterations: u64,
+    /// Measured wall-clock duration in nanoseconds.
+    pub elapsed_ns: u128,
+    /// Retained reusable output capacity.
+    pub output_capacity: usize,
+    /// Allocation activity inside the measured render loop.
+    pub allocations: AllocationSnapshot,
+    /// Feature-gated Ferromark pipeline counters, when enabled.
+    pub pipeline: Option<serde_json::Value>,
+}
+
+/// Values produced by the measured render loop.
+pub struct RunMeasurement {
+    /// Markdown input size.
+    pub input_bytes: usize,
+    /// Produced output size from the last iteration.
+    pub output_bytes: usize,
+    /// Number of measured iterations.
+    pub iterations: u64,
+    /// Measured wall-clock duration in nanoseconds.
+    pub elapsed_ns: u128,
+    /// Retained reusable output capacity.
+    pub output_capacity: usize,
+    /// Allocation activity inside the measured render loop.
+    pub allocations: AllocationSnapshot,
+    /// Feature-gated Ferromark pipeline counters, when enabled.
+    pub pipeline: Option<serde_json::Value>,
+}
+
+impl RunMetadata {
+    /// Build a summary after the measurement window has closed.
+    pub fn new(
+        parser: ParserKind,
+        configuration: RunConfig,
+        corpus: Corpus,
+        measurement: RunMeasurement,
+    ) -> Self {
+        Self {
+            environment: EnvironmentMetadata::collect(),
+            parser: parser.to_string(),
+            configuration: configuration.to_string(),
+            corpus: corpus.to_string(),
+            input_bytes: measurement.input_bytes,
+            output_bytes: measurement.output_bytes,
+            iterations: measurement.iterations,
+            elapsed_ns: measurement.elapsed_ns,
+            output_capacity: measurement.output_capacity,
+            allocations: measurement.allocations,
+            pipeline: measurement.pipeline,
+        }
+    }
+}
+
+fn command_output(program: &str, arguments: &[&str]) -> String {
+    Command::new(program)
+        .args(arguments)
+        .output()
+        .ok()
+        .filter(|output| output.status.success())
+        .map(|output| String::from_utf8_lossy(&output.stdout).trim().to_owned())
+        .unwrap_or_default()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn run_metadata_should_use_stable_selector_names() {
+        let metadata = RunMetadata::new(
+            ParserKind::Ferromark,
+            RunConfig::CommonMark,
+            Corpus::CommonMark5K,
+            RunMeasurement {
+                input_bytes: 10,
+                output_bytes: 12,
+                iterations: 2,
+                elapsed_ns: 100,
+                output_capacity: 32,
+                allocations: AllocationSnapshot::default(),
+                pipeline: None,
+            },
+        );
+
+        assert_eq!(metadata.configuration, "commonmark");
+    }
+}

--- a/benchmarks/pulldown-comparison/src/model.rs
+++ b/benchmarks/pulldown-comparison/src/model.rs
@@ -1,0 +1,194 @@
+use std::{fmt, str::FromStr};
+
+use ferromark::{Options, Profile, RenderPolicy};
+
+use crate::{ParityConfig, ferromark_options, pulldown_options};
+
+/// Parser implementation selected for a diagnostic run.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ParserKind {
+    /// Ferromark using an explicit parity or product configuration.
+    Ferromark,
+    /// pulldown-cmark using a semantically guarded parity configuration.
+    PulldownCmark,
+}
+
+impl ParserKind {
+    /// Stable command-line and metadata name.
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Ferromark => "ferromark",
+            Self::PulldownCmark => "pulldown-cmark",
+        }
+    }
+}
+
+impl fmt::Display for ParserKind {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(self.as_str())
+    }
+}
+
+impl FromStr for ParserKind {
+    type Err = String;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value {
+            "ferromark" => Ok(Self::Ferromark),
+            "pulldown-cmark" | "pulldown" => Ok(Self::PulldownCmark),
+            _ => Err(format!("unknown parser `{value}`")),
+        }
+    }
+}
+
+/// Exact configuration selected for one benchmark or diagnostic run.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RunConfig {
+    /// Trusted CommonMark parity configuration.
+    CommonMark,
+    /// Trusted GFM-overlap parity configuration.
+    GfmOverlap,
+    /// Trusted extended-overlap parity configuration.
+    ExtendedOverlap,
+    /// Secure Ferromark Essentials profile.
+    EssentialsSecure,
+    /// Trusted Ferromark Essentials profile.
+    EssentialsTrusted,
+    /// Secure Ferromark Extended profile.
+    ExtendedSecure,
+    /// Trusted Ferromark Extended profile.
+    ExtendedTrusted,
+    /// Secure Ferromark Full profile.
+    FullSecure,
+    /// Trusted Ferromark Full profile.
+    FullTrusted,
+}
+
+impl RunConfig {
+    /// All configurations accepted by the diagnostic runner.
+    pub const ALL: [Self; 9] = [
+        Self::CommonMark,
+        Self::GfmOverlap,
+        Self::ExtendedOverlap,
+        Self::EssentialsSecure,
+        Self::EssentialsTrusted,
+        Self::ExtendedSecure,
+        Self::ExtendedTrusted,
+        Self::FullSecure,
+        Self::FullTrusted,
+    ];
+
+    /// Stable command-line and metadata name.
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::CommonMark => "commonmark",
+            Self::GfmOverlap => "gfm-overlap",
+            Self::ExtendedOverlap => "extended-overlap",
+            Self::EssentialsSecure => "essentials-secure",
+            Self::EssentialsTrusted => "essentials-trusted",
+            Self::ExtendedSecure => "extended-secure",
+            Self::ExtendedTrusted => "extended-trusted",
+            Self::FullSecure => "full-secure",
+            Self::FullTrusted => "full-trusted",
+        }
+    }
+
+    /// Whether this configuration performs secure rendering checks.
+    pub const fn is_secure(self) -> bool {
+        matches!(
+            self,
+            Self::EssentialsSecure | Self::ExtendedSecure | Self::FullSecure
+        )
+    }
+
+    /// Whether this configuration is valid for the selected parser.
+    pub const fn supports(self, parser: ParserKind) -> bool {
+        match parser {
+            ParserKind::Ferromark => true,
+            ParserKind::PulldownCmark => matches!(
+                self,
+                Self::CommonMark | Self::GfmOverlap | Self::ExtendedOverlap
+            ),
+        }
+    }
+
+    /// Explicit Ferromark options represented by this configuration.
+    pub fn ferromark_options(self) -> Options {
+        match self {
+            Self::CommonMark => ferromark_options(ParityConfig::CommonMark),
+            Self::GfmOverlap => ferromark_options(ParityConfig::GfmOverlap),
+            Self::ExtendedOverlap => ferromark_options(ParityConfig::ExtendedOverlap),
+            Self::EssentialsSecure => Options::from(Profile::Essentials),
+            Self::EssentialsTrusted => trusted(Profile::Essentials),
+            Self::ExtendedSecure => Options::from(Profile::Extended),
+            Self::ExtendedTrusted => trusted(Profile::Extended),
+            Self::FullSecure => Options::from(Profile::Full),
+            Self::FullTrusted => trusted(Profile::Full),
+        }
+    }
+
+    /// Explicit pulldown-cmark options, if this is a parity configuration.
+    pub fn pulldown_options(self) -> Option<pulldown_cmark::Options> {
+        let parity = match self {
+            Self::CommonMark => ParityConfig::CommonMark,
+            Self::GfmOverlap => ParityConfig::GfmOverlap,
+            Self::ExtendedOverlap => ParityConfig::ExtendedOverlap,
+            _ => return None,
+        };
+        Some(pulldown_options(parity))
+    }
+}
+
+impl fmt::Display for RunConfig {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(self.as_str())
+    }
+}
+
+impl FromStr for RunConfig {
+    type Err = String;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        Self::ALL
+            .into_iter()
+            .find(|config| config.as_str() == value)
+            .ok_or_else(|| format!("unknown configuration `{value}`"))
+    }
+}
+
+fn trusted(profile: Profile) -> Options {
+    Options {
+        render_policy: RenderPolicy::Trusted,
+        ..Options::from(profile)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn pulldown_should_reject_product_profiles() {
+        assert!(!RunConfig::FullSecure.supports(ParserKind::PulldownCmark));
+    }
+
+    #[test]
+    fn secure_configuration_should_keep_untrusted_policy() {
+        assert_eq!(
+            RunConfig::EssentialsSecure
+                .ferromark_options()
+                .render_policy,
+            RenderPolicy::Untrusted
+        );
+    }
+
+    #[test]
+    fn trusted_configuration_should_select_trusted_policy() {
+        assert_eq!(
+            RunConfig::EssentialsTrusted
+                .ferromark_options()
+                .render_policy,
+            RenderPolicy::Trusted
+        );
+    }
+}

--- a/benchmarks/pulldown-comparison/tests/diagnostic_matrix.rs
+++ b/benchmarks/pulldown-comparison/tests/diagnostic_matrix.rs
@@ -1,0 +1,53 @@
+use ferromark_pulldown_comparison::{
+    Corpus, ParserKind, RunConfig, render_ferromark_config_into, render_pulldown_config_into,
+};
+
+#[test]
+fn every_ferromark_configuration_should_render() {
+    for configuration in RunConfig::ALL {
+        let corpus = if configuration == RunConfig::ExtendedOverlap {
+            Corpus::Extended
+        } else {
+            Corpus::CommonMark5K
+        }
+        .materialize();
+        let mut output = Vec::new();
+        render_ferromark_config_into(corpus.input(), configuration, &mut output);
+        assert!(
+            !output.is_empty(),
+            "configuration `{configuration}` produced no output"
+        );
+    }
+}
+
+#[test]
+fn every_pulldown_configuration_should_render() {
+    for configuration in RunConfig::ALL
+        .into_iter()
+        .filter(|config| config.supports(ParserKind::PulldownCmark))
+    {
+        let corpus = if configuration == RunConfig::ExtendedOverlap {
+            Corpus::Extended
+        } else {
+            Corpus::CommonMark5K
+        }
+        .materialize();
+        let mut output = String::new();
+        render_pulldown_config_into(corpus.input(), configuration, &mut output)
+            .expect("supported pulldown configuration should render");
+        assert!(
+            !output.is_empty(),
+            "configuration `{configuration}` produced no output"
+        );
+    }
+}
+
+#[test]
+fn every_corpus_should_render_with_extended_secure() {
+    for corpus in Corpus::ALL.into_iter().chain([Corpus::Extended]) {
+        let data = corpus.materialize();
+        let mut output = Vec::new();
+        render_ferromark_config_into(data.input(), RunConfig::ExtendedSecure, &mut output);
+        assert!(!output.is_empty(), "corpus `{corpus}` produced no output");
+    }
+}

--- a/docs/plans/2026-07-11-comprehensive-performance-profile-report.md
+++ b/docs/plans/2026-07-11-comprehensive-performance-profile-report.md
@@ -1,0 +1,246 @@
+# Comprehensive performance profile report
+
+Status: first evidence pass complete
+Date: 2026-07-11
+Design: [`2026-07-11-comprehensive-performance-profiling-design.md`](./2026-07-11-comprehensive-performance-profiling-design.md)
+
+## Scope and evidence quality
+
+This first pass validates the profiling infrastructure and updates the
+opportunity ranking. It is not a replacement for published Criterion numbers.
+
+Environment:
+
+- Apple Silicon Mac Studio (`ARM64_T6000`);
+- macOS 26.5.2;
+- pinned `rustc 1.93.0`, LLVM 21.1.8;
+- portable runs use `-C target-cpu=generic`;
+- reusable output buffers;
+- non-PGO builds;
+- feature-off throughput/allocation runs;
+- separate feature-on pipeline-counter run;
+- three 9-11 second macOS `sample` profiles with 6,632-8,087 samples.
+
+The throughput matrix used one-second diagnostic runs to validate coverage and
+find strong signals. Treat every throughput delta as directional until the same
+lane passes three alternating-order Criterion runs with the documented sample
+and measurement settings. The working tree was dirty with the profiling
+implementation, so these results are development evidence only.
+
+## Primary parity smoke
+
+Trusted CommonMark parity, portable code generation:
+
+| Corpus | Ferromark | pulldown-cmark | Directional lead |
+| --- | ---: | ---: | ---: |
+| 5 KB | 256.16 MiB/s | 235.28 MiB/s | Ferromark +8.9% |
+| 20 KB | 262.67 MiB/s | 234.13 MiB/s | Ferromark +12.2% |
+| 50 KB | 274.67 MiB/s | 243.80 MiB/s | Ferromark +12.7% |
+| 250 KB | 278.42 MiB/s | 242.49 MiB/s | Ferromark +14.8% |
+
+This is materially wider than the previous near-parity observation, but the
+toolchain, explicit portable target, and exact semantics differ from the README
+baseline. It is a reason to run the publication protocol, not a new claim.
+
+## Allocation shape
+
+Per rendered document in trusted CommonMark parity:
+
+| Corpus | Parser | Allocations | Reallocations | Requested bytes |
+| --- | --- | ---: | ---: | ---: |
+| 5 KB | Ferromark | 71 | 4 | 29,895 |
+| 5 KB | pulldown-cmark | 13 | 5 | 71,247 |
+| 20 KB | Ferromark | 79 | 5 | 75,959 |
+| 20 KB | pulldown-cmark | 27 | 7 | 228,667 |
+| 50 KB | Ferromark | 96 | 7 | 173,741 |
+| 50 KB | pulldown-cmark | 61 | 8 | 565,407 |
+| 250 KB | Ferromark | 213 | 10 | 831,809 |
+| 250 KB | pulldown-cmark | 273 | 18 | 2,934,171 |
+
+The unexpected result is that Ferromark performs more small allocations at
+5/20/50 KB while requesting far fewer total bytes. At 250 KB it is lower on both
+counts. Therefore “reduce allocation count” alone is the wrong target. The next
+allocation work should identify fixed small buffers and preserve Ferromark's
+better byte-volume scaling.
+
+On the 50 KB product lane, `Essentials secure` used about 82 allocations and
+172,887 requested bytes per document. `Extended secure` used about 347 and
+207,421. The input contains references, HTML, tables, headings, and other syntax,
+so this is real feature-path work rather than unused-option overhead.
+
+## Pipeline work shape
+
+One instrumented `Extended secure` 50 KB run reported these approximate values
+per document:
+
+| Counter | Per document |
+| --- | ---: |
+| Block events | 4,614 |
+| Inline parses | 1,018 |
+| Inline fast paths | 853 |
+| Inline events | 2,081 |
+| Inline marks | 719 |
+| Emit points | 587 |
+| Inline input bytes | 41,956 |
+| Paragraph bytes copied | 36,080 |
+
+Maximum retained capacities in that run were 6,542 block events and 64 each for
+inline events, marks, and emit points. The counters show that the fast paths are
+frequent and useful. They also show enough paragraph copying and event volume to
+justify structural experiments, but not enough evidence to remove the
+transformable event path.
+
+## CPU profiles
+
+### Mixed 50 KB product lane
+
+Largest exclusive sample buckets included:
+
+| Area | Samples |
+| --- | ---: |
+| Block-event rendering | 854 |
+| Inline parser | 843 |
+| Text escaping | 554 |
+| Block parser | 548 |
+| `memmove` | 502 |
+| Inline rendering | 410 |
+| Mark collection | 401 |
+| Heading ID generation | 367 |
+| Container matching | 245 |
+| Paragraph-line parsing | 235 |
+
+Heading ID generation is the most surprising newly visible feature cost. Its
+profile includes hash-map insertion and rehashing. It needs a focused heading
+corpus before changing its state model.
+
+### Delimiter-heavy lane
+
+The dominant buckets were mark collection (1,162), the inline parser (1,038),
+inline rendering (623), emphasis resolution (500), text escaping (496),
+`memmove` (426), and emit-point insertion sorting (405). This is strong evidence
+for reducing repeated inline-stage work or emitted intermediate work. It is not
+evidence that transformations require removal of events.
+
+### Safe-URL-heavy lane
+
+The dominant buckets were the inline parser (951), raw URL destination escaping
+(848), HTML entity decoding (620), link resolution (482), URL safety
+classification (272), URL encode/HTML escape (220), UTF-8 conversion (206), and
+string pattern searching (172).
+
+This is the clearest evidence of repeated work. Entity-free safe ASCII URLs
+still pass through several classification, conversion, encoding, and escaping
+steps. Consolidating scans has a measurable upper bound without weakening the
+secure rendering contract.
+
+## CPU-specific ceiling
+
+Short `Extended secure` 50 KB runs produced:
+
+| Code generation | Throughput |
+| --- | ---: |
+| portable/generic | 213.82 MiB/s |
+| `apple-m1` + NEON | 218.42 MiB/s |
+| `target-cpu=native` | 216.46 MiB/s |
+
+The M1 mode was about 2.2% above the portable smoke; `native` did not beat the
+explicit M1 mode. This suggests that CPU-specific code generation matters but is
+not a large hidden reserve on this machine. Existing M1/NEON tuning captures
+most of the visible ceiling. PGO remains unmeasured because no representative
+`.profdata` artifact exists yet.
+
+## Ranked opportunity map
+
+### 1. Consolidate the secure URL pipeline
+
+- **Evidence:** several large, separately visible URL decode/classify/encode
+  buckets; 126.78 MiB/s on the focused safe-URL smoke.
+- **Smallest experiment:** classify entity-free ASCII URLs and share one scan
+  result between safety and destination rendering; keep the current fallback.
+- **Expected return:** 1-3% on mixed secure input, substantially more on
+  URL-heavy input.
+- **Risk:** security-sensitive; differential/property tests are mandatory.
+- **Extensibility:** neutral. The semantic link event and trust boundary remain.
+- **Stop:** no repeated mixed-lane gain or any security/output difference.
+
+### 2. Reduce delimiter-stage repeated work
+
+- **Evidence:** mark collection, inline parsing, emphasis resolution, and
+  emit-point sorting dominate the delimiter profile.
+- **Smallest experiment:** have mark collection return a compact feature summary
+  and skip only downstream stages proven absent.
+- **Expected return:** 2-5% delimiter-heavy, potentially 1-2% mixed.
+- **Risk:** high semantic surface around precedence and nesting.
+- **Extensibility:** low impact if resolved events remain the boundary.
+- **Stop:** no gain across simple, mixed, and delimiter-heavy corpora or any
+  CommonMark regression.
+
+### 3. Focus heading-ID state and hashing
+
+- **Evidence:** 367 exclusive mixed-lane samples plus visible hash insertion and
+  rehash work.
+- **Smallest experiment:** add repeated/unique heading corpora and measure ID
+  creation, collision tracking, allocations, and disabled-path cost.
+- **Expected return:** unknown until isolated; potentially feature-specific
+  0.5-2% on heading-heavy documents.
+- **Risk:** duplicate-ID semantics and output compatibility.
+- **Extensibility:** neutral; heading events and transformability remain.
+- **Stop:** heading generation is not repeatably material after isolation.
+
+### 4. Borrow contiguous paragraphs with a buffered fallback
+
+- **Evidence:** about 36 KB copied per 52 KB document plus 502 `memmove` samples
+  in the mixed profile.
+- **Smallest experiment:** count source-contiguous paragraphs, then borrow only
+  the simple case while preserving the existing buffer for indentation and
+  container normalization.
+- **Expected return:** 1-3% on 20/50 KB and lower copied bytes.
+- **Risk:** range and newline normalization correctness.
+- **Extensibility:** favorable if the borrowed slice feeds the same semantic
+  event path.
+- **Stop:** fewer copied bytes without a repeated throughput gain, or complexity
+  leaks into consumers.
+
+### 5. Audit fixed small allocations, not allocation count alone
+
+- **Evidence:** Ferromark has higher small-document allocation counts but much
+  lower requested-byte volume; `InlineParser::new` is visible but not dominant.
+- **Smallest experiment:** attribute allocation stacks for Essentials and
+  Extended 5 KB, then lazily initialize one rare buffer group at a time.
+- **Expected return:** 1-3% at 5 KB; likely less at 50 KB.
+- **Risk:** replacing useful preallocation can regress larger inputs.
+- **Extensibility:** neutral.
+- **Stop:** total bytes or 20/50 KB throughput regress by more than 1%.
+
+### 6. Keep direct rendering optional
+
+- **Evidence:** event volume, rendering, and copying are material, but the current
+  profiles do not isolate event construction as the dominant universal cost.
+- **Smallest experiment:** define an internal sink over already resolved inline
+  semantics and compare event and HTML sinks without deleting either path.
+- **Expected return:** potentially 2-5%, still unbounded.
+- **Risk:** duplicated behavior and divergence between sinks.
+- **Extensibility:** high impact; the event/transform path must remain canonical
+  or share resolution logic.
+- **Stop:** requires duplicated parsing rules or cannot preserve an explicit
+  transformable path.
+
+### 7. Defer more hand-written SIMD
+
+- **Evidence:** existing M1 mode is only about 2.2% above portable and `native`
+  adds nothing in the smoke; earlier SIMD variants were neutral.
+- **Next gate:** instructions/cycles or a hot scalar scan must show a bounded
+  opportunity not already covered by `memchr` or NEON.
+- **Extensibility:** neutral, but portability risk is high.
+
+## Recommended execution order
+
+1. Run publication-quality CommonMark parity repetitions with the pinned
+   toolchain.
+2. Run focused heading-ID and allocation-stack diagnostics.
+3. Implement the secure URL shared-scan experiment.
+4. Implement the inline feature-summary experiment.
+5. Measure source-contiguous paragraphs and prototype the borrowed fast path.
+6. Re-profile before considering an optional direct-render sink.
+7. Build representative PGO training data only after portable source changes
+   stabilize.

--- a/docs/plans/2026-07-11-comprehensive-performance-profiling-design.md
+++ b/docs/plans/2026-07-11-comprehensive-performance-profiling-design.md
@@ -1,0 +1,329 @@
+# Comprehensive performance profiling design
+
+Status: proposed for review
+Date: 2026-07-11
+
+## Context
+
+Ferromark is close enough to `pulldown-cmark` that a difference below 2% can be
+measurement noise, compiler drift, or a real parser cost. The repository already
+contains important low-level optimizations: reusable buffers, range-based events,
+`memchr` scanning, AArch64 NEON paths, fat LTO, one release codegen unit, and PGO
+profiling scripts. It also records several neutral or regressive pre-scan, SIMD,
+streaming, and allocation experiments.
+
+The next phase therefore profiles the complete parse-and-render pipeline before
+making more production changes. It is intended to find unexpected costs, bound
+the value of larger structural changes, and distinguish portable source wins
+from compiler- or CPU-specific wins.
+
+The profiling work must not prematurely collapse Ferromark into one HTML-only
+execution path. A future ecosystem may need remark-like transformations,
+plugins, alternate renderers, or event consumers. Performance evidence may
+justify an optional direct-render fast path, but not the removal of a useful
+intermediate representation without a separate architecture decision.
+
+## Goals
+
+1. Produce repeatable CPU, allocation, memory, and pipeline-work measurements.
+2. Cover representative syntax, document sizes, profiles, and trust policies.
+3. Compare Ferromark and `pulldown-cmark` only where the performed work is
+   semantically comparable.
+4. Identify both local hotspots and structural sources of repeated work.
+5. Measure the ceiling from Apple Silicon tuning, native code generation, and
+   PGO without mixing those gains into portable source claims.
+6. Rank follow-up experiments by expected return, risk, portability, and impact
+   on future extensibility.
+
+## Non-goals
+
+- Optimizing production parser or renderer code in the profiling change.
+- Designing or committing to a public plugin API.
+- Replacing the event pipeline with a direct HTML sink.
+- Publishing new headline benchmark claims from one development-machine run.
+- Adding hand-written SIMD before profiles and instruction data justify it.
+- Treating lower security work as a parser optimization.
+
+## Approaches considered
+
+### One larger CPU sample
+
+Rejected as insufficient. A CPU flame graph can locate time, but it does not
+explain allocation pressure, bytes copied, buffer growth, event volume, peak
+memory, branch behavior, or code-generation differences.
+
+### Begin a structural parser rewrite immediately
+
+Rejected as premature. Direct rendering, aggregated block events, borrowed
+paragraph slices, and compact scratch layouts are credible experiments, but
+their benefit and architectural cost are not yet measured well enough.
+
+### A bounded multidimensional profiling campaign
+
+Accepted. One profiling-focused change adds reproducible harnesses, metadata,
+corpora, counters, and reporting. Production behavior remains unchanged. The
+result is an evidence package and a ranked experiment backlog.
+
+## Architecture constraint: preserve transformability
+
+Profiling and later decisions distinguish three conceptual layers:
+
+1. **Parse state and syntax resolution**
+   discovers block and inline structure, references, and precedence.
+2. **Intermediate semantic representation**
+   exposes resolved structure that future transforms or plugins could inspect
+   or alter.
+3. **Output sinks**
+   turn resolved semantics into HTML or another representation.
+
+The current event model does not automatically become the final plugin API, but
+it represents an important architectural capability. Profiling may show that
+event construction is expensive. If so, acceptable follow-up designs include:
+
+- keeping the event path as the canonical transformable path;
+- adding an optional direct HTML sink for callers that request no transforms;
+- sharing syntax resolution between event and direct-output sinks;
+- using a more compact internal representation that remains traversable;
+- fusing stages only behind an internal or explicit fast-path boundary.
+
+An optimization is not accepted solely because it improves HTML throughput. Its
+evaluation must also state whether it preserves, narrows, duplicates, or removes
+a plausible transformation boundary.
+
+## Profiling harness
+
+Extend the existing `benchmarks/pulldown-comparison` crate with the focused
+profiling harness. It is already independent of md4c and comrak, excluded from
+the published Ferromark package, and owns the semantically guarded parity
+configurations. Keeping one comparison crate avoids duplicating those option
+contracts.
+
+The harness has two execution modes:
+
+### Throughput mode
+
+Criterion measures steady-state end-to-end throughput with reusable output
+buffers. It stores machine-readable estimates for repeated baseline/candidate
+comparisons.
+
+### Diagnostic mode
+
+A long-running binary repeatedly executes exactly one named parser, corpus,
+configuration, and phase. This gives Instruments, `xctrace`, `sample`, and
+Samply a stable process with little benchmark-harness noise.
+
+Every run records:
+
+- git commit and dirty state;
+- `rustc -Vv` and active target;
+- Cargo profile and effective `RUSTFLAGS`;
+- CPU architecture and operating system;
+- corpus name, input bytes, and output bytes;
+- parser and complete option set;
+- trust/rendering policy;
+- iteration count and elapsed time;
+- whether PGO or CPU-specific flags were used.
+
+## Corpus matrix
+
+The matrix is broad enough to reveal phase-specific behavior without becoming a
+combinatorial benchmark suite.
+
+### Core corpora
+
+- simple prose with little markup;
+- mixed CommonMark;
+- code-heavy documents;
+- safe and unsafe URL-heavy documents;
+- reference-definition and reference-link-heavy documents;
+- table-heavy documents;
+- list and blockquote container-heavy documents;
+- delimiter-heavy inline markup;
+- raw-HTML-heavy documents;
+- Unicode- and entity-heavy documents.
+
+### Sizes
+
+- approximately 5 KB for fixed setup and allocation cost;
+- approximately 20 KB for ordinary application documents;
+- approximately 50 KB for the existing published comparison range;
+- one larger fixture, at least 250 KB, for cache, growth, and scaling behavior.
+
+Not every focused corpus requires every size. The three CommonMark sizes and one
+large mixed fixture are mandatory; focused corpora use a representative size.
+
+### Configurations
+
+- Ferromark `Essentials`, `Extended`, and `Full` on compatible input;
+- secure-default and trusted rendering as separately named lanes;
+- CommonMark, GFM-overlap, and extended-overlap parity configurations;
+- `pulldown-cmark` only in semantically guarded parity lanes.
+
+## Measurement dimensions
+
+### CPU time and stacks
+
+Collect repeated time profiles for the primary 5 KB and 50 KB lanes plus each
+focused corpus. Reports retain both inclusive and exclusive samples and group
+symbols into block parsing, inline parsing, reference work, event production,
+rendering, escaping, allocation, and copying.
+
+Use Apple Time Profiler or `xctrace` as the primary local source and Samply as a
+second view where useful. A finding is actionable only when it appears in a
+repeatable run or is supported by another measurement dimension.
+
+### Allocations and memory
+
+A benchmark-only counting allocator records allocation count, reallocation
+count, deallocation count, and allocated bytes inside a controlled measurement
+window. Instruments Allocations provides stack attribution for selected lanes.
+
+Where the public API permits clean isolation, measure:
+
+- parser and renderer setup;
+- block parsing;
+- inline parsing and event emission;
+- rendering;
+- full end-to-end conversion.
+
+Also record output-buffer capacity and peak resident memory for diagnostic runs.
+If internal phase isolation would require production API changes, record only
+end-to-end allocation data and use stack attribution rather than exposing new
+APIs for the profiler.
+
+### Pipeline work counters
+
+Benchmark-only instrumentation records work that wall-clock profiles cannot
+explain reliably:
+
+- block event count by kind;
+- inline event count by kind;
+- inline marks and emit points;
+- buffer growth events and maximum capacities;
+- bytes copied into paragraph or scratch buffers;
+- bytes visited by major inline stages;
+- URL normalization and escaping passes;
+- reference-label normalization calls;
+- fast-path hits and fallbacks.
+
+Counters are enabled only by a non-default profiling feature. Small internal
+hooks behind that feature are allowed, but the feature-off build must have no
+counter fields, branches, public API additions, or changed behavior. The
+instrumented build is never benchmarked as if it were the normal release build.
+
+### Code generation and hardware
+
+Run a separate compiler matrix on a small set of primary lanes:
+
+- portable/default target behavior;
+- current `apple-m1` target configuration;
+- `target-cpu=native` as a local ceiling;
+- non-PGO and PGO builds.
+
+Where Instruments exposes reliable counters, compare instructions, cycles,
+branches, branch misses, and cache-related events. If counters are unavailable
+or unstable, state that limitation rather than estimating them from wall time.
+
+Inspect assembly or LLVM output only for functions that are both hot and
+sensitive to the compiler matrix. CPU-specific wins remain separately labeled
+and do not become the default portable performance claim.
+
+Potential SIMD work is gated by this evidence. Existing NEON and `memchr` paths
+are baselines, not assumptions that custom intrinsics are faster. Any later SIMD
+experiment needs a scalar or portable fallback and cross-platform correctness
+tests.
+
+## Comparison protocol
+
+- Pin and record the benchmark Rust toolchain.
+- Run on AC power with stable machine conditions.
+- Use at least 80 samples, a 5-second measurement window, and a 3-second warmup
+  for screening.
+- Repeat promising or surprising results three times.
+- Alternate baseline and comparison order when practical.
+- Treat changes below 1% as noise unless confidence intervals and medians agree
+  across repeated runs.
+- Keep secure-default and trusted/parity results separate.
+- Store raw Criterion estimates and profiler summaries as artifacts.
+- Do not compare instrumented-counter throughput with normal release throughput.
+
+## Analysis output
+
+The profiling report contains:
+
+1. environment and reproducibility metadata;
+2. throughput matrix and confidence intervals;
+3. CPU hotspot tables by corpus and configuration;
+4. allocation and memory tables;
+5. pipeline work and scaling counters;
+6. compiler/CPU/PGO deltas;
+7. unexpected findings and disproven assumptions;
+8. a ranked opportunity map.
+
+Each opportunity is scored on:
+
+- observed cost or bounded maximum gain;
+- expected throughput and memory benefit;
+- implementation and correctness risk;
+- portability;
+- effect on transformation/plugin flexibility;
+- smallest experiment that can validate it;
+- stop condition.
+
+The report explicitly identifies negative results so later work does not repeat
+them without new evidence.
+
+## Likely follow-up classes
+
+These are hypotheses to measure, not approved implementations:
+
+- lazy or smaller scratch buffers for rare syntax;
+- fewer URL safety, normalization, encoding, and escaping passes;
+- borrowed contiguous paragraph input with a buffered fallback;
+- compact event or mark layouts and less copied metadata;
+- reduced repeated inline-stage scans;
+- shared syntax resolution with optional event and direct-output sinks;
+- better cache locality in block/container state;
+- PGO or target-specific deployment recommendations;
+- focused SIMD only for a demonstrated scan hotspot.
+
+## Validation
+
+The profiling change must pass:
+
+- formatting and Clippy for all added Rust targets;
+- unit tests for metadata and counter-window correctness;
+- semantic parity tests for every cross-parser lane;
+- smoke execution of every corpus/configuration selector;
+- a check that instrumentation is absent from ordinary production builds;
+- the existing Ferromark test and CommonMark suites.
+
+Raw profiler traces may be too large or platform-specific for git. In that case,
+the repository stores scripts, metadata, compact exports, and summaries while
+documenting the location and reproduction command for raw artifacts.
+
+## Deliverables
+
+1. Reproducible throughput and diagnostic runners.
+2. The bounded corpus/configuration matrix.
+3. Allocation and pipeline-work measurement support.
+4. CPU and compiler-matrix profiling scripts.
+5. Machine-readable run metadata and Criterion output retention.
+6. A completed profiling report and ranked experiment backlog.
+7. Updates to the existing performance checklist based on measured evidence.
+
+## Acceptance criteria
+
+- A clean checkout can reproduce every retained measurement command.
+- Every result identifies code, compiler, CPU mode, corpus, options, and trust
+  policy.
+- CPU, allocation, memory, and pipeline-work evidence cover the primary lanes.
+- At least one large-document run verifies scaling and buffer-growth behavior.
+- Ferromark and `pulldown-cmark` are compared only under semantically guarded
+  parity configurations.
+- Portable, Apple-specific, and PGO results are reported separately.
+- No production parser behavior or public API changes are required.
+- The opportunity map includes extensibility impact and a stop condition for
+  every proposed structural experiment.
+- Direct HTML rendering, if later justified, remains optional unless a separate
+  architecture decision explicitly replaces the transformable path.

--- a/docs/plans/2026-07-11-comprehensive-performance-profiling-design.md
+++ b/docs/plans/2026-07-11-comprehensive-performance-profiling-design.md
@@ -1,6 +1,6 @@
 # Comprehensive performance profiling design
 
-Status: proposed for review
+Status: approved for implementation
 Date: 2026-07-11
 
 ## Context

--- a/docs/plans/2026-07-11-comprehensive-performance-profiling-implementation-plan.md
+++ b/docs/plans/2026-07-11-comprehensive-performance-profiling-implementation-plan.md
@@ -1,0 +1,76 @@
+# Comprehensive performance profiling implementation plan
+
+Status: approved for implementation
+Date: 2026-07-11
+Design: [`2026-07-11-comprehensive-performance-profiling-design.md`](./2026-07-11-comprehensive-performance-profiling-design.md)
+
+## Task 1 — Reproducible run model and corpus registry
+
+- [x] Add typed parser, configuration, and corpus selectors to
+      `benchmarks/pulldown-comparison`.
+- [x] Keep parity options centralized in the existing comparison library.
+- [x] Add focused synthetic corpora plus the existing 5/20/50 KB fixtures and a
+      250 KB scaling fixture.
+- [x] Add serializable run metadata covering commit, dirty state, compiler,
+      target, flags, corpus, options, trust policy, and byte sizes.
+- [x] Test selector parsing, corpus identity, and configuration compatibility.
+
+## Task 2 — Diagnostic runner and throughput matrix
+
+- [x] Add a release-mode diagnostic binary that repeatedly runs one exact lane.
+- [x] Support iteration- and duration-based execution without allocations in the
+      measured render loop beyond parser work.
+- [x] Emit one machine-readable JSON summary per run.
+- [x] Add a focused Criterion profiling matrix without replacing the small parity
+      benchmark.
+- [x] Verify every parser/configuration/corpus selector with smoke tests.
+
+## Task 3 — Allocation and memory evidence
+
+- [x] Add a counting global allocator only to the diagnostic binary.
+- [x] Record allocation, reallocation, deallocation, allocated-byte, and
+      deallocated-byte deltas inside an explicit measurement window.
+- [x] Warm output buffers before the window and report retained capacity.
+- [x] Add tests proving reset/window semantics and disabled-window isolation.
+- [x] Document that allocator counts include all parser-internal allocations but
+      exclude setup and summary serialization.
+
+## Task 4 — Feature-gated pipeline work counters
+
+- [x] Add a non-default root `profiling` feature with a hidden diagnostics module.
+- [x] Ensure the feature-off build contains no counter fields, branches, or API.
+- [x] Count block events, inline events, marks, emit points, paragraph bytes,
+      relevant capacities, and selected fast-path outcomes.
+- [x] Reset and snapshot counters per diagnostic run.
+- [x] Test counter correctness and verify normal all-feature/all-target gates.
+
+## Task 5 — Profiler and compiler-matrix orchestration
+
+- [x] Add scripts that build the exact diagnostic binary with debug symbols.
+- [x] Add Time Profiler/`xctrace`, `sample`, and Samply commands without requiring
+      all tools on every platform.
+- [x] Add explicit portable, `apple-m1`, `native`, PGO, and non-PGO modes.
+- [x] Store compact metadata and exports under an ignored results directory.
+- [x] Document stable machine conditions and the three-run protocol.
+
+## Task 6 — First comprehensive evidence pass
+
+- [x] Run the primary 5/20/50 KB and 250 KB lanes.
+- [x] Run focused simple, code, URL, refs, tables, containers, delimiters, HTML,
+      and Unicode/entity lanes.
+- [x] Capture CPU profiles for the highest-value representative lanes.
+- [x] Capture allocation and pipeline-counter summaries.
+- [x] Compare portable/current/native codegen and PGO where available.
+- [x] Write a ranked opportunity map including extensibility impact and stop
+      conditions.
+- [x] Update the existing pulldown-gap checklist with completed and rejected
+      findings.
+
+## Validation gate
+
+- [x] `cargo fmt --all -- --check`
+- [x] `cargo test --all-targets --all-features --locked`
+- [x] `cargo clippy --all-targets --all-features --locked -- -D warnings`
+- [x] Focused comparison tests, Clippy, and benchmark build with `--locked`.
+- [x] Diagnostic smoke matrix succeeds in feature-off and profiling builds.
+- [x] Root package contents exclude generated traces and comparison artifacts.

--- a/docs/plans/2026-07-11-pulldown-gap-performance-plan.md
+++ b/docs/plans/2026-07-11-pulldown-gap-performance-plan.md
@@ -181,12 +181,12 @@ measures.
 
 #### 0.3 Pin the performance toolchain
 
-- [ ] Add a documented benchmark toolchain version; do not silently use the
+- [x] Add a documented benchmark toolchain version; do not silently use the
       developer's current nightly.
 - [ ] Run stable/MSRV and the benchmark toolchain as separate lanes if both are
       useful.
-- [ ] Report PGO and non-PGO results separately.
-- [ ] Save Criterion estimates or machine-readable summaries as artifacts.
+- [x] Report PGO and non-PGO results separately.
+- [x] Save Criterion estimates or machine-readable summaries as artifacts.
 
 Acceptance: a later run can explain compiler-caused drift rather than treating
 it as a parser regression.
@@ -219,7 +219,7 @@ Why: `InlineParser::new()` creates many `Vec::with_capacity` buffers, including
 buffers for disabled or uncommon extensions. This is a fixed cost per document
 and is consistent with parity at 5 KB but a lead at 20 KB.
 
-- [ ] Add an allocation-count benchmark for 5 KB, 20 KB, and 50 KB.
+- [x] Add an allocation-count benchmark for 5 KB, 20 KB, and 50 KB.
 - [ ] Record allocation count and allocated bytes for parser construction,
       block parse, inline parse, and render separately where possible.
 - [ ] Classify every preallocated inline buffer as common-default, conditional,
@@ -371,7 +371,7 @@ Expected gain: fixture-specific 2-5%; likely below 1% on the mixed 50 KB corpus.
 - [ ] Report PGO gains separately for ferromark and pulldown-cmark.
 - [ ] Inspect code size and instruction-cache effects of fat LTO and
       `codegen-units = 1`.
-- [ ] Test `target-cpu=native` only as a local/deployment lane, never as the
+- [x] Test `target-cpu=native` only as a local/deployment lane, never as the
       portable published baseline.
 
 ## Do not repeat without new profile evidence
@@ -400,12 +400,12 @@ paths, and skipping inline-link resolution without a `](` candidate.
 
 - [ ] 0.1 Two-parser harness
 - [ ] 0.2 Semantic lanes and output classification
-- [ ] 0.3 Toolchain/result pinning
+- [x] 0.3 Toolchain/result pinning
 - [ ] 1.1 0.2-versus-0.3 default-path A/B
 - [ ] 1.2 Allocation census and lazy rare buffers
 - [ ] 1.3 Secure URL pass reduction
 - [ ] 1.4 Contiguous paragraph rendering
-- [ ] Re-profile and update the expected-return ranking
+- [x] Re-profile and update the expected-return ranking
 - [ ] 2.1 Inline feature-summary experiment
 - [ ] 2.2 Direct inline render sink
 - [ ] 3.1 Aggregated block-event experiment

--- a/src/inline/marks.rs
+++ b/src/inline/marks.rs
@@ -129,6 +129,11 @@ impl MarkBuffer {
         self.marks.len()
     }
 
+    #[cfg(feature = "profiling")]
+    pub(crate) fn capacity(&self) -> usize {
+        self.marks.capacity()
+    }
+
     /// Check if empty.
     #[inline]
     pub fn is_empty(&self) -> bool {

--- a/src/inline/mod.rs
+++ b/src/inline/mod.rs
@@ -149,6 +149,8 @@ impl InlineParser {
         footnote_store: Option<&FootnoteStore>,
         events: &mut Vec<InlineEvent>,
     ) {
+        #[cfg(feature = "profiling")]
+        let event_start = events.len();
         let has_specials = if highlight && superscript {
             has_inline_specials_highlight_superscript(text)
         } else if highlight {
@@ -166,6 +168,16 @@ impl InlineParser {
             if !text.is_empty() {
                 events.push(InlineEvent::Text(Range::from_usize(0, text.len())));
             }
+            #[cfg(feature = "profiling")]
+            crate::profiling::record_inline_parse(
+                text.len(),
+                events.len() - event_start,
+                0,
+                self.mark_buffer.capacity(),
+                0,
+                self.emit_points.capacity(),
+                true,
+            );
             return;
         }
 
@@ -190,6 +202,16 @@ impl InlineParser {
             if !text.is_empty() {
                 events.push(InlineEvent::Text(Range::from_usize(0, text.len())));
             }
+            #[cfg(feature = "profiling")]
+            crate::profiling::record_inline_parse(
+                text.len(),
+                events.len() - event_start,
+                self.mark_buffer.len(),
+                self.mark_buffer.capacity(),
+                0,
+                self.emit_points.capacity(),
+                true,
+            );
             return;
         }
 
@@ -475,6 +497,16 @@ impl InlineParser {
             &mut self.emit_points,
             &mut self.emit_suppress_ranges,
             events,
+        );
+        #[cfg(feature = "profiling")]
+        crate::profiling::record_inline_parse(
+            text.len(),
+            events.len() - event_start,
+            self.mark_buffer.len(),
+            self.mark_buffer.capacity(),
+            self.emit_points.len(),
+            self.emit_points.capacity(),
+            false,
         );
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,6 +23,9 @@ pub mod limits;
 pub mod link_ref;
 #[cfg(feature = "mdx")]
 pub mod mdx;
+#[cfg(feature = "profiling")]
+#[doc(hidden)]
+pub mod profiling;
 pub mod range;
 pub mod render;
 
@@ -519,10 +522,14 @@ impl ParagraphState {
     }
 
     fn add_text(&mut self, text: &[u8]) {
+        #[cfg(feature = "profiling")]
+        profiling::record_paragraph_copy(text.len());
         self.content.extend_from_slice(text);
     }
 
     fn add_soft_break(&mut self) {
+        #[cfg(feature = "profiling")]
+        profiling::record_paragraph_copy(1);
         self.content.push(b'\n');
     }
 
@@ -852,6 +859,8 @@ fn render_to_writer_impl<R: FencedCodeRenderer + ?Sized>(
     let mut parser = BlockParser::new_with_options(input, *options);
     let mut events = Vec::with_capacity((input.len() / 16).max(64));
     parser.parse(&mut events);
+    #[cfg(feature = "profiling")]
+    profiling::record_block_events(&events, events.capacity());
     let link_refs = parser.take_link_refs();
     let footnote_store = if options.footnotes {
         Some(parser.take_footnote_store())
@@ -1387,6 +1396,8 @@ fn render_inline_content(
         footnote_store,
         inline_events,
     );
+    #[cfg(feature = "profiling")]
+    profiling::record_inline_events(inline_events, inline_events.capacity());
 
     let mut image_state = None;
     for event in inline_events.iter() {

--- a/src/profiling.rs
+++ b/src/profiling.rs
@@ -1,0 +1,194 @@
+//! Feature-gated internal work counters for profiling builds.
+
+use std::cell::Cell;
+
+use crate::{BlockEvent, InlineEvent};
+
+/// Aggregate pipeline work performed since the last reset.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct PipelineSnapshot {
+    /// Documents rendered.
+    pub documents: u64,
+    /// Total block events.
+    pub block_events: u64,
+    /// Block text and soft-break events.
+    pub block_text_events: u64,
+    /// List and blockquote container events.
+    pub block_container_events: u64,
+    /// Table events.
+    pub block_table_events: u64,
+    /// Code block and code content events.
+    pub block_code_events: u64,
+    /// Largest block-event capacity observed.
+    pub max_block_event_capacity: u64,
+    /// Inline parse invocations.
+    pub inline_parses: u64,
+    /// Inline input bytes visited at the parse boundary.
+    pub inline_input_bytes: u64,
+    /// Inline events emitted.
+    pub inline_events: u64,
+    /// Text and code inline events.
+    pub inline_text_events: u64,
+    /// Link, image, and autolink inline events.
+    pub inline_link_events: u64,
+    /// HTML inline events.
+    pub inline_html_events: u64,
+    /// Collected inline marks.
+    pub inline_marks: u64,
+    /// Generated inline emit points.
+    pub inline_emit_points: u64,
+    /// Inline parses completed through a plain-text fast path.
+    pub inline_fast_paths: u64,
+    /// Largest inline-event capacity observed.
+    pub max_inline_event_capacity: u64,
+    /// Largest mark-buffer capacity observed.
+    pub max_mark_capacity: u64,
+    /// Largest emit-point capacity observed.
+    pub max_emit_point_capacity: u64,
+    /// Bytes copied into paragraph scratch storage.
+    pub paragraph_copied_bytes: u64,
+}
+
+thread_local! {
+    static COUNTERS: Cell<PipelineSnapshot> = const { Cell::new(PipelineSnapshot {
+        documents: 0,
+        block_events: 0,
+        block_text_events: 0,
+        block_container_events: 0,
+        block_table_events: 0,
+        block_code_events: 0,
+        max_block_event_capacity: 0,
+        inline_parses: 0,
+        inline_input_bytes: 0,
+        inline_events: 0,
+        inline_text_events: 0,
+        inline_link_events: 0,
+        inline_html_events: 0,
+        inline_marks: 0,
+        inline_emit_points: 0,
+        inline_fast_paths: 0,
+        max_inline_event_capacity: 0,
+        max_mark_capacity: 0,
+        max_emit_point_capacity: 0,
+        paragraph_copied_bytes: 0,
+    }) };
+}
+
+/// Reset counters for the current thread.
+pub fn reset() {
+    COUNTERS.with(|counters| counters.set(PipelineSnapshot::default()));
+}
+
+/// Snapshot counters for the current thread.
+pub fn snapshot() -> PipelineSnapshot {
+    COUNTERS.with(Cell::get)
+}
+
+pub(crate) fn record_block_events(events: &[BlockEvent], capacity: usize) {
+    update(|counters| {
+        counters.documents += 1;
+        counters.block_events += events.len() as u64;
+        counters.max_block_event_capacity = counters.max_block_event_capacity.max(capacity as u64);
+        for event in events {
+            match event {
+                BlockEvent::Text(_) | BlockEvent::SoftBreak | BlockEvent::HtmlBlockText(_) => {
+                    counters.block_text_events += 1;
+                }
+                BlockEvent::BlockQuoteStart { .. }
+                | BlockEvent::BlockQuoteEnd
+                | BlockEvent::ListStart { .. }
+                | BlockEvent::ListEnd { .. }
+                | BlockEvent::ListItemStart { .. }
+                | BlockEvent::ListItemEnd => counters.block_container_events += 1,
+                BlockEvent::TableStart
+                | BlockEvent::TableEnd
+                | BlockEvent::TableHeadStart
+                | BlockEvent::TableHeadEnd
+                | BlockEvent::TableBodyStart
+                | BlockEvent::TableBodyEnd
+                | BlockEvent::TableRowStart
+                | BlockEvent::TableRowEnd
+                | BlockEvent::TableCellStart { .. }
+                | BlockEvent::TableCellEnd => counters.block_table_events += 1,
+                BlockEvent::CodeBlockStart { .. }
+                | BlockEvent::CodeBlockEnd
+                | BlockEvent::Code(_) => counters.block_code_events += 1,
+                _ => {}
+            }
+        }
+    });
+}
+
+pub(crate) fn record_inline_events(events: &[InlineEvent], capacity: usize) {
+    update(|counters| {
+        counters.max_inline_event_capacity =
+            counters.max_inline_event_capacity.max(capacity as u64);
+        for event in events {
+            match event {
+                InlineEvent::Text(_) | InlineEvent::Code(_) => counters.inline_text_events += 1,
+                InlineEvent::LinkStart { .. }
+                | InlineEvent::LinkStartRef { .. }
+                | InlineEvent::LinkEnd
+                | InlineEvent::ImageStart { .. }
+                | InlineEvent::ImageStartRef { .. }
+                | InlineEvent::ImageEnd
+                | InlineEvent::Autolink { .. }
+                | InlineEvent::AutolinkLiteral { .. } => counters.inline_link_events += 1,
+                InlineEvent::Html(_) => counters.inline_html_events += 1,
+                _ => {}
+            }
+        }
+    });
+}
+
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn record_inline_parse(
+    input_bytes: usize,
+    events: usize,
+    marks: usize,
+    mark_capacity: usize,
+    emit_points: usize,
+    emit_point_capacity: usize,
+    fast_path: bool,
+) {
+    update(|counters| {
+        counters.inline_parses += 1;
+        counters.inline_input_bytes += input_bytes as u64;
+        counters.inline_events += events as u64;
+        counters.inline_marks += marks as u64;
+        counters.inline_emit_points += emit_points as u64;
+        counters.inline_fast_paths += u64::from(fast_path);
+        counters.max_mark_capacity = counters.max_mark_capacity.max(mark_capacity as u64);
+        counters.max_emit_point_capacity = counters
+            .max_emit_point_capacity
+            .max(emit_point_capacity as u64);
+    });
+}
+
+pub(crate) fn record_paragraph_copy(bytes: usize) {
+    update(|counters| {
+        counters.paragraph_copied_bytes += bytes as u64;
+    });
+}
+
+fn update(update_counters: impl FnOnce(&mut PipelineSnapshot)) {
+    COUNTERS.with(|cell| {
+        let mut counters = cell.get();
+        update_counters(&mut counters);
+        cell.set(counters);
+    });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn reset_should_clear_recorded_work() {
+        reset();
+        record_paragraph_copy(12);
+        reset();
+
+        assert_eq!(snapshot().paragraph_copied_bytes, 0);
+    }
+}


### PR DESCRIPTION
## Summary

This adds a comprehensive, md4c-independent profiling system for Ferromark and records the first multidimensional evidence pass.

The change is deliberately split into three layers:

1. a reproducible profiling design;
2. benchmark-only measurement infrastructure;
3. a directional evidence report and ranked optimization backlog.

It does not optimize production behavior yet and does not replace the published benchmark numbers.

## Why profile first

Ferromark and pulldown-cmark are close enough that small throughput differences can be compiler drift or measurement noise. Ferromark also already contains NEON paths, memchr-based scans, reusable buffers, fat LTO, and several previously tested fast paths.

A CPU flame graph alone cannot distinguish parser time from:

- allocation count and requested bytes;
- buffer growth and copied paragraph data;
- event and mark volume;
- security-related decode/classify/encode passes;
- target-specific code generation;
- optional feature costs.

This PR adds those missing dimensions before another source-level optimization is selected.

## Profiling infrastructure

The isolated `benchmarks/pulldown-comparison` crate now includes:

- a pinned Rust 1.93.0 profiling toolchain;
- typed parser, configuration, and corpus selectors;
- 5 KB, 20 KB, 50 KB, and 250 KB scaling inputs;
- focused prose, code, URL, reference, table, container, delimiter, HTML, and Unicode/entity corpora;
- a long-running release diagnostic runner;
- a broader Criterion profiling matrix;
- machine-readable JSON metadata;
- a benchmark-only counting allocator;
- scripts for portable, Apple M1, native, and PGO modes;
- `sample`, Samply, and `xctrace` capture commands;
- an ignored results directory for raw local artifacts.

Every run records commit and dirty state, compiler/LLVM version, target, flags, CPU mode, corpus, configuration, trust policy, byte sizes, iterations, duration, output capacity, and allocation activity.

## Feature-gated pipeline counters

The root crate gains a non-default `profiling` feature. When enabled, hidden internal counters measure:

- block events by broad category;
- inline parse and event volume;
- marks and emit points;
- fast-path hits;
- retained capacities;
- inline input bytes;
- paragraph bytes copied.

The feature-off build contains none of these hooks or counters. Instrumented throughput is explicitly not compared with normal release throughput.

## Architecture and plugin flexibility

The profiling design treats a future remark-like transform/plugin ecosystem as an architecture constraint.

The current event path is not declared to be the final plugin API, but performance work must preserve a plausible semantic transformation boundary. A direct HTML sink may be explored later as an optional fast path that shares syntax resolution; this PR does not make HTML output the only internal route.

Every ranked structural experiment includes an extensibility impact and a stop condition.

## First directional findings

These short runs validate the infrastructure and identify strong signals. They are not publication-quality replacement numbers.

- Trusted CommonMark parity was directionally ahead of pulldown-cmark across 5/20/50/250 KB under the pinned portable build.
- Ferromark performed more small allocations at 5/20/50 KB but requested substantially fewer total heap bytes; at 250 KB it was lower on both.
- The 50 KB Extended secure lane produced about 4,614 block events, 2,081 inline events, 719 marks, 587 emit points, and copied about 36 KB into paragraph scratch storage per document.
- Safe-URL profiles exposed repeated entity decode, safety classification, destination encoding, and HTML escaping work.
- Delimiter-heavy profiles were dominated by mark collection, inline resolution, emphasis handling, and emit-point sorting.
- Heading-ID generation and hash-state maintenance were a notable unexpected mixed-document hotspot.
- Apple M1 code generation was only modestly above portable, while `target-cpu=native` did not improve further in the smoke. There is no evidence of a large unused chipset-specific reserve.
- PGO remains separate and unmeasured until representative training data exists.

The report keeps exact caveats, profile sample counts, allocation shapes, and directional throughput tables.

## Ranked next experiments

1. Repeat publication-quality CommonMark parity runs.
2. Consolidate the secure URL scan/decode/classify pipeline.
3. Add an inline feature summary to skip proven-absent stages.
4. Isolate heading-ID state and hashing.
5. Prototype borrowed contiguous paragraphs with the current buffer fallback.
6. Re-profile before considering an optional direct-render sink.
7. Build representative PGO training data after portable source changes stabilize.

## Validation

- `cargo fmt --all -- --check`
- `cargo test --all-targets --all-features --locked`
- `cargo clippy --all-targets --all-features --locked -- -D warnings`
- explicit ignored CommonMark full-report tests
- focused comparison tests with and without profiling counters
- focused comparison Clippy with `-D warnings`
- comparison Criterion benchmark build with `--locked`
- complete diagnostic selector/corpus smoke matrix
- portable, Apple M1, and native diagnostic modes
- three macOS `sample` CPU profiles
- `cargo package --allow-dirty --list`
- clean diff and no tracked result/trace/target artifacts

## Screenshots

Not applicable. This PR adds benchmark infrastructure, feature-gated diagnostics, scripts, and documentation; there are no visual UI changes.
