### PR TITLE
fix(release): pass package validation arguments directly

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -167,7 +167,7 @@ jobs:
           pnpm test
           pnpm typecheck
           pnpm lint
-          pnpm pack:check -- --all-targets
+          node ./scripts/verify-pack.mjs --all-targets
           pnpm smoke:clean
 
       - name: Publish to npm with trusted publishing


### PR DESCRIPTION
## Summary

Fixes the release-only package validation command so `--all-targets` reaches `verify-pack.mjs` exactly once.

The v0.3.2 publish workflow built every native artifact successfully, including both Windows targets, but stopped before publishing because pnpm forwarded an extra argument separator.

## Validation

- `node --check node/scripts/verify-pack.mjs`
- `./scripts/check-workflow-pins.sh`
- Direct invocation reaches package-content validation locally; it cannot complete without the release workflow's downloaded native artifacts.
