### PR TITLE
perf: avoid heading ID state when disabled

### DIFF
--- a/benchmarks/pulldown-comparison/benches/profiling.rs
+++ b/benchmarks/pulldown-comparison/benches/profiling.rs
@@ -108,6 +108,15 @@ fn profiling_benches(c: &mut Criterion) {
             &[ParserKind::Ferromark],
         );
     }
+
+    for corpus in [Corpus::UniqueHeadings, Corpus::RepeatedHeadings] {
+        for configuration in [
+            RunConfig::ExtendedSecure,
+            RunConfig::ExtendedSecureNoHeadingIds,
+        ] {
+            bench_lane(c, corpus, configuration, &[ParserKind::Ferromark]);
+        }
+    }
 }
 
 criterion_group!(benches, profiling_benches);

--- a/benchmarks/pulldown-comparison/benches/profiling.rs
+++ b/benchmarks/pulldown-comparison/benches/profiling.rs
@@ -117,6 +117,13 @@ fn profiling_benches(c: &mut Criterion) {
             bench_lane(c, corpus, configuration, &[ParserKind::Ferromark]);
         }
     }
+
+    bench_lane(
+        c,
+        Corpus::Simple,
+        RunConfig::ExtendedSecureNoHeadingIds,
+        &[ParserKind::Ferromark],
+    );
 }
 
 criterion_group!(benches, profiling_benches);

--- a/benchmarks/pulldown-comparison/src/corpus.rs
+++ b/benchmarks/pulldown-comparison/src/corpus.rs
@@ -22,6 +22,10 @@ pub enum Corpus {
     Code,
     /// Safe absolute and relative links.
     SafeUrls,
+    /// Many headings whose generated IDs all have distinct base slugs.
+    UniqueHeadings,
+    /// Many headings that intentionally collide on one generated base slug.
+    RepeatedHeadings,
     /// Unsafe and obfuscated URL schemes.
     UnsafeUrls,
     /// Reference definitions and reference links.
@@ -42,7 +46,7 @@ pub enum Corpus {
 
 impl Corpus {
     /// All corpus selectors accepted by the diagnostic runner.
-    pub const ALL: [Self; 14] = [
+    pub const ALL: [Self; 16] = [
         Self::CommonMark5K,
         Self::CommonMark20K,
         Self::CommonMark50K,
@@ -50,6 +54,8 @@ impl Corpus {
         Self::Simple,
         Self::Code,
         Self::SafeUrls,
+        Self::UniqueHeadings,
+        Self::RepeatedHeadings,
         Self::UnsafeUrls,
         Self::References,
         Self::Tables,
@@ -69,6 +75,8 @@ impl Corpus {
             Self::Simple => "simple",
             Self::Code => "code",
             Self::SafeUrls => "safe-urls",
+            Self::UniqueHeadings => "unique-headings",
+            Self::RepeatedHeadings => "repeated-headings",
             Self::UnsafeUrls => "unsafe-urls",
             Self::References => "references",
             Self::Tables => "tables",
@@ -97,6 +105,11 @@ impl Corpus {
             )),
             Self::SafeUrls => Cow::Owned(repeat_to_at_least(
                 "[absolute](https://example.com/a%20path?q=one&v=two) [relative](/docs/start) <mailto:team@example.com>\n\n",
+                20_000,
+            )),
+            Self::UniqueHeadings => Cow::Owned(unique_headings_corpus()),
+            Self::RepeatedHeadings => Cow::Owned(repeat_to_at_least(
+                "# Shared heading title with inline `code`\n\nParagraph content keeps ordinary block rendering present.\n\n",
                 20_000,
             )),
             Self::UnsafeUrls => Cow::Owned(repeat_to_at_least(
@@ -193,6 +206,16 @@ fn reference_corpus() -> String {
     output
 }
 
+fn unique_headings_corpus() -> String {
+    let mut output = String::with_capacity(24_000);
+    for index in 0..512 {
+        output.push_str("# Unique heading ");
+        output.push_str(&index.to_string());
+        output.push_str(" with inline `code`\n\nParagraph content keeps ordinary block rendering present.\n\n");
+    }
+    output
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -210,5 +233,15 @@ mod tests {
                 .chain([Corpus::Extended])
                 .all(|corpus| !corpus.materialize().input().is_empty())
         );
+    }
+
+    #[test]
+    fn heading_corpora_should_exercise_their_collision_modes() {
+        let unique = Corpus::UniqueHeadings.materialize();
+        let repeated = Corpus::RepeatedHeadings.materialize();
+
+        assert!(unique.input().contains("Unique heading 0"));
+        assert!(unique.input().contains("Unique heading 511"));
+        assert!(repeated.input().matches("# Shared heading title").count() > 100);
     }
 }

--- a/benchmarks/pulldown-comparison/src/model.rs
+++ b/benchmarks/pulldown-comparison/src/model.rs
@@ -56,6 +56,8 @@ pub enum RunConfig {
     EssentialsTrusted,
     /// Secure Ferromark Extended profile.
     ExtendedSecure,
+    /// Secure Extended profile with heading IDs explicitly disabled.
+    ExtendedSecureNoHeadingIds,
     /// Trusted Ferromark Extended profile.
     ExtendedTrusted,
     /// Secure Ferromark Full profile.
@@ -66,13 +68,14 @@ pub enum RunConfig {
 
 impl RunConfig {
     /// All configurations accepted by the diagnostic runner.
-    pub const ALL: [Self; 9] = [
+    pub const ALL: [Self; 10] = [
         Self::CommonMark,
         Self::GfmOverlap,
         Self::ExtendedOverlap,
         Self::EssentialsSecure,
         Self::EssentialsTrusted,
         Self::ExtendedSecure,
+        Self::ExtendedSecureNoHeadingIds,
         Self::ExtendedTrusted,
         Self::FullSecure,
         Self::FullTrusted,
@@ -87,6 +90,7 @@ impl RunConfig {
             Self::EssentialsSecure => "essentials-secure",
             Self::EssentialsTrusted => "essentials-trusted",
             Self::ExtendedSecure => "extended-secure",
+            Self::ExtendedSecureNoHeadingIds => "extended-secure-no-heading-ids",
             Self::ExtendedTrusted => "extended-trusted",
             Self::FullSecure => "full-secure",
             Self::FullTrusted => "full-trusted",
@@ -97,7 +101,10 @@ impl RunConfig {
     pub const fn is_secure(self) -> bool {
         matches!(
             self,
-            Self::EssentialsSecure | Self::ExtendedSecure | Self::FullSecure
+            Self::EssentialsSecure
+                | Self::ExtendedSecure
+                | Self::ExtendedSecureNoHeadingIds
+                | Self::FullSecure
         )
     }
 
@@ -121,6 +128,10 @@ impl RunConfig {
             Self::EssentialsSecure => Options::from(Profile::Essentials),
             Self::EssentialsTrusted => trusted(Profile::Essentials),
             Self::ExtendedSecure => Options::from(Profile::Extended),
+            Self::ExtendedSecureNoHeadingIds => Options {
+                heading_ids: false,
+                ..Options::from(Profile::Extended)
+            },
             Self::ExtendedTrusted => trusted(Profile::Extended),
             Self::FullSecure => Options::from(Profile::Full),
             Self::FullTrusted => trusted(Profile::Full),
@@ -189,6 +200,22 @@ mod tests {
                 .ferromark_options()
                 .render_policy,
             RenderPolicy::Trusted
+        );
+    }
+
+    #[test]
+    fn heading_id_control_should_change_only_heading_ids() {
+        let enabled = RunConfig::ExtendedSecure.ferromark_options();
+        let disabled = RunConfig::ExtendedSecureNoHeadingIds.ferromark_options();
+
+        assert!(enabled.heading_ids);
+        assert!(!disabled.heading_ids);
+        assert_eq!(
+            Options {
+                heading_ids: false,
+                ..enabled
+            },
+            disabled
         );
     }
 }

--- a/docs/plans/2026-07-11-comprehensive-performance-profile-report.md
+++ b/docs/plans/2026-07-11-comprehensive-performance-profile-report.md
@@ -154,6 +154,23 @@ Heading ID generation is the most surprising newly visible feature cost. Its
 profile includes hash-map insertion and rehashing. It needs a focused heading
 corpus before changing its state model.
 
+## Issue #65: disabled heading-ID state
+
+The focused experiment retained one small change: create the heading-ID tracker
+only when `Options::heading_ids` is enabled. It does not alter ID generation,
+deduplication, or output when IDs are enabled.
+
+On a clean `7da2f80` harness baseline, three alternating 80-sample Criterion
+comparisons (five-second measurement, three-second warmup) improved the
+repeated-heading lane with IDs disabled by 1.119%, 1.468%, and 1.255%. The
+allocation control fell from 42 allocations / 30,712 bytes to 40 allocations /
+28,528 bytes per render. Active-ID lanes remained within noise, and the
+ordinary-prose disabled-ID control varied by at most 0.356%, so the result does
+not support a broader heading-rendering speed claim.
+
+The complete measurements and environment are recorded in
+[`2026-07-11-issue-65-heading-id-state.json`](../reports/2026-07-11-issue-65-heading-id-state.json).
+
 ### Delimiter-heavy lane
 
 The dominant buckets were mark collection (1,162), the inline parser (1,038),

--- a/docs/reports/2026-07-11-issue-65-heading-id-state.json
+++ b/docs/reports/2026-07-11-issue-65-heading-id-state.json
@@ -1,0 +1,67 @@
+{
+  "schema_version": 1,
+  "issue": 65,
+  "purpose": "Measure the cost of constructing heading-ID state when heading IDs are disabled.",
+  "baseline_commit": "7da2f8006ae428784bd36faf153c1e5529efc5e8",
+  "candidate_commit": "dc7edc19daec1476f9a83a7f680cbaa3b2299927",
+  "environment": {
+    "machine": "Apple Silicon Mac Studio (ARM64_T6000)",
+    "operating_system": "macOS 26.5.2",
+    "rustc": "1.95.0-nightly (842bd5be2 2026-01-29)",
+    "rustflags": "",
+    "cpu_mode": "unspecified",
+    "pgo": false
+  },
+  "protocol": {
+    "repetitions": 3,
+    "sample_size": 80,
+    "measurement_seconds": 5,
+    "warmup_seconds": 3,
+    "order": ["candidate", "baseline", "candidate", "baseline", "candidate", "baseline"],
+    "command": "cargo bench --manifest-path benchmarks/pulldown-comparison/Cargo.toml --bench profiling -- <lane> --sample-size 80 --measurement-time 5 --warm-up-time 3"
+  },
+  "criterion_mean_nanoseconds": {
+    "unique_headings_with_ids": {
+      "candidate": [186988.325, 187818.975, 187465.014],
+      "baseline": [187347.523, 187362.513, 188037.646],
+      "candidate_improvement_percent": [0.192, -0.244, 0.305]
+    },
+    "repeated_headings_with_ids": {
+      "candidate": [65320.572, 65281.684, 65454.381],
+      "baseline": [65393.318, 65451.182, 65393.012],
+      "candidate_improvement_percent": [0.111, 0.259, -0.094]
+    },
+    "unique_headings_without_ids": {
+      "candidate": [117816.428, 117766.32, 117716.375],
+      "baseline": [117812.56, 117899.305, 117737.203],
+      "candidate_improvement_percent": [-0.003, 0.113, 0.018]
+    },
+    "repeated_headings_without_ids": {
+      "candidate": [46084.206, 45995.964, 46028.993],
+      "baseline": [46605.499, 46681.163, 46614.14],
+      "candidate_improvement_percent": [1.119, 1.468, 1.255]
+    },
+    "ordinary_prose_without_ids": {
+      "candidate": [13447.763, 13445.269, 13458.097],
+      "baseline": [13440.537, 13407.731, 13410.309],
+      "candidate_improvement_percent": [-0.054, -0.28, -0.356]
+    }
+  },
+  "allocation_control": {
+    "lane": "repeated-headings / extended-secure-no-heading-ids",
+    "baseline": {
+      "allocations": 42,
+      "deallocations": 42,
+      "allocated_bytes": 30712
+    },
+    "candidate": {
+      "allocations": 40,
+      "deallocations": 40,
+      "allocated_bytes": 28528
+    }
+  },
+  "decision": {
+    "status": "accepted",
+    "reason": "The disabled-ID repeated-heading lane improved in all three alternating comparisons by more than one percent, with two fewer allocations and 2184 fewer allocated bytes per rendered document. Active-ID lanes remained within noise, and the ordinary-prose control changed by less than 0.36 percent."
+  }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -782,7 +782,7 @@ struct RenderContext<'a, 'r, R: FencedCodeRenderer + ?Sized> {
     link_refs: &'a LinkRefStore,
     footnote_store: Option<&'a FootnoteStore>,
     footnote_numbers: FootnoteNumbers,
-    heading_id_tracker: HeadingIdTracker,
+    heading_id_tracker: Option<HeadingIdTracker>,
     callout_stack: Vec<Option<block::CalloutType>>,
     pending_footnote_backref: Option<(String, usize)>,
     options: &'a Options,
@@ -816,7 +816,7 @@ impl<'a, 'r, R: FencedCodeRenderer + ?Sized> RenderContext<'a, 'r, R> {
             link_refs,
             footnote_store,
             footnote_numbers: FootnoteNumbers::new(footnote_store.map_or(0, FootnoteStore::len)),
-            heading_id_tracker: HeadingIdTracker::new(),
+            heading_id_tracker: options.heading_ids.then(HeadingIdTracker::new),
             callout_stack: Vec::new(),
             pending_footnote_backref: None,
             options,
@@ -998,8 +998,8 @@ impl<R: FencedCodeRenderer + ?Sized> RenderContext<'_, '_, R> {
                 let content = heading_state.finish();
 
                 // Emit heading open tag (deferred from HeadingStart)
-                if options.heading_ids {
-                    let id = heading_id_tracker.make_id(content);
+                if let Some(tracker) = heading_id_tracker.as_mut() {
+                    let id = tracker.make_id(content);
                     writer.heading_start_with_id(*level, id);
                 } else {
                     writer.heading_start(*level);


### PR DESCRIPTION
## Summary

- adds focused unique/repeated heading corpora and an otherwise identical Extended control with heading IDs disabled
- avoids allocating the heading-ID tracker when `Options::heading_ids` is `false`
- records the full evidence and the narrow scope of the accepted result

## Evidence

Against harness baseline `7da2f80`, the repeated-heading disabled-ID lane improved by `+1.119%`, `+1.468%`, and `+1.255%` across three alternating 80-sample Criterion runs (5 s measurement, 3 s warmup). It also uses two fewer allocations and 2,184 fewer allocated bytes per render.

Active-ID lanes remained within noise. The ordinary-prose disabled-ID control varied by at most `0.356%`, so this PR does not claim a general heading-rendering speedup. Full values and environment: `docs/reports/2026-07-11-issue-65-heading-id-state.json`.

## Validation

- `cargo fmt --all -- --check`
- `cargo test --all-targets --all-features --locked`
- `cargo clippy --all-targets --all-features --locked -- -D warnings`
- `cargo test --test commonmark_spec -- --ignored --nocapture` (577/652 under the existing default safety policy)

Closes #65
