### PR TITLE
perf: short-circuit container blank checks

### DIFF
--- a/benchmarks/pulldown-comparison/benches/profiling.rs
+++ b/benchmarks/pulldown-comparison/benches/profiling.rs
@@ -101,6 +101,8 @@ fn profiling_benches(c: &mut Criterion) {
         Corpus::References,
         Corpus::Tables,
         Corpus::Containers,
+        Corpus::Lists,
+        Corpus::Blockquotes,
         Corpus::Delimiters,
         Corpus::Html,
         Corpus::UnicodeEntities,

--- a/benchmarks/pulldown-comparison/src/corpus.rs
+++ b/benchmarks/pulldown-comparison/src/corpus.rs
@@ -34,6 +34,10 @@ pub enum Corpus {
     Tables,
     /// Nested lists and blockquotes.
     Containers,
+    /// Nested unordered and ordered lists.
+    Lists,
+    /// Nested blockquotes with ordinary paragraph content.
+    Blockquotes,
     /// Inline delimiter-heavy input.
     Delimiters,
     /// Raw HTML-heavy input.
@@ -46,7 +50,7 @@ pub enum Corpus {
 
 impl Corpus {
     /// All corpus selectors accepted by the diagnostic runner.
-    pub const ALL: [Self; 16] = [
+    pub const ALL: [Self; 18] = [
         Self::CommonMark5K,
         Self::CommonMark20K,
         Self::CommonMark50K,
@@ -60,6 +64,8 @@ impl Corpus {
         Self::References,
         Self::Tables,
         Self::Containers,
+        Self::Lists,
+        Self::Blockquotes,
         Self::Delimiters,
         Self::Html,
         Self::UnicodeEntities,
@@ -81,6 +87,8 @@ impl Corpus {
             Self::References => "references",
             Self::Tables => "tables",
             Self::Containers => "containers",
+            Self::Lists => "lists",
+            Self::Blockquotes => "blockquotes",
             Self::Delimiters => "delimiters",
             Self::Html => "html",
             Self::UnicodeEntities => "unicode-entities",
@@ -120,6 +128,14 @@ impl Corpus {
             Self::Tables => Cow::Borrowed(TABLES_5K),
             Self::Containers => Cow::Owned(repeat_to_at_least(
                 "> - first item\n>   - nested item\n>     1. ordered child\n>     2. second child\n>\n> continuation\n\n",
+                20_000,
+            )),
+            Self::Lists => Cow::Owned(repeat_to_at_least(
+                "- first item\n  - nested item\n    1. ordered child\n    2. second child\n  - another nested item\n- second top-level item\n\n",
+                20_000,
+            )),
+            Self::Blockquotes => Cow::Owned(repeat_to_at_least(
+                "> outer quote\n> > nested quote\n> > continued nested content\n>\n> continued outer content\n\n",
                 20_000,
             )),
             Self::Delimiters => Cow::Owned(repeat_to_at_least(

--- a/docs/plans/2026-07-11-comprehensive-performance-profile-report.md
+++ b/docs/plans/2026-07-11-comprehensive-performance-profile-report.md
@@ -338,3 +338,18 @@ most of the visible ceiling. PGO remains unmeasured because no representative
 6. Re-profile before considering an optional direct-render sink.
 7. Build representative PGO training data only after portable source changes
    stabilize.
+
+## Accepted experiment: early-exit container blank checks (issue #68)
+
+Focused CPU samples separated two different costs. Table parsing spends visible
+time splitting cells, but table rows remain dominated by required block events
+and inline rendering. The container profile instead exposed redundant
+line-length scans while matching nonblank list and footnote continuations.
+
+The accepted change replaces that two-pass predicate with one early-exit scan
+and adds independent list-heavy and blockquote-heavy benchmark lanes. Across
+three alternating 80-sample portable runs, list-heavy input improved by
+10.614%, 10.406%, and 10.424%. The mixed container control improved 9.613%;
+CommonMark 20/50 KB improved 3.927% and 2.250%; tables (+0.386%) and
+blockquotes (+0.026%) stayed within the guardrail. Existing block events and
+rendering boundaries are unchanged.

--- a/docs/reports/2026-07-11-issue-68-block-paths.json
+++ b/docs/reports/2026-07-11-issue-68-block-paths.json
@@ -1,0 +1,72 @@
+{
+  "schema_version": 1,
+  "issue": 68,
+  "purpose": "Profile focused container and table block paths, then reduce only a measured container-matching cost.",
+  "baseline_commit": "193aace448d3e2e15797ee950fe980d3a7d04478",
+  "environment": {
+    "machine": "Apple Silicon Mac Studio (ARM64_T6000)",
+    "operating_system": "macOS 26.5.2",
+    "rustc": "1.95.0-nightly (842bd5be2 2026-01-29)",
+    "rustflags": "-C target-cpu=generic",
+    "cpu_mode": "portable",
+    "pgo": false
+  },
+  "evidence": {
+    "container_pipeline": {
+      "input_bytes": 20064,
+      "block_events": 6479,
+      "container_events": 3344,
+      "inline_parses": 1045,
+      "paragraph_copied_bytes": 12122
+    },
+    "table_pipeline": {
+      "input_bytes": 4552,
+      "block_events": 1430,
+      "table_events": 986,
+      "inline_parses": 402,
+      "paragraph_copied_bytes": 457
+    },
+    "cpu_samples": {
+      "containers": "match_containers, list-item recognition, and container closing were prominent in a 14-second portable sample.",
+      "tables": "split_table_cells was the largest block-parser leaf in two 14-second portable samples, but table rendering remained inline- and event-heavy."
+    }
+  },
+  "implementation": {
+    "candidate": "Replace the two-pass blank-line predicate used for list and footnote continuations with a single early-exit scan.",
+    "why": "Nonblank container continuations commonly begin with content. The former predicate still searched to the next newline to compare two counts.",
+    "semantic_boundary": "The helper returns the same result for empty input, horizontal whitespace, a newline, and the first non-whitespace byte. Block events and rendering remain unchanged.",
+    "harness": "Add independent list-heavy and blockquote-heavy profiling lanes."
+  },
+  "protocol": {
+    "repetitions": 3,
+    "sample_size": 80,
+    "measurement_seconds": 5,
+    "warmup_seconds": 3,
+    "order": ["candidate", "baseline", "candidate", "baseline", "candidate", "baseline"],
+    "command": "RUSTFLAGS='-C target-cpu=generic' cargo bench --locked --manifest-path benchmarks/pulldown-comparison/Cargo.toml --bench profiling -- <lane> --sample-size 80 --measurement-time 5 --warm-up-time 3"
+  },
+  "target_mean_nanoseconds": {
+    "lists_extended_secure": {
+      "candidate": [140198.260, 139704.754, 139737.740],
+      "baseline": [156846.026, 155931.090, 155998.851],
+      "candidate_improvement_percent": [10.614, 10.406, 10.424]
+    }
+  },
+  "single_run_controls_candidate_improvement_percent": {
+    "containers_extended_secure": 9.613,
+    "blockquotes_extended_secure": 0.026,
+    "tables_extended_secure": 0.386,
+    "commonmark_20k_extended_secure": 3.927,
+    "commonmark_50k_extended_secure": 2.25
+  },
+  "validation": {
+    "cargo_fmt": "passed",
+    "cargo_test_all_targets_all_features_locked": "passed",
+    "cargo_clippy_all_targets_all_features_locked": "passed with -D warnings",
+    "commonmark": "577/652 in-scope (88.5%); the existing security-policy failures are unchanged"
+  },
+  "decision": {
+    "status": "accepted",
+    "reason": "The list-heavy target improved by more than 10% in all three alternating comparisons. The mixed container corpus and CommonMark controls improved, while table and blockquote controls remained within the 1% guardrail. The change only avoids redundant scanning and preserves existing block events."
+  }
+}

--- a/src/block/parser.rs
+++ b/src/block/parser.rs
@@ -995,18 +995,7 @@ impl<'a> BlockParser<'a> {
                 } => {
                     // Check if line is blank (after any spaces we've consumed so far)
                     let remaining = self.cursor.remaining_slice();
-                    let is_blank = remaining.is_empty()
-                        || remaining[0] == b'\n'
-                        || remaining
-                            .iter()
-                            .take_while(|&&b| b == b' ' || b == b'\t')
-                            .count()
-                            == remaining.len().min(
-                                remaining
-                                    .iter()
-                                    .position(|&b| b == b'\n')
-                                    .unwrap_or(remaining.len()),
-                            );
+                    let is_blank = Self::is_blank_remaining_line(remaining);
 
                     if is_blank {
                         // Blank lines always match list items
@@ -1064,18 +1053,7 @@ impl<'a> BlockParser<'a> {
                 ContainerType::FootnoteDefinition { content_indent } => {
                     // Similar to list items: blank lines match, content needs enough indent
                     let remaining = self.cursor.remaining_slice();
-                    let is_blank = remaining.is_empty()
-                        || remaining[0] == b'\n'
-                        || remaining
-                            .iter()
-                            .take_while(|&&b| b == b' ' || b == b'\t')
-                            .count()
-                            == remaining.len().min(
-                                remaining
-                                    .iter()
-                                    .position(|&b| b == b'\n')
-                                    .unwrap_or(remaining.len()),
-                            );
+                    let is_blank = Self::is_blank_remaining_line(remaining);
 
                     if is_blank {
                         matched += 1;
@@ -1119,6 +1097,20 @@ impl<'a> BlockParser<'a> {
 
         // Don't close containers here - let parse_line handle it
         matched
+    }
+
+    /// Return whether the remaining source contains only horizontal whitespace
+    /// before its next newline or end of input.
+    #[inline]
+    fn is_blank_remaining_line(remaining: &[u8]) -> bool {
+        for &byte in remaining {
+            match byte {
+                b' ' | b'\t' => {}
+                b'\n' => return true,
+                _ => return false,
+            }
+        }
+        true
     }
 
     /// Peek ahead to see if there's a list marker of the same type.
@@ -4403,6 +4395,15 @@ mod tests {
             .iter()
             .any(|e| matches!(e, BlockEvent::ListEnd { .. }));
         assert!(has_list_end);
+    }
+
+    #[test]
+    fn blank_remaining_line_stops_at_first_non_whitespace_byte() {
+        assert!(BlockParser::is_blank_remaining_line(b""));
+        assert!(BlockParser::is_blank_remaining_line(b" \t\nnext"));
+        assert!(BlockParser::is_blank_remaining_line(b" \t"));
+        assert!(!BlockParser::is_blank_remaining_line(b"  content\n"));
+        assert!(!BlockParser::is_blank_remaining_line(b"content\n"));
     }
 
     #[test]


### PR DESCRIPTION
## Result

Closes #68.

This replaces the redundant two-pass blank-line check used while matching list
and footnote continuations with one early-exit scan. It preserves the existing
block-event and rendering boundary.

The PR also adds independent list-heavy and blockquote-heavy profiling lanes.
Focused CPU samples showed that container matching—not the more invasive table
event path—was the bounded, low-risk target.

Portable Criterion results, 80 samples with 5 s measurement and 3 s warmup:

- List-heavy, three alternating comparisons: +10.614%, +10.406%, +10.424%
- Mixed containers: +9.613%
- CommonMark 20 KB / 50 KB: +3.927% / +2.250%
- Tables / blockquotes: +0.386% / +0.026% (within guardrail)

The durable report includes raw means, profile evidence, environment, and the
validation record.
