### PR TITLE
perf: evaluate contiguous paragraph borrowing

### DIFF
--- a/benchmarks/pulldown-comparison/benches/profiling.rs
+++ b/benchmarks/pulldown-comparison/benches/profiling.rs
@@ -84,6 +84,7 @@ fn profiling_benches(c: &mut Criterion) {
         Corpus::CommonMark5K,
         Corpus::CommonMark20K,
         Corpus::CommonMark50K,
+        Corpus::Mixed250K,
     ] {
         bench_lane(
             c,

--- a/docs/plans/2026-07-11-comprehensive-performance-profile-report.md
+++ b/docs/plans/2026-07-11-comprehensive-performance-profile-report.md
@@ -327,6 +327,16 @@ most of the visible ceiling. PGO remains unmeasured because no representative
   opportunity not already covered by `memchr` or NEON.
 - **Extensibility:** neutral, but portability risk is high.
 
+## Rejected experiment: contiguous paragraph borrowing (issue #66)
+
+The source-contiguous fast path passed its semantic tests and reduced copied
+paragraph bytes substantially: 15,206 to 2,774 bytes at CommonMark 20 KB,
+36,080 to 7,582 bytes at 50 KB, and 180,400 to 37,910 bytes at mixed 250 KB.
+It did not meet the performance gate. Across three alternating 80-sample runs,
+the candidate regressed by 1.882-2.888% at 20 KB, 1.612-2.398% at 50 KB, and
+3.407-3.547% on simple prose. The prototype is therefore retained only as a
+documented negative result; no parser change is merged.
+
 ## Recommended execution order
 
 1. Run publication-quality CommonMark parity repetitions with the pinned

--- a/docs/reports/2026-07-11-issue-66-contiguous-paragraphs.json
+++ b/docs/reports/2026-07-11-issue-66-contiguous-paragraphs.json
@@ -1,0 +1,60 @@
+{
+  "schema_version": 1,
+  "issue": 66,
+  "purpose": "Measure whether source-contiguous paragraphs can bypass ParagraphState copying while preserving the buffered normalization fallback.",
+  "baseline_commit": "193aace448d3e2e15797ee950fe980d3a7d04478",
+  "candidate_commit": "c21fd9307fe82084c056bb8701606ceb1f88825c",
+  "harness_commit": "71f4cf5",
+  "environment": {
+    "machine": "Apple Silicon Mac Studio (ARM64_T6000)",
+    "operating_system": "macOS 26.5.2",
+    "rustc": "1.95.0-nightly (842bd5be2 2026-01-29)",
+    "rustflags": "",
+    "pgo": false
+  },
+  "implementation": {
+    "fast_path": "A paragraph with one source-contiguous text range is passed directly to the unchanged inline/event pipeline.",
+    "fallback": "A second text range, soft break, indentation, tab normalization, or trailing whitespace promotes the content into the existing buffer.",
+    "semantic_boundary": "Both paths call the same render_inline_content function."
+  },
+  "pipeline_copied_bytes": {
+    "commonmark_20k": { "baseline": 15206, "candidate": 2774 },
+    "commonmark_50k": { "baseline": 36080, "candidate": 7582 },
+    "mixed_250k": { "baseline": 180400, "candidate": 37910 }
+  },
+  "protocol": {
+    "repetitions": 3,
+    "sample_size": 80,
+    "measurement_seconds": 5,
+    "warmup_seconds": 3,
+    "order": ["candidate", "baseline", "candidate", "baseline", "candidate", "baseline"],
+    "command": "cargo bench --manifest-path benchmarks/pulldown-comparison/Cargo.toml --bench profiling -- <lane> --sample-size 80 --measurement-time 5 --warm-up-time 3"
+  },
+  "target_mean_nanoseconds": {
+    "commonmark_20k_extended": {
+      "candidate": [79819.370, 79984.310, 80055.225],
+      "baseline": [77578.748, 78506.914, 78027.172],
+      "candidate_improvement_percent": [-2.888, -1.882, -2.599]
+    },
+    "commonmark_50k_extended": {
+      "candidate": [211223.274, 210883.679, 212213.223],
+      "baseline": [207088.951, 207537.711, 207243.438],
+      "candidate_improvement_percent": [-1.996, -1.612, -2.398]
+    },
+    "simple_extended": {
+      "candidate": [13536.230, 13568.392, 13548.406],
+      "baseline": [13077.149, 13103.656, 13102.007],
+      "candidate_improvement_percent": [-3.511, -3.547, -3.407]
+    }
+  },
+  "single_run_controls_candidate_improvement_percent": {
+    "mixed_250k_extended": -2.051,
+    "containers_extended": 1.881,
+    "tables_extended": -2.263,
+    "code_extended": 1.292
+  },
+  "decision": {
+    "status": "rejected",
+    "reason": "The candidate reduces copied bytes by 79-82%, but all three alternating comparisons regress on CommonMark 20 KB, CommonMark 50 KB, and simple prose. It fails the required repeatable 20/50 KB throughput gain and the no-simple-regression guard, so no parser change is merged."
+  }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -504,6 +504,8 @@ pub fn to_html_into_with_renderer(
 struct ParagraphState {
     /// Collected text content (joined with newlines).
     content: Vec<u8>,
+    /// A single source-contiguous paragraph that has not needed buffering yet.
+    borrowed: Option<Range>,
     /// Whether we're currently in a paragraph.
     in_paragraph: bool,
 }
@@ -512,6 +514,7 @@ impl ParagraphState {
     fn new() -> Self {
         Self {
             content: Vec::with_capacity(256),
+            borrowed: None,
             in_paragraph: false,
         }
     }
@@ -519,22 +522,38 @@ impl ParagraphState {
     fn start(&mut self) {
         self.in_paragraph = true;
         self.content.clear();
+        self.borrowed = None;
     }
 
-    fn add_text(&mut self, text: &[u8]) {
+    fn add_text(&mut self, input: &[u8], range: Range) {
+        if self.content.is_empty() && self.borrowed.is_none() {
+            self.borrowed = Some(range);
+            return;
+        }
+        self.promote_to_buffer(input);
         #[cfg(feature = "profiling")]
-        profiling::record_paragraph_copy(text.len());
-        self.content.extend_from_slice(text);
+        profiling::record_paragraph_copy(range.len() as usize);
+        self.content.extend_from_slice(range.slice(input));
     }
 
-    fn add_soft_break(&mut self) {
+    fn add_soft_break(&mut self, input: &[u8]) {
+        self.promote_to_buffer(input);
         #[cfg(feature = "profiling")]
         profiling::record_paragraph_copy(1);
         self.content.push(b'\n');
     }
 
-    fn finish(&mut self) -> &[u8] {
+    fn finish<'a>(&'a mut self, input: &'a [u8]) -> ParagraphContent<'a> {
         self.in_paragraph = false;
+        if let Some(range) = self.borrowed.take() {
+            let content = range.slice(input);
+            if !content.last().is_some_and(|&b| b == b' ' || b == b'\t') {
+                return ParagraphContent::Borrowed(content);
+            }
+            self.content.extend_from_slice(content);
+            #[cfg(feature = "profiling")]
+            profiling::record_paragraph_copy(content.len());
+        }
         // CommonMark: strip trailing spaces/tabs from paragraph content
         while self
             .content
@@ -543,7 +562,30 @@ impl ParagraphState {
         {
             self.content.pop();
         }
-        &self.content
+        ParagraphContent::Buffered(&self.content)
+    }
+
+    fn promote_to_buffer(&mut self, input: &[u8]) {
+        if let Some(range) = self.borrowed.take() {
+            let content = range.slice(input);
+            #[cfg(feature = "profiling")]
+            profiling::record_paragraph_copy(content.len());
+            self.content.extend_from_slice(content);
+        }
+    }
+}
+
+/// Paragraph bytes supplied to the common inline rendering boundary.
+enum ParagraphContent<'a> {
+    Borrowed(&'a [u8]),
+    Buffered(&'a [u8]),
+}
+
+impl ParagraphContent<'_> {
+    fn as_bytes(&self) -> &[u8] {
+        match self {
+            Self::Borrowed(content) | Self::Buffered(content) => content,
+        }
     }
 }
 
@@ -952,14 +994,14 @@ impl<R: FencedCodeRenderer + ?Sized> RenderContext<'_, '_, R> {
                         });
 
                 // Parse all accumulated paragraph content at once
-                let content = para_state.finish();
+                let content = para_state.finish(input);
 
                 // Emit pending task checkbox before paragraph content
                 emit_pending_task_checkbox(pending_task, writer);
 
-                if !content.is_empty() {
+                if !content.as_bytes().is_empty() {
                     render_inline_content(
-                        content,
+                        content.as_bytes(),
                         writer,
                         inline_parser,
                         inline_events,
@@ -1051,7 +1093,7 @@ impl<R: FencedCodeRenderer + ?Sized> RenderContext<'_, '_, R> {
             BlockEvent::HtmlBlockEnd => {}
             BlockEvent::SoftBreak => {
                 if para_state.in_paragraph {
-                    para_state.add_soft_break();
+                    para_state.add_soft_break(input);
                 } else if heading_state.in_heading {
                     heading_state.add_soft_break();
                 } else {
@@ -1062,7 +1104,7 @@ impl<R: FencedCodeRenderer + ?Sized> RenderContext<'_, '_, R> {
                 let text = range.slice(input);
                 if para_state.in_paragraph {
                     // Accumulate for later parsing
-                    para_state.add_text(text);
+                    para_state.add_text(input, *range);
                 } else if heading_state.in_heading {
                     heading_state.add_text(text);
                 } else if cell_state.in_cell {


### PR DESCRIPTION
## Result

Rejected experiment for #66. The source-contiguous paragraph path reduced copied
bytes by 79-82%, but it consistently regressed in the required throughput lanes:

- CommonMark 20 KB: -2.888%, -1.882%, -2.599%
- CommonMark 50 KB: -1.996%, -1.612%, -2.398%
- Simple prose: -3.511%, -3.547%, -3.407%

The parser change is deliberately not merged. This draft preserves the
implementation and repeatable negative result; the JSON report records the
protocol, raw means, copy counters, and decision.

Closes #66
