### PR TITLE
feat(mdx): add source-spanned segments

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,6 +259,11 @@ for seg in segment(input) {
 
 The segmenter handles JSX attribute parsing (strings, expressions, spreads), brace-depth tracking (with string/comment/template-literal awareness), fragment syntax, member expressions (`<Foo.Bar>`), and multiline tags. Invalid constructs fall back to Markdown — no panics, always valid output.
 
+For source locations, `segment_spanned()` returns the same zero-copy segments
+with contiguous [`Range`](https://docs.rs/ferromark/latest/ferromark/struct.Range.html)
+values into the original UTF-8 input. A range covers the exact segment text,
+including delimiters and a trailing newline when it belongs to that segment.
+
 Full example: `cargo run --features mdx --example mdx_segment`
 
 <details>

--- a/src/mdx/mod.rs
+++ b/src/mdx/mod.rs
@@ -105,12 +105,69 @@ pub enum Segment<'a> {
     Expression(&'a str),
 }
 
+/// A typed MDX segment together with its exact byte range in the input.
+///
+/// The range covers precisely the bytes in [`Self::segment`], including
+/// delimiters, indentation, and a trailing line ending when the segmenter
+/// includes one. The returned ranges are ordered, contiguous, and cover the
+/// complete input without gaps or overlap.
+///
+/// Like [`Segment`], this type borrows from the input and performs no copying.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SpannedSegment<'a> {
+    /// The zero-copy MDX segment.
+    pub segment: Segment<'a>,
+    /// Exact UTF-8 byte range of [`Self::segment`] in the original input.
+    pub range: crate::Range,
+}
+
 /// Segment an MDX document into typed blocks.
 ///
 /// This is the primary entry point. The returned segments cover the entire
 /// input — no bytes are dropped.
 pub fn segment(input: &str) -> Vec<Segment<'_>> {
     splitter::split(input)
+}
+
+/// Segment an MDX document and retain exact byte ranges for each segment.
+///
+/// This is the source-location-aware counterpart to [`segment`]. It has the
+/// same segmentation semantics, while each result records its position in the
+/// original UTF-8 input. The range includes every byte represented by the
+/// segment, including MDX delimiters and any trailing newline owned by that
+/// segment.
+///
+/// # Panics
+///
+/// Panics when `input` is larger than [`u32::MAX`] bytes, matching the size
+/// limit of [`crate::Range`].
+pub fn segment_spanned(input: &str) -> Vec<SpannedSegment<'_>> {
+    let mut start = 0;
+
+    segment(input)
+        .into_iter()
+        .map(|segment| {
+            let end = start + segment.as_str().len();
+            let range = crate::Range::from_usize(start, end);
+            start = end;
+            SpannedSegment { segment, range }
+        })
+        .collect()
+}
+
+impl<'a> Segment<'a> {
+    /// Return the source text represented by this segment.
+    #[must_use]
+    pub fn as_str(&self) -> &'a str {
+        match self {
+            Self::Esm(text)
+            | Self::Markdown(text)
+            | Self::JsxBlockOpen(text)
+            | Self::JsxBlockClose(text)
+            | Self::JsxBlockSelfClose(text)
+            | Self::Expression(text) => text,
+        }
+    }
 }
 
 pub use render::{MdxOutput, render, render_with_options};

--- a/src/mdx/mod.rs
+++ b/src/mdx/mod.rs
@@ -125,6 +125,7 @@ pub struct SpannedSegment<'a> {
 ///
 /// This is the primary entry point. The returned segments cover the entire
 /// input — no bytes are dropped.
+#[must_use]
 pub fn segment(input: &str) -> Vec<Segment<'_>> {
     splitter::split(input)
 }
@@ -141,15 +142,19 @@ pub fn segment(input: &str) -> Vec<Segment<'_>> {
 ///
 /// Panics when `input` is larger than [`u32::MAX`] bytes, matching the size
 /// limit of [`crate::Range`].
+#[must_use]
 pub fn segment_spanned(input: &str) -> Vec<SpannedSegment<'_>> {
-    let mut start = 0;
+    let input_start = input.as_ptr() as usize;
 
     segment(input)
         .into_iter()
         .map(|segment| {
-            let end = start + segment.as_str().len();
+            let text = segment.as_str();
+            let start = (text.as_ptr() as usize)
+                .checked_sub(input_start)
+                .expect("MDX segment must borrow from its input");
+            let end = start + text.len();
             let range = crate::Range::from_usize(start, end);
-            start = end;
             SpannedSegment { segment, range }
         })
         .collect()

--- a/tests/mdx_segment_tests.rs
+++ b/tests/mdx_segment_tests.rs
@@ -1,20 +1,13 @@
 #![cfg(feature = "mdx")]
 
 use ferromark::Options;
-use ferromark::mdx::{Segment, render, render_with_options, segment};
+use ferromark::mdx::{Segment, render, render_with_options, segment, segment_spanned};
 
 // ── Helper ───────────────────────────────────────────────────────────
 
 /// Extract the inner &str from any Segment variant.
 fn seg_str<'a>(seg: &Segment<'a>) -> &'a str {
-    match seg {
-        Segment::Esm(s)
-        | Segment::Markdown(s)
-        | Segment::JsxBlockOpen(s)
-        | Segment::JsxBlockClose(s)
-        | Segment::JsxBlockSelfClose(s)
-        | Segment::Expression(s) => s,
-    }
+    seg.as_str()
 }
 
 // ── Basic segmentation ───────────────────────────────────────────────
@@ -37,6 +30,53 @@ fn whitespace_only() {
     let input = "   \n\n   \n";
     let segs = segment(input);
     assert_eq!(segs, vec![Segment::Markdown(input)]);
+}
+
+#[test]
+fn spanned_segments_cover_input_with_exact_byte_ranges() {
+    let input = "import A from 'a'\r\n\r\n# Grüß\r\n\r\n<Card />\r\n\r\n{user.name}\r\n";
+    let segments = segment_spanned(input);
+
+    assert_eq!(segments.len(), 5);
+    assert!(matches!(segments[0].segment, Segment::Esm(_)));
+    assert!(matches!(segments[1].segment, Segment::Markdown(_)));
+    assert!(matches!(segments[2].segment, Segment::JsxBlockSelfClose(_)));
+    assert!(matches!(segments[3].segment, Segment::Markdown(_)));
+    assert!(matches!(segments[4].segment, Segment::Expression(_)));
+
+    let mut expected_start = 0;
+    let mut reconstructed = String::new();
+    for spanned in &segments {
+        assert_eq!(spanned.range.start_usize(), expected_start);
+        assert_eq!(
+            spanned.range.slice_str(input.as_bytes()).unwrap(),
+            spanned.segment.as_str()
+        );
+        assert_eq!(
+            spanned.range.end_usize() - spanned.range.start_usize(),
+            spanned.segment.as_str().len()
+        );
+        expected_start = spanned.range.end_usize();
+        reconstructed.push_str(spanned.segment.as_str());
+    }
+
+    assert_eq!(expected_start, input.len());
+    assert_eq!(reconstructed, input);
+}
+
+#[test]
+fn spanned_segments_match_existing_segment_api() {
+    let input = "---\ntitle: Hello\n---\n\n<Layout>\n\n# Heading\n\n</Layout>\n";
+    let existing = segment(input);
+    let spanned = segment_spanned(input);
+
+    assert_eq!(
+        spanned
+            .into_iter()
+            .map(|segment| segment.segment)
+            .collect::<Vec<_>>(),
+        existing
+    );
 }
 
 // ── ESM ──────────────────────────────────────────────────────────────


### PR DESCRIPTION
Closes #85

## What changed

- add `segment_spanned()` and `SpannedSegment` for exact UTF-8 byte ranges
- preserve the existing `segment()` API and segmentation behavior
- document delimiter and trailing-newline range ownership

## Validation

- `cargo fmt --check`
- `cargo test --features mdx`
- `cargo clippy --all-targets --all-features -- -D warnings`