### PR TITLE
feat(mdx): add strict diagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,6 +264,26 @@ with contiguous [`Range`](https://docs.rs/ferromark/latest/ferromark/struct.Rang
 values into the original UTF-8 input. A range covers the exact segment text,
 including delimiters and a trailing newline when it belongs to that segment.
 
+`segment()` remains deliberately permissive: malformed MDX falls back to a
+Markdown segment. For content pipelines that must reject malformed structure,
+use `segment_strict()`. It reports typed diagnostics with byte ranges; convert
+an offset to a one-based line and Unicode column only when presenting it to a
+user with `source_location()`.
+
+```rust
+use ferromark::mdx::{segment_strict, source_location};
+
+let input = "<Card bad=>\n";
+let diagnostics = segment_strict(input).unwrap_err();
+let location = source_location(input, diagnostics[0].primary_range.start_usize());
+assert_eq!((location.line, location.column), (1, 1));
+```
+
+Strict mode checks MDX structure (flow-expression delimiters, JSX tag shape and
+nesting, and ESM placement). It intentionally does not parse or type-check
+JavaScript or TypeScript inside an otherwise well-delimited ESM block or
+expression.
+
 Full example: `cargo run --features mdx --example mdx_segment`
 
 <details>
@@ -282,7 +302,7 @@ What the segmenter deliberately skips — and why that's fine for most use cases
 | **Markdown grammar** | Standard CommonMark/GFM rules | Official mdxjs disables indented code and HTML syntax — relevant if your content relies on `<div>` being JSX, not HTML |
 | **Container nesting** | `> <Component>` stays Markdown | Only if you put JSX inside blockquotes or list items — uncommon |
 | **TypeScript generics** | `<Component<T>>` not parsed | Only relevant for TSX-heavy content pages — very rare in docs |
-| **Error reporting** | Silent fallback to Markdown | Means broken JSX renders as text instead of failing — arguably safer for content pipelines |
+| **Error reporting** | Permissive fallback by default; opt-in structural diagnostics with `segment_strict()` | Use strict mode when broken MDX must fail a content pipeline |
 
 The full `@mdx-js/mdx` compiler exists to produce a React component tree from MDX. It needs a JavaScript parser because it compiles to JSX. ferromark's segmenter exists to answer a simpler question: *where does the Markdown stop and the JSX start?* That question doesn't need a JS runtime.
 

--- a/src/mdx/mod.rs
+++ b/src/mdx/mod.rs
@@ -78,13 +78,17 @@
 //!
 //! ## Silent fallback instead of errors
 //!
-//! Invalid JSX or unterminated expressions are silently treated as Markdown.
-//! The official compiler reports parse errors with source positions.
+//! [`segment`] and [`segment_spanned`] preserve the original permissive
+//! behavior: invalid JSX or unterminated expressions are treated as Markdown.
+//! [`segment_strict`] is an opt-in validation pass that returns structural MDX
+//! diagnostics with source ranges instead. It does not validate JavaScript or
+//! TypeScript syntax inside otherwise well-delimited ESM and expressions.
 
 pub mod expr;
 pub mod jsx_tag;
 pub mod render;
 mod splitter;
+mod strict;
 
 /// A typed segment of an MDX document.
 ///
@@ -119,6 +123,51 @@ pub struct SpannedSegment<'a> {
     pub segment: Segment<'a>,
     /// Exact UTF-8 byte range of [`Self::segment`] in the original input.
     pub range: crate::Range,
+}
+
+/// A stable category for a structural MDX diagnostic.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MdxDiagnosticCode {
+    /// A flow expression has no closing `}`.
+    UnterminatedExpression,
+    /// A JSX tag has no closing `>`.
+    UnterminatedJsxTag,
+    /// A JSX tag has an invalid name, attribute, or closing-tag structure.
+    InvalidJsxTag,
+    /// A closing JSX tag does not have a matching opening tag.
+    UnexpectedJsxClosingTag,
+    /// A closing JSX tag does not match the innermost opening tag.
+    MismatchedJsxClosingTag,
+    /// An opening JSX tag is not closed before the end of the document.
+    UnclosedJsxTag,
+    /// An ESM block is indented or interrupts a Markdown paragraph.
+    InvalidEsmPosition,
+}
+
+/// A structural MDX diagnostic returned by [`segment_strict`].
+///
+/// `primary_range` is always a valid UTF-8 byte range into the original input.
+/// `related_range` identifies the corresponding opening tag for a mismatched
+/// JSX closing tag.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct MdxDiagnostic {
+    /// Stable machine-readable diagnostic category.
+    pub code: MdxDiagnosticCode,
+    /// Concise human-readable explanation.
+    pub message: &'static str,
+    /// Primary source range for this diagnostic.
+    pub primary_range: crate::Range,
+    /// Related source range when a second location helps explain the error.
+    pub related_range: Option<crate::Range>,
+}
+
+/// A one-based source location derived from a UTF-8 byte offset.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SourceLocation {
+    /// One-based line number.
+    pub line: u32,
+    /// One-based Unicode scalar column number.
+    pub column: u32,
 }
 
 /// Segment an MDX document into typed blocks.
@@ -158,6 +207,57 @@ pub fn segment_spanned(input: &str) -> Vec<SpannedSegment<'_>> {
             SpannedSegment { segment, range }
         })
         .collect()
+}
+
+/// Validate structural MDX and return source-spanned segments on success.
+///
+/// This opt-in API adds diagnostics for malformed flow expressions, malformed
+/// JSX tags, JSX tag nesting, and ESM blocks at invalid boundaries. The
+/// permissive [`segment`] APIs deliberately retain their silent Markdown
+/// fallback. JavaScript and TypeScript inside a correctly delimited expression
+/// or ESM block are not parsed or type-checked.
+///
+/// When a malformed construct makes later segmentation ambiguous, validation
+/// stops at that construct. Otherwise, independent diagnostics are collected.
+///
+/// # Panics
+///
+/// Panics when `input` is larger than [`u32::MAX`] bytes, matching the size
+/// limit of [`crate::Range`].
+pub fn segment_strict(input: &str) -> Result<Vec<SpannedSegment<'_>>, Vec<MdxDiagnostic>> {
+    strict::segment_strict(input)
+}
+
+/// Translate a UTF-8 byte offset into a one-based line and Unicode scalar column.
+///
+/// `byte_offset` must be at a UTF-8 character boundary and may equal
+/// `input.len()`. Diagnostic range boundaries returned by [`segment_strict`]
+/// always meet that requirement.
+///
+/// # Panics
+///
+/// Panics when `byte_offset` is greater than `input.len()` or is not a UTF-8
+/// character boundary.
+#[must_use]
+pub fn source_location(input: &str, byte_offset: usize) -> SourceLocation {
+    assert!(
+        byte_offset <= input.len(),
+        "byte offset is outside the input"
+    );
+    assert!(
+        input.is_char_boundary(byte_offset),
+        "byte offset is not a UTF-8 character boundary"
+    );
+
+    let before = &input[..byte_offset];
+    let line = before.bytes().filter(|byte| *byte == b'\n').count() + 1;
+    let line_start = before.rfind('\n').map_or(0, |offset| offset + 1);
+    let column = input[line_start..byte_offset].chars().count() + 1;
+
+    SourceLocation {
+        line: u32::try_from(line).expect("line number exceeds u32::MAX"),
+        column: u32::try_from(column).expect("column number exceeds u32::MAX"),
+    }
 }
 
 impl<'a> Segment<'a> {

--- a/src/mdx/mod.rs
+++ b/src/mdx/mod.rs
@@ -147,8 +147,8 @@ pub enum MdxDiagnosticCode {
 /// A structural MDX diagnostic returned by [`segment_strict`].
 ///
 /// `primary_range` is always a valid UTF-8 byte range into the original input.
-/// `related_range` identifies the corresponding opening tag for a mismatched
-/// JSX closing tag.
+/// For a mismatched JSX closing tag, `related_range` identifies the innermost
+/// opening tag that the closing tag cannot close past.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct MdxDiagnostic {
     /// Stable machine-readable diagnostic category.
@@ -157,7 +157,7 @@ pub struct MdxDiagnostic {
     pub message: &'static str,
     /// Primary source range for this diagnostic.
     pub primary_range: crate::Range,
-    /// Related source range when a second location helps explain the error.
+    /// Related source range for a mismatched JSX closing tag's blocking opening tag.
     pub related_range: Option<crate::Range>,
 }
 

--- a/src/mdx/splitter.rs
+++ b/src/mdx/splitter.rs
@@ -222,22 +222,15 @@ fn consume_trailing_newline(bytes: &[u8], mut pos: usize) -> usize {
 /// look like a continuation.
 ///
 /// Returns the byte offset after the ESM block, or `None` if not ESM.
-fn try_esm(bytes: &[u8], pos: usize) -> Option<usize> {
+pub(crate) fn try_esm(bytes: &[u8], pos: usize) -> Option<usize> {
     let len = bytes.len();
     let rest = &bytes[pos..];
 
-    let is_import = rest.starts_with(b"import ")
-        || rest.starts_with(b"import\t")
-        || rest.starts_with(b"import{")
-        || (rest.len() >= 7 && rest.starts_with(b"import\""))
-        || (rest.len() >= 7 && rest.starts_with(b"import'"));
-    let is_export = rest.starts_with(b"export ")
-        || rest.starts_with(b"export\t")
-        || rest.starts_with(b"export{");
-
-    if !is_import && !is_export {
+    if !is_esm_start(rest) {
         return None;
     }
+
+    let is_import = rest.starts_with(b"import");
 
     // Reject dynamic imports: `import(`, `import (`, `import.`
     if is_import {
@@ -296,6 +289,33 @@ fn try_esm(bytes: &[u8], pos: usize) -> Option<usize> {
     }
 
     Some(end)
+}
+
+/// Check whether bytes start with a static `import` or `export` declaration.
+///
+/// This recognises the same declaration prefixes as [`try_esm`] and excludes
+/// dynamic imports and `import.meta` access.
+pub(crate) fn is_esm_start(rest: &[u8]) -> bool {
+    let is_import = rest.starts_with(b"import ")
+        || rest.starts_with(b"import\t")
+        || rest.starts_with(b"import{")
+        || (rest.len() >= 7 && rest.starts_with(b"import\""))
+        || (rest.len() >= 7 && rest.starts_with(b"import'"));
+    let is_export = rest.starts_with(b"export ")
+        || rest.starts_with(b"export\t")
+        || rest.starts_with(b"export{");
+
+    if !is_import && !is_export {
+        return false;
+    }
+
+    if is_import {
+        let after_import = skip_whitespace_offset(rest, 6); // "import".len() == 6
+        return after_import >= rest.len()
+            || (rest[after_import] != b'(' && rest[after_import] != b'.');
+    }
+
+    true
 }
 
 #[cfg(test)]

--- a/src/mdx/splitter.rs
+++ b/src/mdx/splitter.rs
@@ -230,16 +230,6 @@ pub(crate) fn try_esm(bytes: &[u8], pos: usize) -> Option<usize> {
         return None;
     }
 
-    let is_import = rest.starts_with(b"import");
-
-    // Reject dynamic imports: `import(`, `import (`, `import.`
-    if is_import {
-        let after_import = skip_whitespace_offset(rest, 6); // "import".len() == 6
-        if after_import < rest.len() && (rest[after_import] == b'(' || rest[after_import] == b'.') {
-            return None;
-        }
-    }
-
     // Find the end of the ESM statement.
     // Simple heuristic: accumulate lines until we see a blank line,
     // or the first line ends with a semicolon/newline.

--- a/src/mdx/strict.rs
+++ b/src/mdx/strict.rs
@@ -11,6 +11,8 @@ const UNEXPECTED_JSX_CLOSING_TAG: &str = "closing JSX tag has no matching openin
 const MISMATCHED_JSX_CLOSING_TAG: &str = "closing JSX tag does not match the innermost opening tag";
 const UNCLOSED_JSX_TAG: &str = "expected a matching closing JSX tag";
 const INVALID_ESM_POSITION: &str = "ESM blocks must begin at column 1 after a blank Markdown line";
+// Both `import` and `export` are six bytes; diagnostics highlight just the keyword.
+const ESM_KEYWORD_LEN: usize = 6;
 
 #[derive(Debug)]
 struct OpenTag {
@@ -63,7 +65,7 @@ fn validate(input: &str) -> Vec<MdxDiagnostic> {
                 MdxDiagnosticCode::InvalidEsmPosition,
                 INVALID_ESM_POSITION,
                 first_non_ws,
-                first_non_ws + "import".len(),
+                first_non_ws + ESM_KEYWORD_LEN,
                 None,
             ));
             in_paragraph = true;

--- a/src/mdx/strict.rs
+++ b/src/mdx/strict.rs
@@ -1,0 +1,381 @@
+use super::expr::find_expression_end;
+use super::jsx_tag::parse_jsx_tag;
+use super::splitter::{is_esm_start, try_esm};
+use super::{MdxDiagnostic, MdxDiagnosticCode, SpannedSegment, segment_spanned};
+use crate::Range;
+
+const UNTERMINATED_EXPRESSION: &str = "expected `}` to close this flow expression";
+const UNTERMINATED_JSX_TAG: &str = "expected `>` to close this JSX tag";
+const INVALID_JSX_TAG: &str = "invalid JSX tag structure";
+const UNEXPECTED_JSX_CLOSING_TAG: &str = "closing JSX tag has no matching opening tag";
+const MISMATCHED_JSX_CLOSING_TAG: &str = "closing JSX tag does not match the innermost opening tag";
+const UNCLOSED_JSX_TAG: &str = "expected a matching closing JSX tag";
+const INVALID_ESM_POSITION: &str = "ESM blocks must begin at column 1 after a blank Markdown line";
+
+#[derive(Debug)]
+struct OpenTag {
+    name: String,
+    range: Range,
+}
+
+pub(super) fn segment_strict(input: &str) -> Result<Vec<SpannedSegment<'_>>, Vec<MdxDiagnostic>> {
+    let diagnostics = validate(input);
+    if diagnostics.is_empty() {
+        Ok(segment_spanned(input))
+    } else {
+        Err(diagnostics)
+    }
+}
+
+fn validate(input: &str) -> Vec<MdxDiagnostic> {
+    let bytes = input.as_bytes();
+    let len = bytes.len();
+    let mut diagnostics = Vec::new();
+    let mut open_tags = Vec::new();
+    let mut in_paragraph = false;
+    let mut pos = 0;
+
+    while pos < len {
+        let line_start = pos;
+        let first_non_ws = skip_indentation(bytes, pos);
+
+        if first_non_ws >= len {
+            break;
+        }
+
+        let first = bytes[first_non_ws];
+        if first == b'\n' || first == b'\r' {
+            in_paragraph = false;
+            pos = next_line(bytes, pos);
+            continue;
+        }
+
+        if first_non_ws == pos && !in_paragraph {
+            if let Some(esm_end) = try_esm(bytes, pos) {
+                in_paragraph = false;
+                pos = esm_end;
+                continue;
+            }
+        }
+
+        if is_esm_start(&bytes[first_non_ws..]) {
+            diagnostics.push(diagnostic(
+                MdxDiagnosticCode::InvalidEsmPosition,
+                INVALID_ESM_POSITION,
+                first_non_ws,
+                first_non_ws + "import".len(),
+                None,
+            ));
+            in_paragraph = true;
+            pos = next_line(bytes, pos);
+            continue;
+        }
+
+        if first == b'{' {
+            match find_expression_end(&bytes[first_non_ws..]) {
+                Some(expression_len) => {
+                    let end = first_non_ws + expression_len;
+                    if !has_trailing_content(bytes, end) {
+                        in_paragraph = false;
+                        pos = consume_trailing_newline(bytes, end);
+                        continue;
+                    }
+                }
+                None => {
+                    diagnostics.push(diagnostic(
+                        MdxDiagnosticCode::UnterminatedExpression,
+                        UNTERMINATED_EXPRESSION,
+                        first_non_ws,
+                        len,
+                        None,
+                    ));
+                    break;
+                }
+            }
+        }
+
+        if is_jsx_candidate(bytes, first_non_ws) {
+            if let Some(tag) = parse_jsx_tag(&bytes[first_non_ws..]) {
+                let end = first_non_ws + tag.end_offset;
+                if !has_trailing_content(bytes, end) {
+                    let range = Range::from_usize(first_non_ws, end);
+                    if has_empty_attribute_value(&bytes[first_non_ws..end]) {
+                        diagnostics.push(MdxDiagnostic {
+                            code: MdxDiagnosticCode::InvalidJsxTag,
+                            message: INVALID_JSX_TAG,
+                            primary_range: range,
+                            related_range: None,
+                        });
+                    } else if tag.is_closing {
+                        validate_closing_tag(&mut diagnostics, &mut open_tags, tag.name, range);
+                    } else if !tag.is_self_closing {
+                        open_tags.push(OpenTag {
+                            name: tag.name.to_owned(),
+                            range,
+                        });
+                    }
+                    in_paragraph = false;
+                    pos = consume_trailing_newline(bytes, end);
+                    continue;
+                }
+            } else if let Some(expression_start) = unterminated_tag_expression(bytes, first_non_ws)
+            {
+                diagnostics.push(diagnostic(
+                    MdxDiagnosticCode::UnterminatedExpression,
+                    UNTERMINATED_EXPRESSION,
+                    expression_start,
+                    len,
+                    None,
+                ));
+                break;
+            } else if let Some(end) = find_tag_terminator(bytes, first_non_ws) {
+                diagnostics.push(diagnostic(
+                    MdxDiagnosticCode::InvalidJsxTag,
+                    INVALID_JSX_TAG,
+                    first_non_ws,
+                    end,
+                    None,
+                ));
+                in_paragraph = false;
+                pos = consume_trailing_newline(bytes, end);
+                continue;
+            } else {
+                diagnostics.push(diagnostic(
+                    MdxDiagnosticCode::UnterminatedJsxTag,
+                    UNTERMINATED_JSX_TAG,
+                    first_non_ws,
+                    len,
+                    None,
+                ));
+                break;
+            }
+        }
+
+        in_paragraph = true;
+        pos = next_line(bytes, line_start);
+    }
+
+    diagnostics.extend(open_tags.into_iter().map(|tag| MdxDiagnostic {
+        code: MdxDiagnosticCode::UnclosedJsxTag,
+        message: UNCLOSED_JSX_TAG,
+        primary_range: tag.range,
+        related_range: None,
+    }));
+    diagnostics
+}
+
+fn validate_closing_tag(
+    diagnostics: &mut Vec<MdxDiagnostic>,
+    open_tags: &mut Vec<OpenTag>,
+    name: &str,
+    range: Range,
+) {
+    let Some(top) = open_tags.last() else {
+        diagnostics.push(MdxDiagnostic {
+            code: MdxDiagnosticCode::UnexpectedJsxClosingTag,
+            message: UNEXPECTED_JSX_CLOSING_TAG,
+            primary_range: range,
+            related_range: None,
+        });
+        return;
+    };
+
+    if top.name == name {
+        open_tags.pop();
+        return;
+    }
+
+    diagnostics.push(MdxDiagnostic {
+        code: MdxDiagnosticCode::MismatchedJsxClosingTag,
+        message: MISMATCHED_JSX_CLOSING_TAG,
+        primary_range: range,
+        related_range: Some(top.range),
+    });
+
+    if let Some(match_index) = open_tags.iter().rposition(|tag| tag.name == name) {
+        open_tags.truncate(match_index);
+    }
+}
+
+fn diagnostic(
+    code: MdxDiagnosticCode,
+    message: &'static str,
+    start: usize,
+    end: usize,
+    related_range: Option<Range>,
+) -> MdxDiagnostic {
+    MdxDiagnostic {
+        code,
+        message,
+        primary_range: Range::from_usize(start, end),
+        related_range,
+    }
+}
+
+fn is_jsx_candidate(bytes: &[u8], start: usize) -> bool {
+    if bytes.get(start) != Some(&b'<') {
+        return false;
+    }
+
+    bytes
+        .get(start + 1)
+        .is_some_and(|byte| *byte == b'/' || *byte == b'>' || byte.is_ascii_alphabetic())
+}
+
+fn unterminated_tag_expression(bytes: &[u8], start: usize) -> Option<usize> {
+    let mut pos = start + 1;
+    while pos < bytes.len() {
+        match bytes[pos] {
+            b'>' => return None,
+            b'"' | b'\'' => pos = skip_quoted(bytes, pos)?,
+            b'{' => match find_expression_end(&bytes[pos..]) {
+                Some(length) => pos += length,
+                None => return Some(pos),
+            },
+            _ => pos += 1,
+        }
+    }
+    None
+}
+
+fn find_tag_terminator(bytes: &[u8], start: usize) -> Option<usize> {
+    let mut pos = start + 1;
+    while pos < bytes.len() {
+        match bytes[pos] {
+            b'>' => return Some(pos + 1),
+            b'"' | b'\'' => pos = skip_quoted(bytes, pos)?,
+            b'{' => pos += find_expression_end(&bytes[pos..])?,
+            _ => pos += 1,
+        }
+    }
+    None
+}
+
+fn has_empty_attribute_value(tag: &[u8]) -> bool {
+    let mut pos = 1;
+    if tag.get(pos) == Some(&b'/') {
+        return false;
+    }
+    if tag.get(pos) == Some(&b'>') {
+        return false;
+    }
+
+    while matches!(
+        tag.get(pos),
+        Some(byte) if byte.is_ascii_alphanumeric() || matches!(*byte, b'_' | b'-' | b'.' | b':')
+    ) {
+        pos += 1;
+    }
+
+    while pos < tag.len() {
+        pos = skip_whitespace(tag, pos);
+        if matches!(tag.get(pos), Some(b'>') | Some(b'/')) {
+            return false;
+        }
+        if tag.get(pos) == Some(&b'{') {
+            let Some(length) = find_expression_end(&tag[pos..]) else {
+                return false;
+            };
+            pos += length;
+            continue;
+        }
+
+        while matches!(
+            tag.get(pos),
+            Some(byte)
+                if byte.is_ascii_alphanumeric() || matches!(*byte, b'_' | b'-' | b'.' | b':')
+        ) {
+            pos += 1;
+        }
+        pos = skip_whitespace(tag, pos);
+        if tag.get(pos) != Some(&b'=') {
+            continue;
+        }
+        pos = skip_whitespace(tag, pos + 1);
+        if matches!(tag.get(pos), Some(b'>'))
+            || (tag.get(pos) == Some(&b'/') && tag.get(pos + 1) == Some(&b'>'))
+        {
+            return true;
+        }
+
+        match tag.get(pos) {
+            Some(b'"' | b'\'') => {
+                let Some(next) = skip_quoted(tag, pos) else {
+                    return false;
+                };
+                pos = next;
+            }
+            Some(b'{') => {
+                let Some(length) = find_expression_end(&tag[pos..]) else {
+                    return false;
+                };
+                pos += length;
+            }
+            Some(_) => {
+                while matches!(
+                    tag.get(pos),
+                    Some(byte) if !byte.is_ascii_whitespace() && !matches!(*byte, b'>' | b'/')
+                ) {
+                    pos += 1;
+                }
+            }
+            None => return false,
+        }
+    }
+
+    false
+}
+
+fn skip_quoted(bytes: &[u8], start: usize) -> Option<usize> {
+    let quote = bytes[start];
+    let mut pos = start + 1;
+    while pos < bytes.len() {
+        match bytes[pos] {
+            b'\\' => pos += 2,
+            byte if byte == quote => return Some(pos + 1),
+            _ => pos += 1,
+        }
+    }
+    None
+}
+
+fn skip_whitespace(bytes: &[u8], mut pos: usize) -> usize {
+    while matches!(bytes.get(pos), Some(byte) if byte.is_ascii_whitespace()) {
+        pos += 1;
+    }
+    pos
+}
+
+fn skip_indentation(bytes: &[u8], mut pos: usize) -> usize {
+    while matches!(bytes.get(pos), Some(b' ' | b'\t')) {
+        pos += 1;
+    }
+    pos
+}
+
+fn next_line(bytes: &[u8], mut pos: usize) -> usize {
+    while pos < bytes.len() && bytes[pos] != b'\n' {
+        pos += 1;
+    }
+    if pos < bytes.len() { pos + 1 } else { pos }
+}
+
+fn has_trailing_content(bytes: &[u8], mut pos: usize) -> bool {
+    while matches!(bytes.get(pos), Some(b' ' | b'\t')) {
+        pos += 1;
+    }
+    matches!(bytes.get(pos), Some(byte) if *byte != b'\n' && *byte != b'\r')
+}
+
+fn consume_trailing_newline(bytes: &[u8], mut pos: usize) -> usize {
+    while matches!(bytes.get(pos), Some(b' ' | b'\t')) {
+        pos += 1;
+    }
+    if bytes.get(pos) == Some(&b'\r') {
+        pos += 1;
+    }
+    if bytes.get(pos) == Some(&b'\n') {
+        pos += 1;
+    }
+    pos
+}

--- a/tests/mdx_segment_tests.rs
+++ b/tests/mdx_segment_tests.rs
@@ -1,7 +1,10 @@
 #![cfg(feature = "mdx")]
 
 use ferromark::Options;
-use ferromark::mdx::{Segment, render, render_with_options, segment, segment_spanned};
+use ferromark::mdx::{
+    MdxDiagnosticCode, Segment, render, render_with_options, segment, segment_spanned,
+    segment_strict, source_location,
+};
 
 // ── Helper ───────────────────────────────────────────────────────────
 
@@ -76,6 +79,168 @@ fn spanned_segments_match_existing_segment_api() {
             .map(|segment| segment.segment)
             .collect::<Vec<_>>(),
         existing
+    );
+}
+
+// ── Strict diagnostics ──────────────────────────────────────────────
+
+#[test]
+fn strict_mode_returns_the_existing_spanned_segments_for_valid_mdx() {
+    let input = "import A from 'a'\n\n<Card>\n{user.name}\n</Card>\n";
+
+    assert_eq!(segment_strict(input).unwrap(), segment_spanned(input));
+}
+
+#[test]
+fn strict_mode_keeps_permissive_segmentation_unchanged() {
+    let input = "<Card bad=>\n";
+
+    assert_eq!(segment(input), vec![Segment::JsxBlockOpen(input)]);
+    assert_eq!(
+        segment_strict(input).unwrap_err()[0].code,
+        MdxDiagnosticCode::InvalidJsxTag
+    );
+}
+
+#[test]
+fn strict_mode_reports_unterminated_expression_with_its_source_range() {
+    let input = "# Heading\n\n{user.name\n";
+    let diagnostics = segment_strict(input).unwrap_err();
+
+    assert_eq!(diagnostics.len(), 1);
+    assert_eq!(
+        diagnostics[0].code,
+        MdxDiagnosticCode::UnterminatedExpression
+    );
+    assert_eq!(
+        diagnostics[0]
+            .primary_range
+            .slice_str(input.as_bytes())
+            .unwrap(),
+        "{user.name\n"
+    );
+    assert!(diagnostics[0].message.contains("expected `}`"));
+}
+
+#[test]
+fn strict_mode_reports_unterminated_jsx_tag_with_its_source_range() {
+    let input = "<Card title=\"example\"";
+    let diagnostics = segment_strict(input).unwrap_err();
+
+    assert_eq!(diagnostics.len(), 1);
+    assert_eq!(diagnostics[0].code, MdxDiagnosticCode::UnterminatedJsxTag);
+    assert_eq!(
+        diagnostics[0]
+            .primary_range
+            .slice_str(input.as_bytes())
+            .unwrap(),
+        input
+    );
+    assert!(diagnostics[0].message.contains("expected `>`"));
+}
+
+#[test]
+fn strict_mode_accumulates_independent_diagnostics() {
+    let input = "<Card bad=>\n\n{user.name\n";
+    let diagnostics = segment_strict(input).unwrap_err();
+
+    assert_eq!(
+        diagnostics
+            .iter()
+            .map(|diagnostic| diagnostic.code)
+            .collect::<Vec<_>>(),
+        vec![
+            MdxDiagnosticCode::InvalidJsxTag,
+            MdxDiagnosticCode::UnterminatedExpression,
+        ]
+    );
+}
+
+#[test]
+fn strict_mode_reports_mismatched_jsx_tags_with_related_opening_range() {
+    let input = "<Outer>\n<Inner>\n</Outer>\n";
+    let diagnostics = segment_strict(input).unwrap_err();
+
+    assert_eq!(diagnostics.len(), 1);
+    assert_eq!(
+        diagnostics[0].code,
+        MdxDiagnosticCode::MismatchedJsxClosingTag
+    );
+    assert_eq!(
+        diagnostics[0]
+            .primary_range
+            .slice_str(input.as_bytes())
+            .unwrap(),
+        "</Outer>"
+    );
+    assert_eq!(
+        diagnostics[0]
+            .related_range
+            .unwrap()
+            .slice_str(input.as_bytes())
+            .unwrap(),
+        "<Inner>"
+    );
+}
+
+#[test]
+fn strict_mode_reports_an_unmatched_jsx_closing_tag() {
+    let input = "</Card>\n";
+    let diagnostics = segment_strict(input).unwrap_err();
+
+    assert_eq!(diagnostics.len(), 1);
+    assert_eq!(
+        diagnostics[0].code,
+        MdxDiagnosticCode::UnexpectedJsxClosingTag
+    );
+    assert_eq!(
+        diagnostics[0]
+            .primary_range
+            .slice_str(input.as_bytes())
+            .unwrap(),
+        "</Card>"
+    );
+}
+
+#[test]
+fn strict_mode_reports_invalid_esm_boundaries() {
+    let input = "Paragraph\nimport A from 'a'\n";
+    let diagnostics = segment_strict(input).unwrap_err();
+
+    assert_eq!(diagnostics.len(), 1);
+    assert_eq!(diagnostics[0].code, MdxDiagnosticCode::InvalidEsmPosition);
+    assert_eq!(
+        diagnostics[0]
+            .primary_range
+            .slice_str(input.as_bytes())
+            .unwrap(),
+        "import"
+    );
+}
+
+#[test]
+fn strict_mode_does_not_validate_javascript_inside_esm() {
+    let input = "export const = ;\n";
+
+    assert!(segment_strict(input).is_ok());
+}
+
+#[test]
+fn strict_mode_diagnostics_use_utf8_byte_ranges_and_crlf_locations() {
+    let input = "Grüß\r\n\r\n<Card bad=>\r\n";
+    let diagnostics = segment_strict(input).unwrap_err();
+    let diagnostic = &diagnostics[0];
+
+    assert_eq!(
+        diagnostic
+            .primary_range
+            .slice_str(input.as_bytes())
+            .unwrap(),
+        "<Card bad=>"
+    );
+    assert_eq!(
+        source_location(input, diagnostic.primary_range.start_usize()),
+        ferromark::mdx::SourceLocation { line: 3, column: 1 }
     );
 }
 


### PR DESCRIPTION
## Summary

- add `segment_strict()` with structured, source-ranged MDX diagnostics
- preserve the permissive segmentation APIs and document strict-mode scope
- validate flow expressions, JSX tag structure/nesting, and ESM boundaries

## Why

Content pipelines can now reject malformed MDX without a JavaScript parser, while existing callers keep the established fallback behavior.

Closes #86.

## Validation

- `cargo test --all-features`
- `cargo clippy --all-targets --all-features -- -D warnings`
