### PR TITLE
fix(ci): use portable Linux CPU target

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -6,11 +6,6 @@ rustflags = [
     "-C", "target-feature=+neon",
 ]
 
-[target.x86_64-unknown-linux-gnu]
-rustflags = [
-    "-C", "target-cpu=native",
-]
-
 [target.x86_64-apple-darwin]
 rustflags = [
     "-C", "target-cpu=native",


### PR DESCRIPTION
## What changed

Remove the Linux-wide `target-cpu=native` flag from Cargo configuration.

## Why

GitHub Actions restores `target/` caches across runner hardware. Native CPU code from a previous runner can therefore execute unsupported instructions on a later Ubuntu runner, causing intermittent `SIGILL` test failures.

## Impact

Linux CI now uses Rust's portable default CPU target while local macOS tuning remains unchanged.

## Validation

- `cargo test --locked --all-features`
- `cargo clippy --all-targets --all-features --locked -- -D warnings`