### PR TITLE
perf: skip absent inline resolver stages

### DIFF
--- a/docs/plans/2026-07-11-comprehensive-performance-profile-report.md
+++ b/docs/plans/2026-07-11-comprehensive-performance-profile-report.md
@@ -189,6 +189,24 @@ when the input materializes the corresponding feature.
 The complete measurements and environment are recorded in
 [`2026-07-11-issue-67-rare-inline-buffers.json`](../reports/2026-07-11-issue-67-rare-inline-buffers.json).
 
+## Issue #64: mark-collection feature summary
+
+The inline parser now returns a compact summary from the existing mark
+collection. An absent marker proves that the related resolver cannot do work,
+so the parser can skip a second `<` scan and absent code, math, emphasis,
+tilde, highlight, superscript, and subscript stages. Set bits are conservative:
+they preserve the existing resolver path and may still produce no semantic
+match. The resolved inline-event boundary remains unchanged.
+
+Across three alternating Criterion comparisons, the Extended mixed 50 KB lane
+improved by 4.805%, 1.508%, and 1.572%. Delimiter-heavy input improved by
+0.642%, 4.138%, and 3.348%; mixed 20 KB improved by 1.736%, 0.819%, and
+1.231%. Simple prose, HTML, references, code, and the Essentials/Full controls
+did not regress.
+
+The complete measurements and environment are recorded in
+[`2026-07-11-issue-64-inline-summary.json`](../reports/2026-07-11-issue-64-inline-summary.json).
+
 ### Delimiter-heavy lane
 
 The dominant buckets were mark collection (1,162), the inline parser (1,038),

--- a/docs/reports/2026-07-11-issue-64-inline-summary.json
+++ b/docs/reports/2026-07-11-issue-64-inline-summary.json
@@ -1,0 +1,58 @@
+{
+  "schema_version": 1,
+  "issue": 64,
+  "purpose": "Measure a conservative mark-collection summary that skips resolver stages with no possible marker.",
+  "baseline_commit": "7a5f3c629450e712a169ed0c519c9155df9e6c9d",
+  "candidate_commit": "e5066ea74af91abb024e95fe89f67f9b550b7c5f",
+  "environment": {
+    "machine": "Apple Silicon Mac Studio (ARM64_T6000)",
+    "operating_system": "macOS 26.5.2",
+    "rustc": "1.95.0-nightly (842bd5be2 2026-01-29)",
+    "rustflags": "",
+    "cpu_mode": "unspecified",
+    "pgo": false
+  },
+  "summary": {
+    "source": "existing mark collection",
+    "bits": ["code", "math", "emphasis", "tilde", "highlight", "superscript", "less-than"],
+    "safety": "An unset bit proves the resolver cannot find work. A set bit is conservative and may still run a resolver that finds no semantic match.",
+    "skipped_when_absent": ["second less-than scan", "code-span resolution and extraction", "math resolution", "emphasis", "strikethrough", "subscript", "superscript", "highlight"]
+  },
+  "protocol": {
+    "repetitions": 3,
+    "sample_size": 80,
+    "measurement_seconds": 5,
+    "warmup_seconds": 3,
+    "order": ["candidate", "baseline", "candidate", "baseline", "candidate", "baseline"],
+    "command": "cargo bench --manifest-path benchmarks/pulldown-comparison/Cargo.toml --bench profiling -- <lane> --sample-size 80 --measurement-time 5 --warm-up-time 3"
+  },
+  "target_mean_nanoseconds": {
+    "delimiter_heavy_extended": {
+      "candidate": [177974.312, 173631.928, 173996.734],
+      "baseline": [179124.906, 181127.264, 180023.884],
+      "candidate_improvement_percent": [0.642, 4.138, 3.348]
+    },
+    "mixed_20k_extended": {
+      "candidate": [78984.219, 77810.278, 77768.746],
+      "baseline": [80379.667, 78452.707, 78738.256],
+      "candidate_improvement_percent": [1.736, 0.819, 1.231]
+    },
+    "mixed_50k_extended": {
+      "candidate": [202756.287, 206856.285, 206550.376],
+      "baseline": [212991.565, 210023.025, 209848.822],
+      "candidate_improvement_percent": [4.805, 1.508, 1.572]
+    }
+  },
+  "single_run_controls_candidate_improvement_percent": {
+    "simple_extended": 0.568,
+    "html_extended": 0.146,
+    "references_extended": 1.969,
+    "code_extended": 2.641,
+    "essentials_50k": 0.585,
+    "full_50k": 3.92
+  },
+  "decision": {
+    "status": "accepted",
+    "reason": "Mixed 50 KB improved by more than one percent in all three alternating comparisons. Delimiter-heavy input improved materially in two repetitions, while simple prose and feature controls did not regress. The summary preserves the resolved inline-event boundary and only skips provably absent work."
+  }
+}

--- a/src/inline/marks.rs
+++ b/src/inline/marks.rs
@@ -17,6 +17,64 @@ pub mod flags {
     pub const IN_CODE: u8 = 0b1000;
 }
 
+/// Compact summary of delimiter groups collected for one inline parse.
+///
+/// A missing bit proves that the corresponding resolver has no work to do.
+/// Set bits are deliberately conservative: a resolver may still find no
+/// semantic match after precedence and escape handling.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct MarkSummary(u8);
+
+impl MarkSummary {
+    const CODE: u8 = 1 << 0;
+    const MATH: u8 = 1 << 1;
+    const EMPHASIS: u8 = 1 << 2;
+    const TILDE: u8 = 1 << 3;
+    const HIGHLIGHT: u8 = 1 << 4;
+    const SUPERSCRIPT: u8 = 1 << 5;
+    const LESS_THAN: u8 = 1 << 6;
+
+    #[inline]
+    fn record(&mut self, bit: u8) {
+        self.0 |= bit;
+    }
+
+    #[inline]
+    pub const fn has_code(self) -> bool {
+        self.0 & Self::CODE != 0
+    }
+
+    #[inline]
+    pub const fn has_math(self) -> bool {
+        self.0 & Self::MATH != 0
+    }
+
+    #[inline]
+    pub const fn has_emphasis(self) -> bool {
+        self.0 & Self::EMPHASIS != 0
+    }
+
+    #[inline]
+    pub const fn has_tilde(self) -> bool {
+        self.0 & Self::TILDE != 0
+    }
+
+    #[inline]
+    pub const fn has_highlight(self) -> bool {
+        self.0 & Self::HIGHLIGHT != 0
+    }
+
+    #[inline]
+    pub const fn has_superscript(self) -> bool {
+        self.0 & Self::SUPERSCRIPT != 0
+    }
+
+    #[inline]
+    pub const fn has_less_than(self) -> bool {
+        self.0 & Self::LESS_THAN != 0
+    }
+}
+
 /// A potential delimiter mark.
 #[derive(Debug, Clone, Copy)]
 pub struct Mark {
@@ -167,30 +225,31 @@ pub static SPECIAL_CHARS: [bool; 256] = {
 };
 
 /// Scan text and collect marks for the default inline syntax set.
-pub fn collect_marks(text: &[u8], buffer: &mut MarkBuffer) {
-    collect_marks_impl::<false, false>(text, buffer);
+pub fn collect_marks(text: &[u8], buffer: &mut MarkBuffer) -> MarkSummary {
+    collect_marks_impl::<false, false>(text, buffer)
 }
 
 /// Scan text and collect marks with highlight support enabled.
-pub fn collect_marks_highlight(text: &[u8], buffer: &mut MarkBuffer) {
-    collect_marks_impl::<true, false>(text, buffer);
+pub fn collect_marks_highlight(text: &[u8], buffer: &mut MarkBuffer) -> MarkSummary {
+    collect_marks_impl::<true, false>(text, buffer)
 }
 
 /// Scan text and collect marks with superscript support enabled.
-pub fn collect_marks_superscript(text: &[u8], buffer: &mut MarkBuffer) {
-    collect_marks_impl::<false, true>(text, buffer);
+pub fn collect_marks_superscript(text: &[u8], buffer: &mut MarkBuffer) -> MarkSummary {
+    collect_marks_impl::<false, true>(text, buffer)
 }
 
 /// Scan text and collect marks with highlight and superscript enabled.
-pub fn collect_marks_highlight_superscript(text: &[u8], buffer: &mut MarkBuffer) {
-    collect_marks_impl::<true, true>(text, buffer);
+pub fn collect_marks_highlight_superscript(text: &[u8], buffer: &mut MarkBuffer) -> MarkSummary {
+    collect_marks_impl::<true, true>(text, buffer)
 }
 
 fn collect_marks_impl<const HIGHLIGHT: bool, const SUPERSCRIPT: bool>(
     text: &[u8],
     buffer: &mut MarkBuffer,
-) {
+) -> MarkSummary {
     buffer.clear();
+    let mut summary = MarkSummary::default();
 
     let mut pos = 0;
     let len = text.len();
@@ -204,6 +263,7 @@ fn collect_marks_impl<const HIGHLIGHT: bool, const SUPERSCRIPT: bool>(
 
         match b {
             b'`' => {
+                summary.record(MarkSummary::CODE);
                 // Count consecutive backticks
                 let start = pos;
                 while pos < len && text[pos] == b'`' {
@@ -223,6 +283,7 @@ fn collect_marks_impl<const HIGHLIGHT: bool, const SUPERSCRIPT: bool>(
             }
 
             b'$' => {
+                summary.record(MarkSummary::MATH);
                 // Count consecutive dollar signs (1 or 2 for math)
                 let start = pos;
                 while pos < len && text[pos] == b'$' {
@@ -248,6 +309,13 @@ fn collect_marks_impl<const HIGHLIGHT: bool, const SUPERSCRIPT: bool>(
                 if b == b'^' && !SUPERSCRIPT {
                     pos += 1;
                     continue;
+                }
+                match b {
+                    b'*' | b'_' => summary.record(MarkSummary::EMPHASIS),
+                    b'~' => summary.record(MarkSummary::TILDE),
+                    b'=' => summary.record(MarkSummary::HIGHLIGHT),
+                    b'^' => summary.record(MarkSummary::SUPERSCRIPT),
+                    _ => {}
                 }
                 // Count consecutive delimiter runs for emphasis-like constructs
                 let start = pos;
@@ -291,6 +359,7 @@ fn collect_marks_impl<const HIGHLIGHT: bool, const SUPERSCRIPT: bool>(
                         // For backticks, also collect them separately for code span matching
                         // The code_span resolver will handle the backslash-escape logic
                         if next == b'`' {
+                            summary.record(MarkSummary::CODE);
                             buffer.push(Mark::new(
                                 (pos + 1) as u32,
                                 (pos + 2) as u32,
@@ -373,6 +442,7 @@ fn collect_marks_impl<const HIGHLIGHT: bool, const SUPERSCRIPT: bool>(
             }
 
             b'<' => {
+                summary.record(MarkSummary::LESS_THAN);
                 // Potential autolink
                 buffer.push(Mark::new(
                     pos as u32,
@@ -389,6 +459,8 @@ fn collect_marks_impl<const HIGHLIGHT: bool, const SUPERSCRIPT: bool>(
             }
         }
     }
+
+    summary
 }
 
 #[inline]

--- a/src/inline/mod.rs
+++ b/src/inline/mod.rs
@@ -31,8 +31,8 @@ use links::{
     resolve_links_into, resolve_reference_links_into,
 };
 use marks::{
-    Mark, MarkBuffer, collect_marks, collect_marks_highlight, collect_marks_highlight_superscript,
-    collect_marks_superscript, flags,
+    Mark, MarkBuffer, MarkSummary, collect_marks, collect_marks_highlight,
+    collect_marks_highlight_superscript, collect_marks_superscript, flags,
 };
 use math::{MathSpan, resolve_math_spans};
 use memchr::memchr;
@@ -183,19 +183,20 @@ impl InlineParser {
 
         // Phase 1: Collect marks
         self.mark_buffer.reserve_for_text(text.len());
-        if has_specials {
+        let summary = if has_specials {
             if highlight && superscript {
-                collect_marks_highlight_superscript(text, &mut self.mark_buffer);
+                collect_marks_highlight_superscript(text, &mut self.mark_buffer)
             } else if highlight {
-                collect_marks_highlight(text, &mut self.mark_buffer);
+                collect_marks_highlight(text, &mut self.mark_buffer)
             } else if superscript {
-                collect_marks_superscript(text, &mut self.mark_buffer);
+                collect_marks_superscript(text, &mut self.mark_buffer)
             } else {
-                collect_marks(text, &mut self.mark_buffer);
+                collect_marks(text, &mut self.mark_buffer)
             }
         } else {
             self.mark_buffer.clear();
-        }
+            MarkSummary::default()
+        };
 
         if self.mark_buffer.is_empty() && !may_have_autolinks {
             // No special characters and no autolink candidates, emit as plain text
@@ -217,7 +218,7 @@ impl InlineParser {
 
         // Phase 2: Resolve marks by precedence
         // First: autolinks + raw HTML (skip if no '<' present)
-        let has_lt = memchr(b'<', text).is_some();
+        let has_lt = summary.has_less_than();
         self.autolinks.clear();
         if has_lt {
             find_autolinks_into(text, &mut self.autolinks);
@@ -241,16 +242,20 @@ impl InlineParser {
             .extend(self.html_spans.iter().map(|s| (s.start, s.end)));
 
         // Third: code spans (highest precedence, but should not start inside HTML tags)
-        resolve_code_spans(self.mark_buffer.marks_mut(), text, &self.html_ranges);
+        if summary.has_code() {
+            resolve_code_spans(self.mark_buffer.marks_mut(), text, &self.html_ranges);
+        }
 
         // Get code span ranges for filtering
         self.code_spans.clear();
-        self.code_spans
-            .extend(extract_code_spans(self.mark_buffer.marks()));
+        if summary.has_code() {
+            self.code_spans
+                .extend(extract_code_spans(self.mark_buffer.marks()));
+        }
         filter_html_spans_in_code_spans(&mut self.html_spans, &self.code_spans);
 
         // Math spans (after code spans, before links; gated on math option)
-        if math {
+        if math && summary.has_math() {
             self.math_spans = resolve_math_spans(self.mark_buffer.marks_mut(), text);
         } else {
             self.math_spans.clear();
@@ -265,12 +270,11 @@ impl InlineParser {
         });
 
         // Fourth: collect bracket positions and detect inline delimiter candidates in one pass
-        let (has_emphasis_marks, has_tilde_marks, has_highlight_marks, has_superscript_marks) =
-            Self::collect_brackets_and_scan_emphasis(
-                self.mark_buffer.marks(),
-                &mut self.open_brackets,
-                &mut self.close_brackets,
-            );
+        Self::collect_brackets(
+            self.mark_buffer.marks(),
+            &mut self.open_brackets,
+            &mut self.close_brackets,
+        );
         let has_brackets = !self.open_brackets.is_empty() && !self.close_brackets.is_empty();
         self.open_brackets
             .retain(|&(pos, _)| !pos_in_spans(pos, &self.html_spans));
@@ -375,7 +379,7 @@ impl InlineParser {
         for fref in &self.footnote_refs {
             self.link_boundaries.push((fref.start, fref.end));
         }
-        let emphasis_matches = if has_emphasis_marks {
+        let emphasis_matches = if summary.has_emphasis() {
             resolve_emphasis_with_stacks_into(
                 self.mark_buffer.marks_mut(),
                 &self.link_boundaries,
@@ -389,7 +393,7 @@ impl InlineParser {
         };
 
         // Seventh: strikethrough (after emphasis, since they share the mark buffer)
-        if has_tilde_marks && strikethrough {
+        if summary.has_tilde() && strikethrough {
             resolve_strikethrough_into(
                 self.mark_buffer.marks_mut(),
                 &self.link_boundaries,
@@ -401,7 +405,7 @@ impl InlineParser {
         let strikethrough_matches = self.strikethrough_matches.as_slice();
 
         // Eighth: subscript (after strikethrough, since they share `~`)
-        if has_tilde_marks && subscript {
+        if summary.has_tilde() && subscript {
             resolve_subscript_into(
                 self.mark_buffer.marks_mut(),
                 text,
@@ -415,7 +419,7 @@ impl InlineParser {
         let subscript_matches = self.subscript_matches.as_slice();
 
         // Ninth: superscript
-        if has_superscript_marks && superscript {
+        if summary.has_superscript() && superscript {
             resolve_superscript_into(
                 self.mark_buffer.marks_mut(),
                 text,
@@ -429,7 +433,7 @@ impl InlineParser {
         let superscript_matches = self.superscript_matches.as_slice();
 
         // Tenth: highlight/mark
-        if has_highlight_marks && highlight {
+        if summary.has_highlight() && highlight {
             resolve_highlight_into(
                 self.mark_buffer.marks_mut(),
                 text,
@@ -591,35 +595,19 @@ impl InlineParser {
         }
     }
 
-    /// Collect bracket positions for link parsing.
-    /// Returns (has_emphasis_marks, has_tilde_marks, has_highlight_marks, has_superscript_marks).
-    fn collect_brackets_and_scan_emphasis(
+    /// Collect bracket positions for link parsing after code-span resolution.
+    fn collect_brackets(
         marks: &[Mark],
         open_brackets: &mut Vec<(u32, bool)>,
         close_brackets: &mut Vec<u32>,
-    ) -> (bool, bool, bool, bool) {
+    ) {
         let estimated = (marks.len() / 4).max(4);
         open_brackets.clear();
         close_brackets.clear();
         open_brackets.reserve(estimated);
         close_brackets.reserve(estimated);
 
-        let mut has_emphasis_marks = false;
-        let mut has_tilde_marks = false;
-        let mut has_highlight_marks = false;
-        let mut has_superscript_marks = false;
         for mark in marks {
-            if mark.flags & flags::IN_CODE == 0 {
-                if mark.ch == b'*' || mark.ch == b'_' {
-                    has_emphasis_marks = true;
-                } else if mark.ch == b'~' {
-                    has_tilde_marks = true;
-                } else if mark.ch == b'=' {
-                    has_highlight_marks = true;
-                } else if mark.ch == b'^' {
-                    has_superscript_marks = true;
-                }
-            }
             // Skip brackets inside code spans
             if mark.flags & flags::IN_CODE != 0 && mark.ch != b'[' {
                 continue;
@@ -637,12 +625,6 @@ impl InlineParser {
                 _ => {}
             }
         }
-        (
-            has_emphasis_marks,
-            has_tilde_marks,
-            has_highlight_marks,
-            has_superscript_marks,
-        )
     }
 
     /// Emit events based on resolved marks.


### PR DESCRIPTION
## Summary

- returns a compact conservative marker summary from the existing inline mark collection
- skips resolver stages only when their marker is provably absent
- keeps the resolved inline-event boundary and documents the evidence

## Evidence

Three alternating Criterion runs (80 samples, 5 s measurement, 3 s warmup) improved Extended mixed 50 KB by `+4.805%`, `+1.508%`, and `+1.572%`. Delimiter-heavy input improved by `+0.642%`, `+4.138%`, and `+3.348%`.

Simple prose, HTML, references, code, and Essentials/Full controls did not regress. Set summary bits remain conservative and keep the existing resolver path; only absent markers skip work.

Full values and environment: `docs/reports/2026-07-11-issue-64-inline-summary.json`.

## Validation

- `cargo fmt --all -- --check`
- `cargo test --all-targets --all-features --locked`
- `cargo clippy --all-targets --all-features --locked -- -D warnings`
- `cargo test --test commonmark_spec -- --ignored --nocapture` (577/652 under the existing default safety policy)

Closes #64
