### PR TITLE
bench: establish publication-quality performance baseline

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,9 @@
 [![Rust 1.85+](https://img.shields.io/badge/rust-1.85%2B-orange.svg)](https://www.rust-lang.org)
 [![clippy](https://img.shields.io/badge/clippy--strict-passing-brightgreen.svg)](https://doc.rust-lang.org/clippy/)
 
-Markdown to HTML at 280 MiB/s. Faster than pulldown-cmark, md4c (C), and comrak. Passes all 652 CommonMark spec tests. Every GFM extension included.
+Markdown to HTML with a secure default and every GFM extension included. The
+reproducible benchmark protocol and current CommonMark conformance result are
+documented below.
 
 ## Quick start
 
@@ -76,7 +78,11 @@ does not expose an equivalent trust boundary.
 
 ## What you get
 
-**Full CommonMark**: 652/652 spec tests pass. No filtering, no exceptions.
+**CommonMark conformance**: The current default-policy report passes 577 of 652
+spec examples (88.5%). Raw HTML is escaped by default as part of Ferromark's
+browser-facing safety boundary, so this is not a claim of full raw-HTML
+CommonMark parity. Run `cargo test --test commonmark_spec -- --ignored
+--nocapture` for the complete, current report.
 
 **All five GFM extensions**: Tables, strikethrough, task lists, autolink literals, disallowed raw HTML.
 

--- a/benchmarks/pulldown-comparison/README.md
+++ b/benchmarks/pulldown-comparison/README.md
@@ -78,9 +78,10 @@ experiment may begin or when a performance claim needs an auditable baseline:
 scripts/run-publication-baseline.sh
 ```
 
-It refuses a dirty checkout, uses portable non-PGO code generation, and runs
-three repetitions of the required Criterion lanes with 80 samples, a five-second
-measurement window, and a three-second warmup. Each run retains its
+It refuses a dirty checkout, uses portable non-PGO code generation, alternates
+the parity parser order across its three repetitions, and runs every Criterion
+lane with 80 samples, a five-second measurement window, and a three-second
+warmup. Each run retains its
 `estimates.json` files plus an environment probe under the ignored
 `results/publication-<timestamp>/` directory.
 

--- a/benchmarks/pulldown-comparison/README.md
+++ b/benchmarks/pulldown-comparison/README.md
@@ -82,18 +82,20 @@ It refuses a dirty checkout, uses portable non-PGO code generation, alternates
 the parity parser order across its three repetitions, and runs every Criterion
 lane with 80 samples, a five-second measurement window, and a three-second
 warmup. Each run retains its
-`estimates.json` files plus an environment probe under the ignored
-`results/publication-<timestamp>/` directory.
+`estimates.json` files plus an environment probe under a unique ignored
+`results/publication-<random>/` directory. A process-wide lock prevents a
+second runner in the same harness checkout from sharing Criterion output.
 
 The run covers trusted CommonMark parity at 5, 20, 50, and 250 KB; secure-default
 Extended rendering at 5, 20, and 50 KB; and the Essentials, Extended, and Full
 profile-cost lanes at 50 KB. Trusted parity and secure-default results answer
 different questions and must never be merged into one comparative claim.
 
-Copy the exact result directory into durable CI or release storage before
-cleaning the worktree. Summarize only the three-run result in the performance
-report; do not update the README benchmark headline until the publication
-protocol has passed.
+Publish the exact result directory as durable CI or release storage before
+cleaning the worktree. Commit or link an audit-ready estimate artifact alongside
+any publication summary; an ignored local path alone is not evidence another
+checkout can inspect. Do not update the README benchmark headline until the
+publication protocol has passed.
 
 The CPU mode must be named explicitly:
 

--- a/benchmarks/pulldown-comparison/README.md
+++ b/benchmarks/pulldown-comparison/README.md
@@ -69,6 +69,31 @@ Run the bounded primary matrix:
 scripts/run-primary-matrix.sh 5 portable
 ```
 
+## Publication baseline
+
+Use the publication runner when a result will decide whether a production
+experiment may begin or when a performance claim needs an auditable baseline:
+
+```bash
+scripts/run-publication-baseline.sh
+```
+
+It refuses a dirty checkout, uses portable non-PGO code generation, and runs
+three repetitions of the required Criterion lanes with 80 samples, a five-second
+measurement window, and a three-second warmup. Each run retains its
+`estimates.json` files plus an environment probe under the ignored
+`results/publication-<timestamp>/` directory.
+
+The run covers trusted CommonMark parity at 5, 20, 50, and 250 KB; secure-default
+Extended rendering at 5, 20, and 50 KB; and the Essentials, Extended, and Full
+profile-cost lanes at 50 KB. Trusted parity and secure-default results answer
+different questions and must never be merged into one comparative claim.
+
+Copy the exact result directory into durable CI or release storage before
+cleaning the worktree. Summarize only the three-run result in the performance
+report; do not update the README benchmark headline until the publication
+protocol has passed.
+
 The CPU mode must be named explicitly:
 
 - `portable`: `target-cpu=generic`, used for portable source comparisons;

--- a/benchmarks/pulldown-comparison/benches/profiling.rs
+++ b/benchmarks/pulldown-comparison/benches/profiling.rs
@@ -3,6 +3,13 @@ use ferromark_pulldown_comparison::{
     Corpus, ParserKind, RunConfig, render_ferromark_config_into, render_pulldown_config_into,
 };
 
+fn parity_parsers() -> [ParserKind; 2] {
+    match std::env::var("FERROMARK_PARITY_ORDER").as_deref() {
+        Ok("pulldown-first") => [ParserKind::PulldownCmark, ParserKind::Ferromark],
+        _ => [ParserKind::Ferromark, ParserKind::PulldownCmark],
+    }
+}
+
 fn bench_lane(c: &mut Criterion, corpus: Corpus, configuration: RunConfig, parsers: &[ParserKind]) {
     let data = corpus.materialize();
     let input = data.input();
@@ -48,7 +55,7 @@ fn bench_lane(c: &mut Criterion, corpus: Corpus, configuration: RunConfig, parse
 }
 
 fn profiling_benches(c: &mut Criterion) {
-    let both = [ParserKind::Ferromark, ParserKind::PulldownCmark];
+    let both = parity_parsers();
     for corpus in [
         Corpus::CommonMark5K,
         Corpus::CommonMark20K,

--- a/benchmarks/pulldown-comparison/benches/profiling.rs
+++ b/benchmarks/pulldown-comparison/benches/profiling.rs
@@ -58,11 +58,9 @@ fn profiling_benches(c: &mut Criterion) {
         bench_lane(c, corpus, RunConfig::CommonMark, &both);
     }
 
-    for configuration in [
-        RunConfig::EssentialsSecure,
-        RunConfig::ExtendedSecure,
-        RunConfig::FullSecure,
-    ] {
+    // Extended is covered by the secure-default size matrix below. Keeping it
+    // out of this loop ensures one stable Criterion identifier per lane.
+    for configuration in [RunConfig::EssentialsSecure, RunConfig::FullSecure] {
         bench_lane(
             c,
             Corpus::CommonMark50K,

--- a/benchmarks/pulldown-comparison/benches/profiling.rs
+++ b/benchmarks/pulldown-comparison/benches/profiling.rs
@@ -72,6 +72,19 @@ fn profiling_benches(c: &mut Criterion) {
     }
 
     for corpus in [
+        Corpus::CommonMark5K,
+        Corpus::CommonMark20K,
+        Corpus::CommonMark50K,
+    ] {
+        bench_lane(
+            c,
+            corpus,
+            RunConfig::ExtendedSecure,
+            &[ParserKind::Ferromark],
+        );
+    }
+
+    for corpus in [
         Corpus::Simple,
         Corpus::Code,
         Corpus::SafeUrls,

--- a/benchmarks/pulldown-comparison/scripts/run-publication-baseline.sh
+++ b/benchmarks/pulldown-comparison/scripts/run-publication-baseline.sh
@@ -43,12 +43,27 @@ criterion_groups=(
   'profiling_commonmark-50k_full-secure'
 )
 
+criterion_functions=(
+  'ferromark pulldown-cmark'
+  'ferromark pulldown-cmark'
+  'ferromark pulldown-cmark'
+  'ferromark pulldown-cmark'
+  'ferromark'
+  'ferromark'
+  'ferromark'
+  'ferromark'
+  'ferromark'
+)
+
+orders=(ferromark-first pulldown-first ferromark-first)
+
 for repetition in $(seq 1 "$repetitions"); do
   run_dir="$results_dir/run-$repetition"
   mkdir -p "$run_dir/criterion"
 
   for target in "${targets[@]}"; do
-    FERROMARK_CPU_MODE=portable RUSTFLAGS='-C target-cpu=generic' \
+    FERROMARK_CPU_MODE=portable FERROMARK_PARITY_ORDER="${orders[$((repetition - 1))]}" \
+      RUSTFLAGS='-C target-cpu=generic' \
       cargo bench --locked --bench profiling -- \
       "$target" --sample-size 80 --measurement-time 5 --warm-up-time 3 --noplot
   done
@@ -61,13 +76,22 @@ for repetition in $(seq 1 "$repetitions"); do
     --iterations 1 \
     --json "$run_dir/environment-probe.json" >/dev/null
 
-  for criterion_group in "${criterion_groups[@]}"; do
+  for index in "${!criterion_groups[@]}"; do
+    criterion_group=${criterion_groups[$index]}
     target_path="$crate_dir/target/criterion/$criterion_group"
     if [[ ! -d "$target_path" ]]; then
       echo "Criterion result missing for $criterion_group" >&2
       exit 1
     fi
-    cp -R "$target_path" "$run_dir/criterion/$criterion_group"
+    for criterion_function in ${criterion_functions[$index]}; do
+      result_path="$target_path/$criterion_function"
+      if [[ ! -d "$result_path" ]]; then
+        echo "Criterion result missing for $criterion_group/$criterion_function" >&2
+        exit 1
+      fi
+      mkdir -p "$run_dir/criterion/$criterion_group"
+      cp -R "$result_path" "$run_dir/criterion/$criterion_group/$criterion_function"
+    done
   done
 done
 

--- a/benchmarks/pulldown-comparison/scripts/run-publication-baseline.sh
+++ b/benchmarks/pulldown-comparison/scripts/run-publication-baseline.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repetitions="${1:-3}"
+if [[ "$repetitions" != "3" ]]; then
+  echo "publication baseline requires exactly three repetitions" >&2
+  exit 1
+fi
+
+script_dir=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+crate_dir=$(cd -- "$script_dir/.." && pwd)
+results_dir="$crate_dir/results/publication-$(date -u +%Y%m%dT%H%M%SZ)"
+
+if [[ -n "$(git -C "$crate_dir/../.." status --porcelain)" ]]; then
+  echo "publication baseline requires a clean checkout" >&2
+  exit 1
+fi
+
+mkdir -p "$results_dir"
+cd "$crate_dir"
+
+targets=(
+  '^profiling/commonmark-5k/commonmark/'
+  '^profiling/commonmark-20k/commonmark/'
+  '^profiling/commonmark-50k/commonmark/'
+  '^profiling/mixed-250k/commonmark/'
+  '^profiling/commonmark-5k/extended-secure/ferromark$'
+  '^profiling/commonmark-20k/extended-secure/ferromark$'
+  '^profiling/commonmark-50k/extended-secure/ferromark$'
+  '^profiling/commonmark-50k/essentials-secure/ferromark$'
+  '^profiling/commonmark-50k/full-secure/ferromark$'
+)
+
+criterion_groups=(
+  'profiling_commonmark-5k_commonmark'
+  'profiling_commonmark-20k_commonmark'
+  'profiling_commonmark-50k_commonmark'
+  'profiling_mixed-250k_commonmark'
+  'profiling_commonmark-5k_extended-secure'
+  'profiling_commonmark-20k_extended-secure'
+  'profiling_commonmark-50k_extended-secure'
+  'profiling_commonmark-50k_essentials-secure'
+  'profiling_commonmark-50k_full-secure'
+)
+
+for repetition in $(seq 1 "$repetitions"); do
+  run_dir="$results_dir/run-$repetition"
+  mkdir -p "$run_dir/criterion"
+
+  for target in "${targets[@]}"; do
+    FERROMARK_CPU_MODE=portable RUSTFLAGS='-C target-cpu=generic' \
+      cargo bench --locked --bench profiling -- \
+      "$target" --sample-size 80 --measurement-time 5 --warm-up-time 3 --noplot
+  done
+
+  FERROMARK_CPU_MODE=portable RUSTFLAGS='-C target-cpu=generic' \
+    cargo run --locked --release --bin profile_driver -- \
+    --parser ferromark \
+    --config extended-secure \
+    --corpus commonmark-50k \
+    --iterations 1 \
+    --json "$run_dir/environment-probe.json" >/dev/null
+
+  for criterion_group in "${criterion_groups[@]}"; do
+    target_path="$crate_dir/target/criterion/$criterion_group"
+    if [[ ! -d "$target_path" ]]; then
+      echo "Criterion result missing for $criterion_group" >&2
+      exit 1
+    fi
+    cp -R "$target_path" "$run_dir/criterion/$criterion_group"
+  done
+done
+
+echo "Publication baseline artifacts: $results_dir"

--- a/benchmarks/pulldown-comparison/scripts/run-publication-baseline.sh
+++ b/benchmarks/pulldown-comparison/scripts/run-publication-baseline.sh
@@ -9,14 +9,21 @@ fi
 
 script_dir=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
 crate_dir=$(cd -- "$script_dir/.." && pwd)
-results_dir="$crate_dir/results/publication-$(date -u +%Y%m%dT%H%M%SZ)"
+lock_dir="$crate_dir/.publication-baseline.lock"
 
 if [[ -n "$(git -C "$crate_dir/../.." status --porcelain)" ]]; then
   echo "publication baseline requires a clean checkout" >&2
   exit 1
 fi
 
-mkdir -p "$results_dir"
+mkdir -p "$crate_dir/results"
+if ! mkdir "$lock_dir" 2>/dev/null; then
+  echo "another publication baseline is already running" >&2
+  exit 1
+fi
+trap 'rmdir "$lock_dir"' EXIT
+
+results_dir=$(mktemp -d "$crate_dir/results/publication-XXXXXXXX")
 cd "$crate_dir"
 
 targets=(

--- a/docs/plans/2026-07-11-comprehensive-performance-profile-report.md
+++ b/docs/plans/2026-07-11-comprehensive-performance-profile-report.md
@@ -35,7 +35,9 @@ Silicon Mac Studio (`ARM64_T6000`) with macOS 26.5.2, pinned `rustc 1.93.0`
 used three repetitions, 80 Criterion samples, a five-second measurement window,
 and a three-second warmup. It ran Ferromark first in repetitions one and three
 and pulldown-cmark first in repetition two. The checked-in machine-readable
-summary is [`2026-07-11-issue-63-publication-baseline.json`](../reports/2026-07-11-issue-63-publication-baseline.json).
+summary is [`2026-07-11-issue-63-publication-baseline.json`](../reports/2026-07-11-issue-63-publication-baseline.json), with its
+per-run median confidence intervals in
+[`2026-07-11-issue-63-publication-baseline-criterion-estimates.json`](../reports/2026-07-11-issue-63-publication-baseline-criterion-estimates.json).
 
 Trusted CommonMark parity remains a deliberately separate comparison lane. It
 uses trusted raw HTML in Ferromark because pulldown-cmark does not expose the

--- a/docs/plans/2026-07-11-comprehensive-performance-profile-report.md
+++ b/docs/plans/2026-07-11-comprehensive-performance-profile-report.md
@@ -1,6 +1,6 @@
 # Comprehensive performance profile report
 
-Status: first evidence pass complete
+Status: Issue #63 portable baseline accepted; first evidence pass retained
 Date: 2026-07-11
 Design: [`2026-07-11-comprehensive-performance-profiling-design.md`](./2026-07-11-comprehensive-performance-profiling-design.md)
 
@@ -26,6 +26,45 @@ find strong signals. Treat every throughput delta as directional until the same
 lane passes three alternating-order Criterion runs with the documented sample
 and measurement settings. The working tree was dirty with the profiling
 implementation, so these results are development evidence only.
+
+## Issue #63 publication baseline
+
+The publication baseline was collected from clean commit `9102db4` on an Apple
+Silicon Mac Studio (`ARM64_T6000`) with macOS 26.5.2, pinned `rustc 1.93.0`
+(LLVM 21.1.8), `-C target-cpu=generic`, and non-PGO release builds. The runner
+used three repetitions, 80 Criterion samples, a five-second measurement window,
+and a three-second warmup. It ran Ferromark first in repetitions one and three
+and pulldown-cmark first in repetition two. The checked-in machine-readable
+summary is [`2026-07-11-issue-63-publication-baseline.json`](../reports/2026-07-11-issue-63-publication-baseline.json).
+
+Trusted CommonMark parity remains a deliberately separate comparison lane. It
+uses trusted raw HTML in Ferromark because pulldown-cmark does not expose the
+same untrusted-rendering boundary. Secure-default measurements are product-lane
+numbers, not direct pulldown-cmark comparisons.
+
+| Trusted CommonMark corpus | Ferromark MiB/s (three medians) | pulldown-cmark MiB/s (three medians) | Ferromark lead |
+| --- | ---: | ---: | ---: |
+| 5 KB | 272.02 / 271.67 / 271.59 | 268.37 / 268.01 / 267.31 | 1.36% / 1.37% / 1.60% |
+| 20 KB | 276.20 / 277.16 / 276.80 | 265.70 / 264.05 / 264.97 | 3.95% / 4.97% / 4.46% |
+| 50 KB | 290.41 / 289.96 / 289.36 | 277.35 / 276.84 / 276.83 | 4.71% / 4.74% / 4.53% |
+| 250 KB | 292.86 / 293.41 / 293.49 | 275.13 / 273.85 / 276.59 | 6.44% / 7.14% / 6.11% |
+
+The ordering is stable in all twelve parity comparisons. The 20 KB lead spans
+1.01 percentage points, effectively the one-point screening boundary, so it is
+evidence of a stable ordering rather than a precise marketing claim. The
+publication protocol therefore unblocks source experiments but does not change
+the README benchmark headline.
+
+The secure-default Extended lane recorded 219.40 / 218.84 / 218.63 MiB/s at
+5 KB, 234.86 / 235.19 / 234.72 MiB/s at 20 KB, and 220.85 / 225.41 / 224.98
+MiB/s at 50 KB. At 50 KB, the Essentials, Extended, and Full profile medians
+were 283.71–284.03, 220.85–225.41, and 211.51–212.03 MiB/s respectively. These
+are controls for later experiments, not cross-parser claims.
+
+The complete CommonMark report run as part of this gate currently reports 577
+passing examples and 75 failures out of 652 under the default safety policy.
+That result corrects the former README claim; it does not turn this performance
+baseline into a claim of full CommonMark or raw-HTML parity.
 
 ## Primary parity smoke
 

--- a/docs/plans/2026-07-11-issue-63-publication-baseline-plan.md
+++ b/docs/plans/2026-07-11-issue-63-publication-baseline-plan.md
@@ -1,0 +1,32 @@
+# Issue #63 implementation plan: publication baseline
+
+## Goal
+
+Turn the existing diagnostic harness into a reproducible publication-baseline
+runner. It measures the current portable, non-PGO `main` implementation; it
+does not change parser or renderer behavior.
+
+## Steps
+
+1. Extend the Criterion profiling matrix with secure-default Extended runs at
+   5, 20, and 50 KB while retaining trusted CommonMark parity at 5, 20, 50,
+   and 250 KB and profile-cost runs at 50 KB.
+2. Add a runner that refuses a dirty checkout, executes three Criterion
+   repetitions with 80 samples, a five-second measurement window, and a
+   three-second warmup, then copies each run's machine-readable estimates to
+   the ignored result directory.
+3. Record one JSON environment probe beside every Criterion result set so the
+   commit, compiler, target, Rust flags, CPU mode, and machine can be audited.
+4. Document the command, lane semantics, artifacts, and publication boundary.
+5. Run the harness on the clean committed baseline, summarize the three
+   repetitions in the performance report, and apply the full Rust validation
+   gates before opening the Issue #63 PR.
+
+## Acceptance checks
+
+- The runner covers every Issue #63 lane and leaves three timestamped result
+  directories with Criterion `estimates.json` files and an environment probe.
+- The report states the exact lane, toolchain, and result quality; it does not
+  promote numbers to the README before the publication protocol is complete.
+- The harness passes formatting, locked tests, strict Clippy, and the
+  repository's CommonMark/security guardrails.

--- a/docs/plans/2026-07-11-pulldown-gap-performance-plan.md
+++ b/docs/plans/2026-07-11-pulldown-gap-performance-plan.md
@@ -421,7 +421,8 @@ scorecard:
 - secure default 50 KB: **at least 4% ahead** over three publication runs;
 - trusted-semantics 50 KB: **at least 6% ahead** over three publication runs;
 - no primary fixture regression above 1%;
-- 652/652 CommonMark examples and the full test suite remain green;
+- the complete CommonMark report and full test suite run for every kept change,
+  with no supported conformance regression;
 - every kept/rejected experiment has reproducible evidence.
 
 Reaching 4% on the secure 50 KB lane appears realistic from the combined

--- a/docs/reports/2026-07-11-issue-63-publication-baseline-criterion-estimates.json
+++ b/docs/reports/2026-07-11-issue-63-publication-baseline-criterion-estimates.json
@@ -1,0 +1,52 @@
+{
+  "schema_version": 1,
+  "source_commit": "9102db4bf642a9aa8a53fcd1bb45b6f8a99a5c84",
+  "toolchain": "rustc 1.93.0, LLVM 21.1.8, target-cpu=generic",
+  "runs": [
+    {"run": 1, "estimates": [
+      {"lane":"trusted-commonmark-5k","parser":"ferromark","input_bytes":5632,"median_ns":19745,"confidence_interval_ns":[19692,19805]},
+      {"lane":"trusted-commonmark-5k","parser":"pulldown-cmark","input_bytes":5632,"median_ns":20014,"confidence_interval_ns":[19963,20064]},
+      {"lane":"trusted-commonmark-20k","parser":"ferromark","input_bytes":20484,"median_ns":70727,"confidence_interval_ns":[70581,70906]},
+      {"lane":"trusted-commonmark-20k","parser":"pulldown-cmark","input_bytes":20484,"median_ns":73522,"confidence_interval_ns":[73412,73761]},
+      {"lane":"trusted-commonmark-50k","parser":"ferromark","input_bytes":52342,"median_ns":171886,"confidence_interval_ns":[171513,172133]},
+      {"lane":"trusted-commonmark-50k","parser":"pulldown-cmark","input_bytes":52342,"median_ns":179982,"confidence_interval_ns":[179749,180293]},
+      {"lane":"trusted-commonmark-250k","parser":"ferromark","input_bytes":261710,"median_ns":852236,"confidence_interval_ns":[850207,853822]},
+      {"lane":"trusted-commonmark-250k","parser":"pulldown-cmark","input_bytes":261710,"median_ns":907148,"confidence_interval_ns":[905598,908591]},
+      {"lane":"secure-extended-5k","parser":"ferromark","input_bytes":5632,"median_ns":24481,"confidence_interval_ns":[24436,24578]},
+      {"lane":"secure-extended-20k","parser":"ferromark","input_bytes":20484,"median_ns":83176,"confidence_interval_ns":[83042,83388]},
+      {"lane":"secure-extended-50k","parser":"ferromark","input_bytes":52342,"median_ns":226021,"confidence_interval_ns":[224068,227485]},
+      {"lane":"secure-essentials-50k","parser":"ferromark","input_bytes":52342,"median_ns":175943,"confidence_interval_ns":[175398,176462]},
+      {"lane":"secure-full-50k","parser":"ferromark","input_bytes":52342,"median_ns":235430,"confidence_interval_ns":[234978,235902]}
+    ]},
+    {"run": 2, "estimates": [
+      {"lane":"trusted-commonmark-5k","parser":"ferromark","input_bytes":5632,"median_ns":19770,"confidence_interval_ns":[19706,19823]},
+      {"lane":"trusted-commonmark-5k","parser":"pulldown-cmark","input_bytes":5632,"median_ns":20041,"confidence_interval_ns":[19991,20108]},
+      {"lane":"trusted-commonmark-20k","parser":"ferromark","input_bytes":20484,"median_ns":70484,"confidence_interval_ns":[70370,70563]},
+      {"lane":"trusted-commonmark-20k","parser":"pulldown-cmark","input_bytes":20484,"median_ns":73984,"confidence_interval_ns":[73770,74113]},
+      {"lane":"trusted-commonmark-50k","parser":"ferromark","input_bytes":52342,"median_ns":172149,"confidence_interval_ns":[171888,172737]},
+      {"lane":"trusted-commonmark-50k","parser":"pulldown-cmark","input_bytes":52342,"median_ns":180311,"confidence_interval_ns":[179619,180642]},
+      {"lane":"trusted-commonmark-250k","parser":"ferromark","input_bytes":261710,"median_ns":850651,"confidence_interval_ns":[848512,852037]},
+      {"lane":"trusted-commonmark-250k","parser":"pulldown-cmark","input_bytes":261710,"median_ns":911397,"confidence_interval_ns":[908763,914344]},
+      {"lane":"secure-extended-5k","parser":"ferromark","input_bytes":5632,"median_ns":24543,"confidence_interval_ns":[24456,24591]},
+      {"lane":"secure-extended-20k","parser":"ferromark","input_bytes":20484,"median_ns":83059,"confidence_interval_ns":[82773,83215]},
+      {"lane":"secure-extended-50k","parser":"ferromark","input_bytes":52342,"median_ns":221446,"confidence_interval_ns":[220806,222092]},
+      {"lane":"secure-essentials-50k","parser":"ferromark","input_bytes":52342,"median_ns":175751,"confidence_interval_ns":[175443,176094]},
+      {"lane":"secure-full-50k","parser":"ferromark","input_bytes":52342,"median_ns":236001,"confidence_interval_ns":[235716,236354]}
+    ]},
+    {"run": 3, "estimates": [
+      {"lane":"trusted-commonmark-5k","parser":"ferromark","input_bytes":5632,"median_ns":19777,"confidence_interval_ns":[19712,19811]},
+      {"lane":"trusted-commonmark-5k","parser":"pulldown-cmark","input_bytes":5632,"median_ns":20093,"confidence_interval_ns":[20064,20110]},
+      {"lane":"trusted-commonmark-20k","parser":"ferromark","input_bytes":20484,"median_ns":70574,"confidence_interval_ns":[70433,70781]},
+      {"lane":"trusted-commonmark-20k","parser":"pulldown-cmark","input_bytes":20484,"median_ns":73725,"confidence_interval_ns":[73613,73799]},
+      {"lane":"trusted-commonmark-50k","parser":"ferromark","input_bytes":52342,"median_ns":172510,"confidence_interval_ns":[172127,172994]},
+      {"lane":"trusted-commonmark-50k","parser":"pulldown-cmark","input_bytes":52342,"median_ns":180318,"confidence_interval_ns":[180021,180785]},
+      {"lane":"trusted-commonmark-250k","parser":"ferromark","input_bytes":261710,"median_ns":850403,"confidence_interval_ns":[848944,853301]},
+      {"lane":"trusted-commonmark-250k","parser":"pulldown-cmark","input_bytes":261710,"median_ns":902356,"confidence_interval_ns":[900228,903297]},
+      {"lane":"secure-extended-5k","parser":"ferromark","input_bytes":5632,"median_ns":24567,"confidence_interval_ns":[24511,24618]},
+      {"lane":"secure-extended-20k","parser":"ferromark","input_bytes":20484,"median_ns":83227,"confidence_interval_ns":[83097,83398]},
+      {"lane":"secure-extended-50k","parser":"ferromark","input_bytes":52342,"median_ns":221875,"confidence_interval_ns":[221511,222083]},
+      {"lane":"secure-essentials-50k","parser":"ferromark","input_bytes":52342,"median_ns":175746,"confidence_interval_ns":[175528,176163]},
+      {"lane":"secure-full-50k","parser":"ferromark","input_bytes":52342,"median_ns":235447,"confidence_interval_ns":[234950,235746]}
+    ]}
+  ]
+}

--- a/docs/reports/2026-07-11-issue-63-publication-baseline.json
+++ b/docs/reports/2026-07-11-issue-63-publication-baseline.json
@@ -1,0 +1,64 @@
+{
+  "schema_version": 1,
+  "issue": 63,
+  "purpose": "Portable non-PGO performance baseline for evidence-gated experiments.",
+  "commit": "9102db4bf642a9aa8a53fcd1bb45b6f8a99a5c84",
+  "environment": {
+    "machine": "Apple Silicon Mac Studio (ARM64_T6000)",
+    "operating_system": "macOS 26.5.2",
+    "rustc": "1.93.0 (LLVM 21.1.8)",
+    "rustflags": "-C target-cpu=generic",
+    "cpu_mode": "portable",
+    "pgo": false
+  },
+  "protocol": {
+    "repetitions": 3,
+    "sample_size": 80,
+    "measurement_seconds": 5,
+    "warmup_seconds": 3,
+    "parity_order": ["ferromark-first", "pulldown-first", "ferromark-first"],
+    "raw_artifacts": "benchmarks/pulldown-comparison/results/publication-20260711T141443Z"
+  },
+  "trusted_commonmark_parity": [
+    {
+      "corpus": "commonmark-5k",
+      "ferromark_mib_per_sec": [272.02, 271.67, 271.59],
+      "pulldown_cmark_mib_per_sec": [268.37, 268.01, 267.31],
+      "ferromark_lead_percent": [1.36, 1.37, 1.6]
+    },
+    {
+      "corpus": "commonmark-20k",
+      "ferromark_mib_per_sec": [276.2, 277.16, 276.8],
+      "pulldown_cmark_mib_per_sec": [265.7, 264.05, 264.97],
+      "ferromark_lead_percent": [3.95, 4.97, 4.46]
+    },
+    {
+      "corpus": "commonmark-50k",
+      "ferromark_mib_per_sec": [290.41, 289.96, 289.36],
+      "pulldown_cmark_mib_per_sec": [277.35, 276.84, 276.83],
+      "ferromark_lead_percent": [4.71, 4.74, 4.53]
+    },
+    {
+      "corpus": "mixed-250k",
+      "ferromark_mib_per_sec": [292.86, 293.41, 293.49],
+      "pulldown_cmark_mib_per_sec": [275.13, 273.85, 276.59],
+      "ferromark_lead_percent": [6.44, 7.14, 6.11]
+    }
+  ],
+  "secure_default_extended_mib_per_sec": {
+    "commonmark-5k": [219.4, 218.84, 218.63],
+    "commonmark-20k": [234.86, 235.19, 234.72],
+    "commonmark-50k": [220.85, 225.41, 224.98]
+  },
+  "secure_profile_50k_mib_per_sec": {
+    "essentials": [283.71, 284.02, 284.03],
+    "extended": [220.85, 225.41, 224.98],
+    "full": [212.03, 211.51, 212.01]
+  },
+  "commonmark_default_policy_report": {
+    "passed": 577,
+    "failed": 75,
+    "total": 652,
+    "pass_rate_percent": 88.5
+  }
+}

--- a/docs/reports/2026-07-11-issue-63-publication-baseline.json
+++ b/docs/reports/2026-07-11-issue-63-publication-baseline.json
@@ -17,7 +17,7 @@
     "measurement_seconds": 5,
     "warmup_seconds": 3,
     "parity_order": ["ferromark-first", "pulldown-first", "ferromark-first"],
-    "raw_artifacts": "benchmarks/pulldown-comparison/results/publication-20260711T141443Z"
+    "criterion_estimates": "docs/reports/2026-07-11-issue-63-publication-baseline-criterion-estimates.json"
   },
   "trusted_commonmark_parity": [
     {

--- a/docs/superpowers/specs/2026-07-11-epic-71-performance-design.md
+++ b/docs/superpowers/specs/2026-07-11-epic-71-performance-design.md
@@ -1,0 +1,82 @@
+# Epic #71: Evidence-gated performance campaign
+
+## Decision
+
+Run the campaign as a sequence of isolated, evidence-gated experiments. The
+baseline package (#63) is the prerequisite for every later package. At most one
+experiment is active at a time. An accepted result merges before the next
+experiment starts; a rejected result remains as a closed, unmerged draft pull
+request with its exact measurements recorded in the issue.
+
+This is the selected approach because it preserves comparable measurements and
+makes negative results useful. A single long-lived optimization branch would
+mix variables and invalidate rebaselining. A documentation-only campaign would
+not test the production hypotheses.
+
+## Boundaries
+
+The public rendering contract remains intact throughout the campaign:
+
+- secure-default rendering stays the product lane;
+- closest-semantics parity results are separate and explicitly named;
+- the semantic event and future transform/plugin path remains available;
+- portable source wins are reported separately from PGO and CPU-specific
+  builds;
+- no benchmark claim changes until the publication baseline passes its protocol.
+
+## Execution flow
+
+1. #63 defines the pinned toolchain, machine metadata, fixtures, result
+   artifacts, repetitions, and publication protocol.
+2. #62, #65, and #67 run from that untouched baseline in dependency-safe order.
+3. #64, #66, and #68 run after their stated prerequisites and updated profiles.
+4. #69 may introduce only an internal optional sink that shares resolved
+   semantics with the event path.
+5. #70 evaluates PGO and target-specific lanes only after accepted portable
+   source work is stable.
+6. The epic closes only with a final scorecard listing secure-default,
+   parity, profile, allocation, copied-byte, event-volume, PGO, and
+   accepted/rejected results.
+
+## Measurement and decision protocol
+
+Each package uses an untouched current-`main` baseline worktree and an isolated
+candidate worktree. Screening uses at least 80 Criterion samples, a five-second
+measurement window, and a three-second warmup. Promising candidates run three
+times, with baseline and candidate order alternated when practical. Results
+under one percent are noise unless repeated medians and confidence intervals
+agree. No primary guardrail may regress by more than one percent reproducibly.
+
+Every issue records the baseline commit, `rustc -Vv`, CPU mode, machine and
+power state, command lines, result artifacts, and final decision. The Epic #71
+dashboard is updated when a package starts, produces a draft PR, or reaches its
+final disposition.
+
+## Correctness, safety, and Rust design constraints
+
+Production changes use borrowing rather than needless cloning, keep hot paths
+statically dispatched where concrete types are known, and express failures with
+explicit `Result`/`Option` handling. No production `unwrap`, undocumented
+`unsafe`, or HTML-only shortcut may bypass the semantic boundary. Public Rust
+APIs get rustdoc that states behavior, errors, and executable examples where
+useful.
+
+Each kept parser or renderer change runs format, locked all-feature tests,
+strict Clippy, the complete CommonMark report, and representative raw-HTML,
+unsafe-URL, table, reference-link, nested-emphasis, and fenced-code checks.
+Security-sensitive changes also receive focused differential or property tests.
+
+## Documentation
+
+Benchmark documentation leads with the reader-relevant claim, states the exact
+lane and semantic boundary, and separates confirmed measurements from
+directional evidence. It names the command and environment needed to reproduce
+the result, avoids unverified comparative language, and explains a rejection as
+a useful result rather than hiding it.
+
+## Completion criteria
+
+All nine work packages have a final accepted, rejected, or explicitly blocked
+disposition; no package is silently skipped. The Epic #71 table and individual
+issues contain accurate links and measurements, the final scorecard is present,
+and all accepted code has passed the required validation and review/CI gates.


### PR DESCRIPTION
Closes #63

## Summary

- adds a publication-baseline runner for the isolated Ferromark/pulldown-cmark harness;
- records three portable, non-PGO Criterion repetitions with 80 samples, five-second measurement windows, three-second warmups, alternating parity order, and isolated result copies;
- commits a machine-readable baseline summary and documents the trusted-parity versus secure-default boundary;
- corrects the README CommonMark conformance claim to the verified current report (577/652 under the default safety policy).

No parser or renderer behavior changes in this PR.

## Baseline result

Trusted CommonMark parity preserved Ferromark's lead in every repetition: 1.36–1.60% at 5 KB, 3.95–4.97% at 20 KB, 4.53–4.74% at 50 KB, and 6.11–7.14% at 250 KB. The full raw Criterion result directories remain in the benchmark result path; the compact, reviewable summary is committed under `docs/reports/`.

## Validation

- `cargo fmt --all -- --check`
- `cargo test --manifest-path benchmarks/pulldown-comparison/Cargo.toml --locked`
- `cargo test --all-targets --all-features --locked`
- `cargo test --test commonmark_spec -- --ignored --nocapture`
- `cargo clippy --all-targets --all-features --locked -- -D warnings`
- `bash -n benchmarks/pulldown-comparison/scripts/run-publication-baseline.sh`
- three full `benchmarks/pulldown-comparison/scripts/run-publication-baseline.sh` repetitions
