### PR TITLE
feat(mdx): add inline JSX events

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,7 +297,7 @@ What the segmenter deliberately skips — and why that's fine for most use cases
 
 | What | Our approach | When it matters |
 |---|---|---|
-| **Inline JSX** (`text <em>here</em>`) | Stays inside Markdown segments | Only if you mix JSX and prose on the same line inside a paragraph — rare in practice |
+| **Inline JSX** (`text <em>here</em>`) | Stays in `segment()` Markdown blocks; `InlineParser::parse_mdx()` exposes typed MDX inline events | Use the opt-in inline event stream when a downstream consumer must distinguish prose and components |
 | **JS validation** | Heuristic detection (keyword + brace counting) instead of acorn/swc | Only if you need to report syntax errors in user-authored MDX at parse time |
 | **Markdown grammar** | Standard CommonMark/GFM rules | Official mdxjs disables indented code and HTML syntax — relevant if your content relies on `<div>` being JSX, not HTML |
 | **Container nesting** | `> <Component>` stays Markdown | Only if you put JSX inside blockquotes or list items — uncommon |

--- a/src/inline/event.rs
+++ b/src/inline/event.rs
@@ -107,6 +107,22 @@ pub enum InlineEvent {
 
     /// Display math span (`$$...$$`).
     MathDisplay(Range),
+
+    /// An inline MDX JavaScript expression, including its `{` and `}` delimiters.
+    #[cfg(feature = "mdx")]
+    MdxExpression(Range),
+
+    /// An inline MDX JSX opening tag, including its delimiters.
+    #[cfg(feature = "mdx")]
+    MdxJsxOpen(Range),
+
+    /// An inline MDX JSX closing tag, including its delimiters.
+    #[cfg(feature = "mdx")]
+    MdxJsxClose(Range),
+
+    /// An inline MDX JSX self-closing tag, including its delimiters.
+    #[cfg(feature = "mdx")]
+    MdxJsxSelfClose(Range),
 }
 
 #[cfg(test)]

--- a/src/inline/mod.rs
+++ b/src/inline/mod.rs
@@ -133,6 +133,28 @@ impl InlineParser {
         );
     }
 
+    /// Parse inline Markdown with opt-in MDX expressions and JSX tags.
+    ///
+    /// This keeps the normal Markdown inline grammar intact while exposing
+    /// well-delimited inline MDX constructs as source-ranged [`InlineEvent`]
+    /// variants. Code spans and backslash escapes retain their normal
+    /// precedence, and malformed MDX remains plain text.
+    ///
+    /// Inline HTML is intentionally disabled for this mode so valid JSX tags
+    /// are not consumed as raw HTML before MDX recognition.
+    #[cfg(feature = "mdx")]
+    pub fn parse_mdx(
+        &mut self,
+        text: &[u8],
+        link_refs: Option<&LinkRefStore>,
+        events: &mut Vec<InlineEvent>,
+    ) {
+        self.parse_with_options(
+            text, link_refs, false, true, false, false, false, true, false, None, events,
+        );
+        split_mdx_text_events(text, events);
+    }
+
     /// Parse inline content with configurable inline extensions.
     #[allow(clippy::too_many_arguments)]
     pub fn parse_with_options(
@@ -1426,6 +1448,65 @@ fn has_inline_link_opener(input: &[u8]) -> bool {
 impl Default for InlineParser {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+#[cfg(feature = "mdx")]
+fn split_mdx_text_events(text: &[u8], events: &mut Vec<InlineEvent>) {
+    let original_events = std::mem::take(events);
+    events.reserve(original_events.len());
+
+    for event in original_events {
+        match event {
+            InlineEvent::Text(range) => split_mdx_text_range(text, range, events),
+            event => events.push(event),
+        }
+    }
+}
+
+#[cfg(feature = "mdx")]
+fn split_mdx_text_range(text: &[u8], range: Range, events: &mut Vec<InlineEvent>) {
+    let start = range.start_usize();
+    let end = range.end_usize();
+    let mut pos = start;
+    let mut text_start = start;
+
+    while pos < end {
+        let event = match text[pos] {
+            b'{' => crate::mdx::expr::find_expression_end(&text[pos..end]).map(|length| {
+                (
+                    InlineEvent::MdxExpression(Range::from_usize(pos, pos + length)),
+                    pos + length,
+                )
+            }),
+            b'<' => crate::mdx::jsx_tag::parse_jsx_tag(&text[pos..end]).map(|tag| {
+                let tag_end = pos + tag.end_offset;
+                let event = if tag.is_closing {
+                    InlineEvent::MdxJsxClose(Range::from_usize(pos, tag_end))
+                } else if tag.is_self_closing {
+                    InlineEvent::MdxJsxSelfClose(Range::from_usize(pos, tag_end))
+                } else {
+                    InlineEvent::MdxJsxOpen(Range::from_usize(pos, tag_end))
+                };
+                (event, tag_end)
+            }),
+            _ => None,
+        };
+
+        if let Some((event, event_end)) = event {
+            if text_start < pos {
+                events.push(InlineEvent::Text(Range::from_usize(text_start, pos)));
+            }
+            events.push(event);
+            pos = event_end;
+            text_start = event_end;
+        } else {
+            pos += 1;
+        }
+    }
+
+    if text_start < end {
+        events.push(InlineEvent::Text(Range::from_usize(text_start, end)));
     }
 }
 

--- a/src/inline/mod.rs
+++ b/src/inline/mod.rs
@@ -149,10 +149,11 @@ impl InlineParser {
         link_refs: Option<&LinkRefStore>,
         events: &mut Vec<InlineEvent>,
     ) {
+        let new_events_start = events.len();
         self.parse_with_options(
             text, link_refs, false, true, false, false, false, true, false, None, events,
         );
-        split_mdx_text_events(text, events);
+        split_mdx_text_events(text, events, new_events_start);
     }
 
     /// Parse inline content with configurable inline extensions.
@@ -1452,9 +1453,8 @@ impl Default for InlineParser {
 }
 
 #[cfg(feature = "mdx")]
-fn split_mdx_text_events(text: &[u8], events: &mut Vec<InlineEvent>) {
-    let original_events = std::mem::take(events);
-    events.reserve(original_events.len());
+fn split_mdx_text_events(text: &[u8], events: &mut Vec<InlineEvent>, new_events_start: usize) {
+    let original_events = events.split_off(new_events_start);
 
     for event in original_events {
         match event {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1441,6 +1441,19 @@ fn render_inline_event(
                 writer.write_text_with_entities(range.slice(text));
             }
         }
+        #[cfg(feature = "mdx")]
+        InlineEvent::MdxExpression(range)
+        | InlineEvent::MdxJsxOpen(range)
+        | InlineEvent::MdxJsxClose(range)
+        | InlineEvent::MdxJsxSelfClose(range) => {
+            if in_image {
+                writer.write_escaped_attr(range.slice(text));
+            } else if render_policy == RenderPolicy::Trusted {
+                writer.write_bytes(range.slice(text));
+            } else {
+                writer.write_escaped_text(range.slice(text));
+            }
+        }
         InlineEvent::Code(range) => {
             // In image alt text, just write the code content as plain text
             if in_image {

--- a/src/mdx/mod.rs
+++ b/src/mdx/mod.rs
@@ -31,12 +31,15 @@
 //! documentation (Next.js, Docusaurus, Astro). It intentionally does **not**
 //! replicate the full `@mdx-js/mdx` compiler. The differences:
 //!
-//! ## Block-level only
+//! ## Block-level segmentation
 //!
-//! The segmenter detects JSX and expressions at block level (start of a line).
+//! [`segment`] detects JSX and expressions at block level (start of a line).
 //! Inline JSX (`paragraph with <em>JSX</em> inside`) and inline expressions
-//! (`text {variable} here`) stay inside Markdown segments and are **not**
-//! split out. The official mdxjs compiler handles both flow and text positions.
+//! (`text {variable} here`) stay inside Markdown segments and are **not** split
+//! out. For consumers that need typed inline constructs, the opt-in
+//! [`crate::InlineParser::parse_mdx`] method emits source-ranged MDX inline
+//! events while preserving the surrounding Markdown events. The official mdxjs
+//! compiler handles both flow and text positions in a single parse.
 //!
 //! ## No JavaScript validation
 //!

--- a/src/profiling.rs
+++ b/src/profiling.rs
@@ -126,6 +126,11 @@ pub(crate) fn record_inline_events(events: &[InlineEvent], capacity: usize) {
         for event in events {
             match event {
                 InlineEvent::Text(_) | InlineEvent::Code(_) => counters.inline_text_events += 1,
+                #[cfg(feature = "mdx")]
+                InlineEvent::MdxExpression(_)
+                | InlineEvent::MdxJsxOpen(_)
+                | InlineEvent::MdxJsxClose(_)
+                | InlineEvent::MdxJsxSelfClose(_) => counters.inline_text_events += 1,
                 InlineEvent::LinkStart { .. }
                 | InlineEvent::LinkStartRef { .. }
                 | InlineEvent::LinkEnd

--- a/tests/mdx_inline_tests.rs
+++ b/tests/mdx_inline_tests.rs
@@ -155,3 +155,19 @@ fn malformed_inline_mdx_falls_back_to_text() {
     assert_eq!(events.len(), 1);
     assert_eq!(event_source(input, &events[0]), Some(input));
 }
+
+#[test]
+fn inline_mdx_only_splits_events_added_by_this_call() {
+    let mut parser = InlineParser::new();
+    let mut events = Vec::new();
+
+    parser.parse_mdx(b"First {value}", None, &mut events);
+    let first_events = events.clone();
+    parser.parse_mdx(b"Second <Icon />", None, &mut events);
+
+    assert_eq!(&events[..first_events.len()], first_events);
+    assert!(matches!(
+        events.last(),
+        Some(InlineEvent::MdxJsxSelfClose(_))
+    ));
+}

--- a/tests/mdx_inline_tests.rs
+++ b/tests/mdx_inline_tests.rs
@@ -1,0 +1,157 @@
+#![cfg(feature = "mdx")]
+
+use ferromark::{InlineEvent, InlineParser};
+
+fn parse(input: &str) -> Vec<InlineEvent> {
+    let mut parser = InlineParser::new();
+    let mut events = Vec::new();
+    parser.parse_mdx(input.as_bytes(), None, &mut events);
+    events
+}
+
+fn event_source<'a>(input: &'a str, event: &InlineEvent) -> Option<&'a str> {
+    let range = match event {
+        InlineEvent::Text(range)
+        | InlineEvent::Code(range)
+        | InlineEvent::MdxExpression(range)
+        | InlineEvent::MdxJsxOpen(range)
+        | InlineEvent::MdxJsxClose(range)
+        | InlineEvent::MdxJsxSelfClose(range) => range,
+        _ => return None,
+    };
+    range.slice_str(input.as_bytes()).ok()
+}
+
+#[test]
+fn inline_expressions_are_source_ranged_between_text() {
+    let input = "Hello {user.profile.name}!";
+    let events = parse(input);
+
+    assert_eq!(events.len(), 3);
+    assert_eq!(event_source(input, &events[0]), Some("Hello "));
+    assert_eq!(event_source(input, &events[1]), Some("{user.profile.name}"));
+    assert_eq!(event_source(input, &events[2]), Some("!"));
+    assert!(matches!(events[1], InlineEvent::MdxExpression(_)));
+}
+
+#[test]
+fn inline_expressions_share_the_nested_brace_scanner() {
+    let input = "Heading {format({ value: user.name })}";
+    let events = parse(input);
+
+    assert_eq!(events.len(), 2);
+    assert_eq!(event_source(input, &events[0]), Some("Heading "));
+    assert_eq!(
+        event_source(input, &events[1]),
+        Some("{format({ value: user.name })}")
+    );
+    assert!(matches!(events[1], InlineEvent::MdxExpression(_)));
+}
+
+#[test]
+fn inline_jsx_pairs_and_self_closing_tags_are_typed() {
+    let input = "Read <Badge>the guide</Badge> and <Icon name=\"book\" />.";
+    let events = parse(input);
+
+    let typed = events
+        .iter()
+        .filter_map(|event| match event {
+            InlineEvent::MdxJsxOpen(_)
+            | InlineEvent::MdxJsxClose(_)
+            | InlineEvent::MdxJsxSelfClose(_) => event_source(input, event),
+            _ => None,
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(typed, vec!["<Badge>", "</Badge>", "<Icon name=\"book\" />"]);
+}
+
+#[test]
+fn inline_jsx_reuses_expression_attributes_fragments_and_member_names() {
+    let input = "<><UI.Badge {...props}>{label}</UI.Badge></>";
+    let events = parse(input);
+
+    let typed = events
+        .iter()
+        .filter_map(|event| match event {
+            InlineEvent::MdxExpression(_)
+            | InlineEvent::MdxJsxOpen(_)
+            | InlineEvent::MdxJsxClose(_)
+            | InlineEvent::MdxJsxSelfClose(_) => event_source(input, event),
+            _ => None,
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(
+        typed,
+        vec![
+            "<>",
+            "<UI.Badge {...props}>",
+            "{label}",
+            "</UI.Badge>",
+            "</>"
+        ]
+    );
+}
+
+#[test]
+fn markdown_events_continue_around_inline_mdx() {
+    let input = "*Hello* {user} [guide](/guide) <Icon />";
+    let events = parse(input);
+
+    assert!(matches!(events[0], InlineEvent::EmphasisStart));
+    assert!(matches!(events[2], InlineEvent::EmphasisEnd));
+    assert!(
+        events
+            .iter()
+            .any(|event| matches!(event, InlineEvent::MdxExpression(_)))
+    );
+    assert!(
+        events
+            .iter()
+            .any(|event| matches!(event, InlineEvent::LinkStart { .. }))
+    );
+    assert!(
+        events
+            .iter()
+            .any(|event| matches!(event, InlineEvent::LinkEnd))
+    );
+    assert!(
+        events
+            .iter()
+            .any(|event| matches!(event, InlineEvent::MdxJsxSelfClose(_)))
+    );
+}
+
+#[test]
+fn code_spans_and_escaped_delimiters_remain_non_mdx() {
+    let input = r"`{literal} <Badge>` \{escaped\} \<Tag> {real}";
+    let events = parse(input);
+
+    assert!(
+        events
+            .iter()
+            .any(|event| matches!(event, InlineEvent::Code(_)))
+    );
+    assert!(events.iter().any(|event| matches!(event, InlineEvent::MdxExpression(range) if event_source(input, &InlineEvent::MdxExpression(*range)) == Some("{real}"))));
+    assert_eq!(
+        events
+            .iter()
+            .filter(|event| matches!(
+                event,
+                InlineEvent::MdxExpression(_)
+                    | InlineEvent::MdxJsxOpen(_)
+                    | InlineEvent::MdxJsxClose(_)
+                    | InlineEvent::MdxJsxSelfClose(_)
+            ))
+            .count(),
+        1
+    );
+}
+
+#[test]
+fn malformed_inline_mdx_falls_back_to_text() {
+    let input = "Broken {user and <Badge prop=";
+    let events = parse(input);
+
+    assert_eq!(events.len(), 1);
+    assert_eq!(event_source(input, &events[0]), Some(input));
+}


### PR DESCRIPTION
## Summary

- add an opt-in `InlineParser::parse_mdx()` stream for source-ranged MDX expressions and JSX tags
- reuse the existing expression and JSX scanners, while preserving normal Markdown events around inline MDX
- keep code spans, escapes, malformed input, and the default inline parser behaviour unchanged

Closes #87.

## Validation

- `cargo fmt --check`
- `cargo test --all-features`
- `cargo clippy --all-targets --all-features -- -D warnings`
