### PR TITLE
docs(perf): record PGO deployment results

### DIFF
--- a/docs/reports/2026-07-11-epic-71-final-scorecard.md
+++ b/docs/reports/2026-07-11-epic-71-final-scorecard.md
@@ -1,0 +1,36 @@
+# Epic #71 final scorecard
+
+Epic #71 completed an evidence-gated portable optimization campaign. Production
+changes were merged only after the issue-specific throughput and correctness
+gates passed; rejected experiments remain available through closed draft PRs.
+
+## Merged source wins
+
+- Heading-ID state is now absent when IDs are disabled, removing two repeated
+  heading allocations.
+- Rare inline buffers are lazy, reducing 5 KB allocation pressure without a
+  20/50 KB regression.
+- Inline resolvers skip work that the mark summary proves absent; mixed 50 KB
+  improved in all three repeated comparisons.
+- Container matching stops at the first non-whitespace byte. List-heavy input
+  improved by 10.614%, 10.406%, and 10.424% across alternating runs.
+
+## Rejected directions
+
+- The shared secure-URL scan did not meet its mixed/50 KB gate.
+- Borrowed contiguous paragraphs cut copies by 79-82% but repeatedly regressed
+  20/50 KB and simple prose throughput.
+- A direct resolved-inline HTML sink would duplicate renderer policy/state or
+  weaken the transform boundary; event materialization was not isolated as the
+  dominant universal bottleneck.
+
+## Deployment result
+
+Portable remains the source-performance baseline. On the balanced PGO training
+set, the separate PGO artifact improved secure Extended CommonMark 50 KB by
+4.893% and improved every checked focused corpus; it increases the diagnostic
+binary by 5.1%. Apple-M1 (+1.196%) and native (+0.475%) do not justify separate
+default artifacts. Ship PGO only as an explicit, reproducible deployment lane.
+
+Detailed baseline, allocation, event, copied-byte, source-experiment, and PGO
+evidence live in the dated JSON reports beside this scorecard.

--- a/docs/reports/2026-07-11-epic-71-final-scorecard.md
+++ b/docs/reports/2026-07-11-epic-71-final-scorecard.md
@@ -17,9 +17,13 @@ gates passed; rejected experiments remain available through closed draft PRs.
 
 ## Rejected directions
 
-- The shared secure-URL scan did not meet its mixed/50 KB gate.
+- The shared secure-URL scan did not meet its mixed/50 KB gate; its exact
+  [rejection report](https://github.com/sebastian-software/ferromark/blob/codex/issue-62-secure-url-scan/docs/reports/2026-07-11-issue-62-secure-url-scan.json)
+  remains on closed draft PR #73.
 - Borrowed contiguous paragraphs cut copies by 79-82% but repeatedly regressed
-  20/50 KB and simple prose throughput.
+  20/50 KB and simple prose throughput; see the
+  [exact report](https://github.com/sebastian-software/ferromark/blob/codex/issue-66-contiguous-paragraphs/docs/reports/2026-07-11-issue-66-contiguous-paragraphs.json)
+  preserved by closed draft PR #77.
 - A direct resolved-inline HTML sink would duplicate renderer policy/state or
   weaken the transform boundary; event materialization was not isolated as the
   dominant universal bottleneck.

--- a/docs/reports/2026-07-11-issue-70-pgo-codegen.json
+++ b/docs/reports/2026-07-11-issue-70-pgo-codegen.json
@@ -5,6 +5,13 @@
   "toolchain": "rustc 1.93.0 (LLVM 21.1.8)",
   "training": {
     "profile_data_bytes": 2621440,
+    "profile_data_sha256": "not-retained-local-artifact",
+    "machine": "Apple Silicon Mac Studio (ARM64_T6000), macOS 26.5.2",
+    "rustflags_generate": "-Cprofile-generate=/private/tmp/ferromark-issue-70-profraw-stable",
+    "rustflags_use": "-C profile-use=/private/tmp/ferromark-issue-70-stable.profdata -C llvm-args=-pgo-warn-missing-function",
+    "generate_command": "CARGO_TARGET_DIR=/private/tmp/ferromark-pgo-instrumented-stable RUSTFLAGS='-Cprofile-generate=/private/tmp/ferromark-issue-70-profraw-stable' cargo build --locked --release --manifest-path benchmarks/pulldown-comparison/Cargo.toml --bin profile_driver",
+    "merge_command": "$(rustup run 1.93.0 rustc --print sysroot)/lib/rustlib/aarch64-apple-darwin/bin/llvm-profdata merge -o /private/tmp/ferromark-issue-70-stable.profdata /private/tmp/ferromark-issue-70-profraw-stable/*.profraw",
+    "benchmark_command": "profile_driver --config extended-secure --corpus <corpus> --seconds 5 --warmup-iterations 3",
     "corpora": ["commonmark-5k", "commonmark-20k", "commonmark-50k", "mixed-250k", "simple", "safe-urls", "delimiters", "references", "tables", "containers"],
     "profiles": ["commonmark", "essentials-secure", "extended-secure"]
   },

--- a/docs/reports/2026-07-11-issue-70-pgo-codegen.json
+++ b/docs/reports/2026-07-11-issue-70-pgo-codegen.json
@@ -1,0 +1,30 @@
+{
+  "schema_version": 1,
+  "issue": 70,
+  "baseline_commit": "227e3ebc268a28380a50703372dc796b16fed0a8",
+  "toolchain": "rustc 1.93.0 (LLVM 21.1.8)",
+  "training": {
+    "profile_data_bytes": 2621440,
+    "corpora": ["commonmark-5k", "commonmark-20k", "commonmark-50k", "mixed-250k", "simple", "safe-urls", "delimiters", "references", "tables", "containers"],
+    "profiles": ["commonmark", "essentials-secure", "extended-secure"]
+  },
+  "commonmark_50k_extended_secure_throughput_change_percent": {
+    "apple_m1_vs_portable": 1.196,
+    "native_vs_portable": 0.475,
+    "pgo_vs_portable": 4.893
+  },
+  "pgo_cross_corpus_throughput_change_percent": {
+    "simple": 18.824,
+    "safe_urls": 17.914,
+    "delimiters": 8.758,
+    "references": 5.873,
+    "tables": 16.448,
+    "containers": 47.53,
+    "mixed_250k": 25.513
+  },
+  "binary_size_bytes": { "portable": 1377072, "pgo": 1447296 },
+  "decision": {
+    "status": "accepted_documentation",
+    "reason": "Balanced PGO improves every checked corpus and the primary 50 KB lane by 4.893%, with a 5.1% binary-size increase. Recommend an optional, separately built PGO deployment artifact; keep portable source claims and the default distribution non-PGO. Apple M1 and native flags do not justify a separate default artifact."
+  }
+}


### PR DESCRIPTION
Closes #70. Adds a balanced PGO training record, separate portable/Apple-M1/native/PGO results, Cross-Corpus validation, binary-size impact, and the final Epic #71 scorecard. PGO is an optional deployment lane; portable claims remain separate.