### PR TITLE
fix(release): build native Windows artifacts through cmd

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,3 +110,34 @@ jobs:
       - run: pnpm lint
       - run: pnpm pack:check
       - run: pnpm smoke:clean
+
+  native-windows:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { os: windows-latest, rust_target: x86_64-pc-windows-msvc }
+          - { os: windows-11-arm, rust_target: aarch64-pc-windows-msvc }
+    runs-on: ${{ matrix.os }}
+    name: native Windows (${{ matrix.rust_target }})
+    defaults:
+      run:
+        working-directory: node
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6
+        with:
+          package_json_file: node/package.json
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          node-version: "22"
+          cache: pnpm
+          cache-dependency-path: node/pnpm-lock.yaml
+      - uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88 # master
+        with:
+          toolchain: stable
+          targets: ${{ matrix.rust_target }}
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm build:native
+        env:
+          FERROMARK_RUST_TARGET: ${{ matrix.rust_target }}

--- a/node/ferromark/scripts/build-native.mjs
+++ b/node/ferromark/scripts/build-native.mjs
@@ -25,6 +25,8 @@ args.push('--', '--locked')
 
 const result = spawnSync(pnpm, args, {
   cwd: new URL('..', import.meta.url),
+  // Windows command shims such as pnpm.cmd require cmd.exe for spawning.
+  shell: process.platform === 'win32',
   stdio: 'inherit',
 })
 


### PR DESCRIPTION
## Cause

Release v0.3.1 failed before N-API compilation on both Windows targets because
Node tried to spawn `pnpm.cmd` without a shell, producing
`spawnSync pnpm.cmd EINVAL`.

## Fix

- Run the Windows pnpm command shim through cmd.exe.
- Add the release's x64 and ARM64 Windows native-build matrix to PR CI.

## Recovery

After CI, merge this patch and let Release Please create the follow-up patch
release. The existing v0.3.1 GitHub release has no published npm/crates
artifacts because publication was skipped.
