### PR TITLE
docs: record resolved-inline sink RFC

### DIFF
--- a/docs/arch/ARCH-RFC-002-resolved-inline-sink.md
+++ b/docs/arch/ARCH-RFC-002-resolved-inline-sink.md
@@ -1,0 +1,40 @@
+# RFC: optional resolved-inline sink
+
+## Decision
+
+Do not add a direct HTML sink in the current architecture. Keep the resolved
+`InlineEvent` sequence as the one shared boundary between inline resolution and
+output. Reopen this RFC only if profiling isolates event materialization as a
+dominant cost and a sink can consume one shared resolved representation without
+duplicating renderer semantics.
+
+## Evidence
+
+On the portable current baseline, CommonMark 50 KB produces 2,081 inline events
+from 1,018 inline parses; mixed 250 KB produces 10,405 events from 5,090 parses.
+Those counts are material, but they do not establish that event storage is the
+dominant cost. The resolved-event generation still sorts emit points, while the
+HTML renderer owns stateful image-alt handling, link policy, raw-HTML policy,
+and footnote numbering.
+
+## Evaluated boundary
+
+The smallest credible abstraction would let `InlineParser` emit the already
+resolved operations to either an event collector or an HTML writer. In practice,
+the writer needs the same image nesting, reference lookup, URL policy, raw HTML
+filtering, and footnote-number state as `render_inline_event`. Moving those
+rules into a second sink would duplicate behavior; moving them into the parser
+would make parsing depend on an HTML policy and weaken the transform boundary.
+
+## Reopen gate
+
+Require all of the following before a new prototype:
+
+- a profile showing event allocation or event iteration as a dominant 50 KB
+  cost after resolution;
+- one resolved operation model consumed by both the event collector and HTML
+  sink;
+- byte-identical HTML across images, links, raw HTML policy, footnotes, and
+  nested emphasis;
+- a credible transform/plugin consumer of the same operation model; and
+- a repeated 2% 50 KB gain or a substantial allocation reduction.

--- a/docs/plans/2026-07-11-comprehensive-performance-profile-report.md
+++ b/docs/plans/2026-07-11-comprehensive-performance-profile-report.md
@@ -353,3 +353,14 @@ three alternating 80-sample portable runs, list-heavy input improved by
 CommonMark 20/50 KB improved 3.927% and 2.250%; tables (+0.386%) and
 blockquotes (+0.026%) stayed within the guardrail. Existing block events and
 rendering boundaries are unchanged.
+
+## Rejected RFC: direct resolved-inline HTML sink (issue #69)
+
+The event stream is material but not isolated as the universal bottleneck:
+CommonMark 50 KB produced 2,081 inline events and mixed 250 KB produced 10,405.
+A direct sink would need the renderer's image-alt state, reference resolution,
+URL and raw-HTML policies, and footnote-number state. Duplicating those rules
+would risk divergence; moving them into the parser would weaken the only
+credible transform boundary. No source prototype is merged. The event path
+remains canonical until a profile proves event materialization dominates and
+one shared resolved-operation model can serve HTML and transforms.

--- a/docs/reports/2026-07-11-issue-69-inline-sink.json
+++ b/docs/reports/2026-07-11-issue-69-inline-sink.json
@@ -1,0 +1,18 @@
+{
+  "schema_version": 1,
+  "issue": 69,
+  "baseline_commit": "227e3ebc268a28380a50703372dc796b16fed0a8",
+  "environment": {
+    "machine": "Apple Silicon Mac Studio (ARM64_T6000)",
+    "rustc": "1.95.0-nightly (842bd5be2 2026-01-29)",
+    "pgo": false
+  },
+  "pipeline": {
+    "commonmark_50k": { "inline_parses": 1018, "inline_events": 2081, "inline_emit_points": 587, "allocations": 341, "allocated_bytes": 206813 },
+    "mixed_250k": { "inline_parses": 5090, "inline_events": 10405, "inline_emit_points": 2935, "allocations": 458, "allocated_bytes": 864881 }
+  },
+  "decision": {
+    "status": "rejected",
+    "reason": "A direct HTML sink would either duplicate image, link, HTML-policy, and footnote rendering semantics or move those semantics into the parser. Current counters show material event volume but do not prove event storage dominates throughput. The existing resolved InlineEvent boundary remains the credible transform/plugin path."
+  }
+}


### PR DESCRIPTION
Rejected RFC for #69. Counters show material event volume but not a dominant event-materialization bottleneck. A direct HTML sink would duplicate renderer policy/state or weaken the transform boundary. This draft preserves the RFC and measured evidence; no production change is merged.