### PR TITLE
feat(mdx): add semantic event stream

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,6 +284,32 @@ nesting, and ESM placement). It intentionally does not parse or type-check
 JavaScript or TypeScript inside an otherwise well-delimited ESM block or
 expression.
 
+Compiler and localization consumers can opt into a flat semantic event buffer
+without going through HTML. `parse_events()` composes the existing MDX
+segmenter, block parser, and MDX-aware inline parser; ranges in the returned
+events point into the original input.
+
+```rust
+use ferromark::InlineEvent;
+use ferromark::mdx::{MdxEvent, parse_events};
+
+let input = "# Hello {name}\n";
+let stream = parse_events(input);
+let prose = stream.events.iter().filter_map(|event| match event {
+    MdxEvent::Inline(InlineEvent::Text(range)) => {
+        Some(range.slice_str(input.as_bytes()).unwrap())
+    }
+    _ => None,
+}).collect::<Vec<_>>();
+
+assert_eq!(prose, vec!["Hello "]);
+```
+
+The event path is fully opt-in and does not alter the normal Markdown or MDX
+HTML renderer. `parse_events_strict()` applies the same structural diagnostics
+as `segment_strict()` before producing events. Its strict validation covers
+flow constructs; malformed inline MDX retains the documented text fallback.
+
 Full example: `cargo run --features mdx --example mdx_segment`
 
 <details>
@@ -297,10 +323,10 @@ What the segmenter deliberately skips — and why that's fine for most use cases
 
 | What | Our approach | When it matters |
 |---|---|---|
-| **Inline JSX** (`text <em>here</em>`) | Stays in `segment()` Markdown blocks; `InlineParser::parse_mdx()` exposes typed MDX inline events | Use the opt-in inline event stream when a downstream consumer must distinguish prose and components |
+| **Inline JSX** (`text <em>here</em>`) | Stays in `segment()` Markdown blocks; `parse_events()` and `InlineParser::parse_mdx()` expose typed MDX inline events | Use the opt-in event APIs when a downstream consumer must distinguish prose and components |
 | **JS validation** | Heuristic detection (keyword + brace counting) instead of acorn/swc | Only if you need to report syntax errors in user-authored MDX at parse time |
 | **Markdown grammar** | Standard CommonMark/GFM rules | Official mdxjs disables indented code and HTML syntax — relevant if your content relies on `<div>` being JSX, not HTML |
-| **Container nesting** | `> <Component>` stays Markdown | Only if you put JSX inside blockquotes or list items — uncommon |
+| **Container nesting** | `> <Component>` stays Markdown flow; `parse_events()` still exposes the tag as inline MDX | Full flow semantics matter only when JSX inside blockquotes or list items must alter rendering |
 | **TypeScript generics** | `<Component<T>>` not parsed | Only relevant for TSX-heavy content pages — very rare in docs |
 | **Error reporting** | Permissive fallback by default; opt-in structural diagnostics with `segment_strict()` | Use strict mode when broken MDX must fail a content pipeline |
 

--- a/src/link_ref.rs
+++ b/src/link_ref.rs
@@ -46,6 +46,26 @@ impl LinkRefStore {
     pub fn is_empty(&self) -> bool {
         self.defs.is_empty()
     }
+
+    #[cfg(feature = "mdx")]
+    pub(crate) fn merge_first_wins(&mut self, other: Self) {
+        let mut labels = vec![None; other.defs.len()];
+        for (label, index) in other.by_label {
+            labels[index] = Some(label);
+        }
+
+        for (index, definition) in other.defs.into_iter().enumerate() {
+            let label = labels[index]
+                .take()
+                .expect("every link reference definition must have a label");
+            self.insert(label, definition);
+        }
+    }
+
+    #[cfg(feature = "mdx")]
+    pub(crate) fn append_definitions_to(&self, definitions: &mut Vec<LinkRefDef>) {
+        definitions.extend(self.defs.iter().cloned());
+    }
 }
 
 /// Normalize a link label per CommonMark: decode entities, process backslash escapes,

--- a/src/mdx/events.rs
+++ b/src/mdx/events.rs
@@ -57,8 +57,9 @@ impl MdxEvent {
     ///
     /// For container and formatting boundary events the compact underlying
     /// parser representation intentionally carries no delimiter range, so this
-    /// method returns `None`. For links, images, autolinks, and math, the
-    /// primary range has the same meaning as on the embedded [`InlineEvent`].
+    /// method returns `None`. For a fenced code-block start it returns the info
+    /// string, when present. For links, images, autolinks, and math, the primary
+    /// range has the same meaning as on the embedded [`InlineEvent`].
     #[must_use]
     pub fn source_range(&self) -> Option<Range> {
         match self {
@@ -120,46 +121,10 @@ pub fn parse_events(input: &str) -> MdxEventStream {
         "MDX input exceeds the supported u32 source range"
     );
 
-    let mut stream = MdxEventStream {
-        version: MDX_EVENT_STREAM_VERSION,
-        events: Vec::with_capacity((input.len() / 12).max(32)),
-        link_references: Vec::new(),
-    };
-
-    let content_start = emit_front_matter(input, &mut stream.events);
+    let (content_start, front_matter) = front_matter_event(input);
     let content = &input[content_start..];
     let segments = segment_spanned(content);
-    let link_refs = collect_link_references(&segments);
-    link_refs.append_definitions_to(&mut stream.link_references);
-
-    for spanned in segments {
-        let segment_start = content_start + spanned.range.start_usize();
-        match spanned.segment {
-            Segment::Esm(_) => stream
-                .events
-                .push(MdxEvent::Esm(offset_range(spanned.range, content_start))),
-            Segment::Markdown(markdown) => {
-                emit_markdown_events(markdown, segment_start, &link_refs, &mut stream.events);
-            }
-            Segment::JsxBlockOpen(_) => stream.events.push(MdxEvent::FlowJsxOpen(offset_range(
-                spanned.range,
-                content_start,
-            ))),
-            Segment::JsxBlockClose(_) => stream.events.push(MdxEvent::FlowJsxClose(offset_range(
-                spanned.range,
-                content_start,
-            ))),
-            Segment::JsxBlockSelfClose(_) => stream.events.push(MdxEvent::FlowJsxSelfClose(
-                offset_range(spanned.range, content_start),
-            )),
-            Segment::Expression(_) => stream.events.push(MdxEvent::FlowExpression(offset_range(
-                spanned.range,
-                content_start,
-            ))),
-        }
-    }
-
-    stream
+    build_event_stream(input, content_start, front_matter, segments)
 }
 
 /// Build a strict semantic MDX event stream.
@@ -180,10 +145,14 @@ pub fn parse_events_strict(input: &str) -> Result<MdxEventStream, Vec<MdxDiagnos
         "MDX input exceeds the supported u32 source range"
     );
 
-    let content_start =
-        crate::extract_front_matter(input).map_or(0, |(_, rest_offset)| rest_offset);
+    let (content_start, front_matter) = front_matter_event(input);
     match super::segment_strict(&input[content_start..]) {
-        Ok(_) => Ok(parse_events(input)),
+        Ok(segments) => Ok(build_event_stream(
+            input,
+            content_start,
+            front_matter,
+            segments,
+        )),
         Err(mut diagnostics) => {
             for diagnostic in &mut diagnostics {
                 diagnostic.primary_range = offset_range(diagnostic.primary_range, content_start);
@@ -196,9 +165,69 @@ pub fn parse_events_strict(input: &str) -> Result<MdxEventStream, Vec<MdxDiagnos
     }
 }
 
-fn emit_front_matter(input: &str, events: &mut Vec<MdxEvent>) -> usize {
+fn build_event_stream(
+    input: &str,
+    content_start: usize,
+    front_matter: Option<MdxEvent>,
+    segments: Vec<super::SpannedSegment<'_>>,
+) -> MdxEventStream {
+    let mut stream = MdxEventStream {
+        version: MDX_EVENT_STREAM_VERSION,
+        events: Vec::with_capacity((input.len() / 12).max(32)),
+        link_references: Vec::new(),
+    };
+
+    if let Some(event) = front_matter {
+        stream.events.push(event);
+    }
+
+    let (link_refs, markdown_block_events) = parse_markdown_segments(&segments);
+    link_refs.append_definitions_to(&mut stream.link_references);
+    let mut markdown_block_events = markdown_block_events.into_iter();
+
+    for spanned in segments {
+        let segment_start = content_start + spanned.range.start_usize();
+        match spanned.segment {
+            Segment::Esm(_) => stream
+                .events
+                .push(MdxEvent::Esm(offset_range(spanned.range, content_start))),
+            Segment::Markdown(markdown) => {
+                let block_events = markdown_block_events
+                    .next()
+                    .expect("every Markdown segment must have parsed block events");
+                emit_markdown_events(
+                    markdown,
+                    segment_start,
+                    &link_refs,
+                    block_events,
+                    &mut stream.events,
+                );
+            }
+            Segment::JsxBlockOpen(_) => stream.events.push(MdxEvent::FlowJsxOpen(offset_range(
+                spanned.range,
+                content_start,
+            ))),
+            Segment::JsxBlockClose(_) => stream.events.push(MdxEvent::FlowJsxClose(offset_range(
+                spanned.range,
+                content_start,
+            ))),
+            Segment::JsxBlockSelfClose(_) => stream.events.push(MdxEvent::FlowJsxSelfClose(
+                offset_range(spanned.range, content_start),
+            )),
+            Segment::Expression(_) => stream.events.push(MdxEvent::FlowExpression(offset_range(
+                spanned.range,
+                content_start,
+            ))),
+        }
+    }
+    debug_assert!(markdown_block_events.next().is_none());
+
+    stream
+}
+
+fn front_matter_event(input: &str) -> (usize, Option<MdxEvent>) {
     let Some((content, rest_offset)) = crate::extract_front_matter(input) else {
-        return 0;
+        return (0, None);
     };
 
     let input_start = input.as_ptr() as usize;
@@ -207,11 +236,13 @@ fn emit_front_matter(input: &str, events: &mut Vec<MdxEvent>) -> usize {
         .expect("front matter must borrow from its input");
     let content_end = content_start + content.len();
 
-    events.push(MdxEvent::FrontMatter {
-        range: Range::from_usize(0, rest_offset),
-        content: Range::from_usize(content_start, content_end),
-    });
-    rest_offset
+    (
+        rest_offset,
+        Some(MdxEvent::FrontMatter {
+            range: Range::from_usize(0, rest_offset),
+            content: Range::from_usize(content_start, content_end),
+        }),
+    )
 }
 
 fn semantic_options() -> Options {
@@ -222,8 +253,11 @@ fn semantic_options() -> Options {
     }
 }
 
-fn collect_link_references(segments: &[super::SpannedSegment<'_>]) -> LinkRefStore {
+fn parse_markdown_segments(
+    segments: &[super::SpannedSegment<'_>],
+) -> (LinkRefStore, Vec<Vec<BlockEvent>>) {
     let mut link_refs = LinkRefStore::new();
+    let mut parsed = Vec::new();
 
     for segment in segments {
         let Segment::Markdown(markdown) = segment.segment else {
@@ -233,23 +267,21 @@ fn collect_link_references(segments: &[super::SpannedSegment<'_>]) -> LinkRefSto
         let mut parser = BlockParser::new_with_options(markdown.as_bytes(), semantic_options());
         let mut events = Vec::new();
         parser.parse(&mut events);
+        fixup_list_tight(&mut events);
         link_refs.merge_first_wins(parser.take_link_refs());
+        parsed.push(events);
     }
 
-    link_refs
+    (link_refs, parsed)
 }
 
 fn emit_markdown_events(
     markdown: &str,
     source_offset: usize,
     link_refs: &LinkRefStore,
+    block_events: Vec<BlockEvent>,
     events: &mut Vec<MdxEvent>,
 ) {
-    let mut block_parser = BlockParser::new_with_options(markdown.as_bytes(), semantic_options());
-    let mut block_events = Vec::with_capacity((markdown.len() / 16).max(16));
-    block_parser.parse(&mut block_events);
-    fixup_list_tight(&mut block_events);
-
     let mut inline_parser = InlineParser::new();
     let mut inline_events = Vec::new();
     let mut inline_group = Vec::new();
@@ -398,7 +430,6 @@ fn offset_block_event(mut event: BlockEvent, offset: usize) -> BlockEvent {
             kind: CodeBlockKind::Fenced { info: Some(range) },
         }
         | BlockEvent::HtmlBlockText(range)
-        | BlockEvent::Text(range)
         | BlockEvent::Code(range) => *range = offset_range(*range, offset),
         _ => {}
     }
@@ -432,9 +463,12 @@ fn offset_inline_event(mut event: InlineEvent, offset: usize) -> InlineEvent {
 
 fn block_event_range(event: &BlockEvent) -> Option<Range> {
     match event {
-        BlockEvent::HtmlBlockText(range) | BlockEvent::Text(range) | BlockEvent::Code(range) => {
-            Some(*range)
+        BlockEvent::CodeBlockStart {
+            kind: CodeBlockKind::Fenced { info: Some(range) },
         }
+        | BlockEvent::HtmlBlockText(range)
+        | BlockEvent::Text(range)
+        | BlockEvent::Code(range) => Some(*range),
         _ => None,
     }
 }

--- a/src/mdx/events.rs
+++ b/src/mdx/events.rs
@@ -1,0 +1,469 @@
+//! Opt-in semantic MDX event stream.
+//!
+//! This module composes the existing MDX segmenter, Markdown block parser, and
+//! MDX-aware inline parser. It does not participate in the default HTML
+//! rendering path.
+
+use crate::block::CodeBlockKind;
+use crate::{
+    BlockEvent, BlockParser, InlineEvent, InlineParser, LinkRefDef, LinkRefStore, Options, Range,
+    fixup_list_tight,
+};
+
+use super::{MdxDiagnostic, Segment, segment_spanned};
+
+/// Version of the public MDX event ordering and balancing contract.
+///
+/// Consumers that persist or exchange event data can record this value
+/// alongside their derived representation.
+pub const MDX_EVENT_STREAM_VERSION: u16 = 1;
+
+/// A semantic event in an MDX document.
+///
+/// Flow-level MDX and ESM events appear between balanced Markdown block
+/// streams. Within a Markdown block, [`BlockEvent::Text`] placeholders are
+/// replaced by their resolved [`InlineEvent`] sequence so source text is not
+/// emitted twice.
+///
+/// Ranges embedded in any event are absolute byte ranges into the original
+/// input passed to [`parse_events`](super::parse_events).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum MdxEvent {
+    /// Front matter including its opening and closing delimiter lines.
+    FrontMatter {
+        /// Full front matter range, including delimiters.
+        range: Range,
+        /// Front matter payload between the delimiter lines.
+        content: Range,
+    },
+    /// Root-level ESM statement.
+    Esm(Range),
+    /// Flow-level JavaScript expression.
+    FlowExpression(Range),
+    /// Flow-level JSX opening tag.
+    FlowJsxOpen(Range),
+    /// Flow-level JSX closing tag.
+    FlowJsxClose(Range),
+    /// Flow-level self-closing JSX tag.
+    FlowJsxSelfClose(Range),
+    /// Markdown block structure or block-owned source.
+    Block(BlockEvent),
+    /// Resolved inline Markdown or inline MDX structure.
+    Inline(InlineEvent),
+}
+
+impl MdxEvent {
+    /// Return the event's primary source range when it carries one.
+    ///
+    /// For container and formatting boundary events the compact underlying
+    /// parser representation intentionally carries no delimiter range, so this
+    /// method returns `None`. For links, images, autolinks, and math, the
+    /// primary range has the same meaning as on the embedded [`InlineEvent`].
+    #[must_use]
+    pub fn source_range(&self) -> Option<Range> {
+        match self {
+            Self::FrontMatter { range, .. }
+            | Self::Esm(range)
+            | Self::FlowExpression(range)
+            | Self::FlowJsxOpen(range)
+            | Self::FlowJsxClose(range)
+            | Self::FlowJsxSelfClose(range) => Some(*range),
+            Self::Block(event) => block_event_range(event),
+            Self::Inline(event) => inline_event_range(event),
+        }
+    }
+}
+
+/// Collected, flat semantic events for one MDX document.
+///
+/// Events are ordered in source order. Markdown block start/end events and
+/// inline formatting start/end events retain the balancing guarantees of the
+/// existing parsers. Each Markdown segment is closed before the following
+/// flow-level MDX or ESM event.
+///
+/// A paragraph whose physical source is contiguous is inline-parsed as one
+/// unit, including line endings. When Markdown container prefixes make its
+/// logical content non-contiguous, each source-contiguous line is inline-parsed
+/// independently so every emitted range remains exact. Same-line JSX and
+/// expressions are still recognized in those containers; cross-line container
+/// MDX remains Markdown recovery.
+#[derive(Debug)]
+pub struct MdxEventStream {
+    /// Version of this event contract.
+    pub version: u16,
+    /// Ordered semantic events.
+    pub events: Vec<MdxEvent>,
+    /// Resolved reference-link definitions used by `LinkStartRef` and
+    /// `ImageStartRef` inline events.
+    pub link_references: Vec<LinkRefDef>,
+}
+
+impl MdxEventStream {
+    /// Resolve a reference-link definition by the index carried in an inline
+    /// reference event.
+    #[must_use]
+    pub fn link_reference(&self, index: u32) -> Option<&LinkRefDef> {
+        self.link_references.get(index as usize)
+    }
+}
+
+/// Build the permissive semantic event stream for an MDX document.
+///
+/// Malformed flow or inline MDX follows the existing permissive recovery
+/// contract and remains Markdown text. Use
+/// [`parse_events_strict`](super::parse_events_strict) when structural
+/// diagnostics are required.
+#[must_use]
+pub fn parse_events(input: &str) -> MdxEventStream {
+    assert!(
+        u32::try_from(input.len()).is_ok(),
+        "MDX input exceeds the supported u32 source range"
+    );
+
+    let mut stream = MdxEventStream {
+        version: MDX_EVENT_STREAM_VERSION,
+        events: Vec::with_capacity((input.len() / 12).max(32)),
+        link_references: Vec::new(),
+    };
+
+    let content_start = emit_front_matter(input, &mut stream.events);
+    let content = &input[content_start..];
+    let segments = segment_spanned(content);
+    let link_refs = collect_link_references(&segments);
+    link_refs.append_definitions_to(&mut stream.link_references);
+
+    for spanned in segments {
+        let segment_start = content_start + spanned.range.start_usize();
+        match spanned.segment {
+            Segment::Esm(_) => stream
+                .events
+                .push(MdxEvent::Esm(offset_range(spanned.range, content_start))),
+            Segment::Markdown(markdown) => {
+                emit_markdown_events(markdown, segment_start, &link_refs, &mut stream.events);
+            }
+            Segment::JsxBlockOpen(_) => stream.events.push(MdxEvent::FlowJsxOpen(offset_range(
+                spanned.range,
+                content_start,
+            ))),
+            Segment::JsxBlockClose(_) => stream.events.push(MdxEvent::FlowJsxClose(offset_range(
+                spanned.range,
+                content_start,
+            ))),
+            Segment::JsxBlockSelfClose(_) => stream.events.push(MdxEvent::FlowJsxSelfClose(
+                offset_range(spanned.range, content_start),
+            )),
+            Segment::Expression(_) => stream.events.push(MdxEvent::FlowExpression(offset_range(
+                spanned.range,
+                content_start,
+            ))),
+        }
+    }
+
+    stream
+}
+
+/// Build a strict semantic MDX event stream.
+///
+/// On structurally valid input this produces the same event ordering as
+/// [`parse_events`]. When strict validation finds malformed flow MDX, no
+/// partial event stream is returned; all available diagnostics are returned
+/// instead. Front matter is excluded from structural MDX validation and every
+/// diagnostic range is translated back to an absolute input range.
+///
+/// JavaScript and TypeScript syntax inside well-delimited constructs remains
+/// outside this validator's scope. The existing strict validator covers flow
+/// constructs; malformed inline MDX retains the permissive `InlineEvent::Text`
+/// recovery in both event modes.
+pub fn parse_events_strict(input: &str) -> Result<MdxEventStream, Vec<MdxDiagnostic>> {
+    assert!(
+        u32::try_from(input.len()).is_ok(),
+        "MDX input exceeds the supported u32 source range"
+    );
+
+    let content_start =
+        crate::extract_front_matter(input).map_or(0, |(_, rest_offset)| rest_offset);
+    match super::segment_strict(&input[content_start..]) {
+        Ok(_) => Ok(parse_events(input)),
+        Err(mut diagnostics) => {
+            for diagnostic in &mut diagnostics {
+                diagnostic.primary_range = offset_range(diagnostic.primary_range, content_start);
+                diagnostic.related_range = diagnostic
+                    .related_range
+                    .map(|range| offset_range(range, content_start));
+            }
+            Err(diagnostics)
+        }
+    }
+}
+
+fn emit_front_matter(input: &str, events: &mut Vec<MdxEvent>) -> usize {
+    let Some((content, rest_offset)) = crate::extract_front_matter(input) else {
+        return 0;
+    };
+
+    let input_start = input.as_ptr() as usize;
+    let content_start = (content.as_ptr() as usize)
+        .checked_sub(input_start)
+        .expect("front matter must borrow from its input");
+    let content_end = content_start + content.len();
+
+    events.push(MdxEvent::FrontMatter {
+        range: Range::from_usize(0, rest_offset),
+        content: Range::from_usize(content_start, content_end),
+    });
+    rest_offset
+}
+
+fn semantic_options() -> Options {
+    Options {
+        allow_html: false,
+        front_matter: false,
+        ..Options::default()
+    }
+}
+
+fn collect_link_references(segments: &[super::SpannedSegment<'_>]) -> LinkRefStore {
+    let mut link_refs = LinkRefStore::new();
+
+    for segment in segments {
+        let Segment::Markdown(markdown) = segment.segment else {
+            continue;
+        };
+
+        let mut parser = BlockParser::new_with_options(markdown.as_bytes(), semantic_options());
+        let mut events = Vec::new();
+        parser.parse(&mut events);
+        link_refs.merge_first_wins(parser.take_link_refs());
+    }
+
+    link_refs
+}
+
+fn emit_markdown_events(
+    markdown: &str,
+    source_offset: usize,
+    link_refs: &LinkRefStore,
+    events: &mut Vec<MdxEvent>,
+) {
+    let mut block_parser = BlockParser::new_with_options(markdown.as_bytes(), semantic_options());
+    let mut block_events = Vec::with_capacity((markdown.len() / 16).max(16));
+    block_parser.parse(&mut block_events);
+    fixup_list_tight(&mut block_events);
+
+    let mut inline_parser = InlineParser::new();
+    let mut inline_events = Vec::new();
+    let mut inline_group = Vec::new();
+    for block_event in block_events {
+        match block_event {
+            BlockEvent::Text(range) => {
+                inline_group.push(InlineSourcePart::Text(range));
+            }
+            BlockEvent::SoftBreak => {
+                inline_group.push(InlineSourcePart::SoftBreak);
+            }
+            event => {
+                flush_inline_group(
+                    markdown,
+                    source_offset,
+                    link_refs,
+                    &mut inline_parser,
+                    &mut inline_events,
+                    &mut inline_group,
+                    events,
+                );
+                events.push(MdxEvent::Block(offset_block_event(event, source_offset)));
+            }
+        }
+    }
+    flush_inline_group(
+        markdown,
+        source_offset,
+        link_refs,
+        &mut inline_parser,
+        &mut inline_events,
+        &mut inline_group,
+        events,
+    );
+}
+
+#[derive(Debug, Clone, Copy)]
+enum InlineSourcePart {
+    Text(Range),
+    SoftBreak,
+}
+
+#[allow(clippy::too_many_arguments)]
+fn flush_inline_group(
+    markdown: &str,
+    source_offset: usize,
+    link_refs: &LinkRefStore,
+    inline_parser: &mut InlineParser,
+    inline_events: &mut Vec<InlineEvent>,
+    parts: &mut Vec<InlineSourcePart>,
+    events: &mut Vec<MdxEvent>,
+) {
+    if parts.is_empty() {
+        return;
+    }
+
+    if let Some(range) = contiguous_inline_range(markdown.as_bytes(), parts) {
+        emit_inline_range(
+            range,
+            markdown.as_bytes(),
+            source_offset,
+            link_refs,
+            inline_parser,
+            inline_events,
+            events,
+        );
+    } else {
+        for part in parts.iter().copied() {
+            match part {
+                InlineSourcePart::Text(range) => emit_inline_range(
+                    range,
+                    markdown.as_bytes(),
+                    source_offset,
+                    link_refs,
+                    inline_parser,
+                    inline_events,
+                    events,
+                ),
+                InlineSourcePart::SoftBreak => {
+                    events.push(MdxEvent::Inline(InlineEvent::SoftBreak));
+                }
+            }
+        }
+    }
+
+    parts.clear();
+}
+
+fn contiguous_inline_range(input: &[u8], parts: &[InlineSourcePart]) -> Option<Range> {
+    let mut parts = parts.iter();
+    let InlineSourcePart::Text(first) = *parts.next()? else {
+        return None;
+    };
+    let mut previous = first;
+    let mut expect_text = false;
+
+    for part in parts {
+        match (*part, expect_text) {
+            (InlineSourcePart::SoftBreak, false) => {
+                expect_text = true;
+            }
+            (InlineSourcePart::Text(range), true) => {
+                let gap = &input[previous.end_usize()..range.start_usize()];
+                if gap != b"\n" && gap != b"\r\n" {
+                    return None;
+                }
+                previous = range;
+                expect_text = false;
+            }
+            _ => return None,
+        }
+    }
+    if expect_text {
+        return None;
+    }
+
+    Some(Range::from_usize(first.start_usize(), previous.end_usize()))
+}
+
+#[allow(clippy::too_many_arguments)]
+fn emit_inline_range(
+    range: Range,
+    markdown: &[u8],
+    source_offset: usize,
+    link_refs: &LinkRefStore,
+    inline_parser: &mut InlineParser,
+    inline_events: &mut Vec<InlineEvent>,
+    events: &mut Vec<MdxEvent>,
+) {
+    inline_events.clear();
+    inline_parser.parse_mdx(range.slice(markdown), Some(link_refs), inline_events);
+    let inline_offset = source_offset + range.start_usize();
+
+    for event in inline_events.drain(..) {
+        events.push(MdxEvent::Inline(offset_inline_event(event, inline_offset)));
+    }
+}
+
+fn offset_range(range: Range, offset: usize) -> Range {
+    Range::from_usize(offset + range.start_usize(), offset + range.end_usize())
+}
+
+fn offset_block_event(mut event: BlockEvent, offset: usize) -> BlockEvent {
+    match &mut event {
+        BlockEvent::CodeBlockStart {
+            kind: CodeBlockKind::Fenced { info: Some(range) },
+        }
+        | BlockEvent::HtmlBlockText(range)
+        | BlockEvent::Text(range)
+        | BlockEvent::Code(range) => *range = offset_range(*range, offset),
+        _ => {}
+    }
+    event
+}
+
+fn offset_inline_event(mut event: InlineEvent, offset: usize) -> InlineEvent {
+    match &mut event {
+        InlineEvent::Text(range)
+        | InlineEvent::Code(range)
+        | InlineEvent::Html(range)
+        | InlineEvent::MathInline(range)
+        | InlineEvent::MathDisplay(range)
+        | InlineEvent::MdxExpression(range)
+        | InlineEvent::MdxJsxOpen(range)
+        | InlineEvent::MdxJsxClose(range)
+        | InlineEvent::MdxJsxSelfClose(range) => *range = offset_range(*range, offset),
+        InlineEvent::LinkStart { url, title } | InlineEvent::ImageStart { url, title } => {
+            *url = offset_range(*url, offset);
+            if let Some(range) = title {
+                *range = offset_range(*range, offset);
+            }
+        }
+        InlineEvent::Autolink { url, .. } | InlineEvent::AutolinkLiteral { url, .. } => {
+            *url = offset_range(*url, offset);
+        }
+        _ => {}
+    }
+    event
+}
+
+fn block_event_range(event: &BlockEvent) -> Option<Range> {
+    match event {
+        BlockEvent::HtmlBlockText(range) | BlockEvent::Text(range) | BlockEvent::Code(range) => {
+            Some(*range)
+        }
+        _ => None,
+    }
+}
+
+fn inline_event_range(event: &InlineEvent) -> Option<Range> {
+    match event {
+        InlineEvent::Text(range)
+        | InlineEvent::Code(range)
+        | InlineEvent::Html(range)
+        | InlineEvent::MathInline(range)
+        | InlineEvent::MathDisplay(range)
+        | InlineEvent::MdxExpression(range)
+        | InlineEvent::MdxJsxOpen(range)
+        | InlineEvent::MdxJsxClose(range)
+        | InlineEvent::MdxJsxSelfClose(range) => Some(*range),
+        InlineEvent::LinkStart { url, .. }
+        | InlineEvent::ImageStart { url, .. }
+        | InlineEvent::Autolink { url, .. }
+        | InlineEvent::AutolinkLiteral { url, .. } => Some(*url),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn semantic_event_stays_compact() {
+        assert!(std::mem::size_of::<MdxEvent>() <= 40);
+    }
+}

--- a/src/mdx/mod.rs
+++ b/src/mdx/mod.rs
@@ -1,4 +1,4 @@
-//! MDX segmenter: splits MDX input into typed segments.
+//! MDX segmentation, rendering, diagnostics, and semantic events.
 //!
 //! MDX combines Markdown with JSX/JavaScript. Instead of parsing the full MDX
 //! syntax, this module splits the input into typed blocks. Only the Markdown
@@ -24,6 +24,28 @@
 //!     }
 //! }
 //! ```
+//!
+//! Compiler consumers that need Markdown block boundaries and resolved inline
+//! semantics can use the separate, collected event stream:
+//!
+//! ```
+//! use ferromark::InlineEvent;
+//! use ferromark::mdx::{MdxEvent, parse_events};
+//!
+//! let input = "# Hello {name}\n";
+//! let stream = parse_events(input);
+//! let translatable = stream.events.iter().filter_map(|event| match event {
+//!     MdxEvent::Inline(InlineEvent::Text(range)) => {
+//!         Some(range.slice_str(input.as_bytes()).unwrap())
+//!     }
+//!     _ => None,
+//! }).collect::<Vec<_>>();
+//! assert_eq!(translatable, vec!["Hello "]);
+//! ```
+//!
+//! [`parse_events`] is opt-in and does not participate in the default HTML
+//! rendering path. Its flat ordering and balancing contract is versioned by
+//! [`MDX_EVENT_STREAM_VERSION`].
 //!
 //! # Differences from the official mdxjs compiler
 //!
@@ -64,14 +86,17 @@
 //!
 //! ## No container awareness
 //!
-//! JSX/ESM inside block containers is not detected:
+//! Flow JSX/ESM inside block containers is not detected:
 //! ```text
 //! > <Component>   ← treated as blockquote + markdown, not JSX
 //! - import x      ← treated as list item, not ESM
 //! ```
 //!
 //! The official compiler tracks container context (blockquote markers, list
-//! indentation) and can detect JSX/ESM inside them.
+//! indentation) and can detect JSX/ESM inside them. [`parse_events`] still
+//! exposes well-delimited tags and expressions in container prose as inline
+//! MDX events, which is sufficient for consumers that need to separate
+//! translatable text from syntax without changing Markdown flow semantics.
 //!
 //! ## No TypeScript generics in JSX
 //!
@@ -87,11 +112,16 @@
 //! diagnostics with source ranges instead. It does not validate JavaScript or
 //! TypeScript syntax inside otherwise well-delimited ESM and expressions.
 
+mod events;
 pub mod expr;
 pub mod jsx_tag;
 pub mod render;
 mod splitter;
 mod strict;
+
+pub use events::{
+    MDX_EVENT_STREAM_VERSION, MdxEvent, MdxEventStream, parse_events, parse_events_strict,
+};
 
 /// A typed segment of an MDX document.
 ///

--- a/tests/mdx_event_tests.rs
+++ b/tests/mdx_event_tests.rs
@@ -277,3 +277,16 @@ fn strict_stream_preserves_inline_mdx_text_recovery() {
                 == "Paragraph with {unterminated inline expression.")
     }));
 }
+
+#[test]
+fn fenced_code_info_exposes_its_absolute_source_range() {
+    let input = "<Divider />\n\n```rust,ignore\nlet value = 1;\n```\n";
+    let stream = parse_events(input);
+    let event = stream
+        .events
+        .iter()
+        .find(|event| matches!(event, MdxEvent::Block(BlockEvent::CodeBlockStart { .. })))
+        .unwrap();
+
+    assert_eq!(source(input, event), Some("rust,ignore"));
+}

--- a/tests/mdx_event_tests.rs
+++ b/tests/mdx_event_tests.rs
@@ -1,0 +1,279 @@
+#![cfg(feature = "mdx")]
+
+use ferromark::mdx::{
+    MDX_EVENT_STREAM_VERSION, MdxDiagnosticCode, MdxEvent, parse_events, parse_events_strict,
+};
+use ferromark::{BlockEvent, InlineEvent};
+
+fn source<'a>(input: &'a str, event: &MdxEvent) -> Option<&'a str> {
+    event
+        .source_range()
+        .map(|range| range.slice_str(input.as_bytes()).unwrap())
+}
+
+#[test]
+fn semantic_stream_composes_flow_blocks_and_inline_mdx_with_absolute_ranges() {
+    let input = "\
+---
+title: Hello
+---
+import Card from './Card'
+
+# Hello *world*
+
+<Card />
+
+> Translate {user.name} with <Badge>care</Badge>.
+
+`literal`
+";
+    let stream = parse_events(input);
+
+    assert_eq!(stream.version, MDX_EVENT_STREAM_VERSION);
+    let Some(MdxEvent::FrontMatter { range, content }) = stream.events.first() else {
+        panic!("expected front matter as the first event");
+    };
+    assert_eq!(
+        range.slice_str(input.as_bytes()).unwrap(),
+        "---\ntitle: Hello\n---\n"
+    );
+    assert_eq!(
+        content.slice_str(input.as_bytes()).unwrap(),
+        "title: Hello\n"
+    );
+    let strict = parse_events_strict(input);
+    assert!(strict.is_ok(), "{strict:?}");
+    assert!(
+        stream
+            .events
+            .iter()
+            .any(|event| matches!(event, MdxEvent::Esm(_)))
+    );
+    assert!(
+        stream
+            .events
+            .iter()
+            .any(|event| matches!(event, MdxEvent::FlowJsxSelfClose(_)))
+    );
+    assert!(
+        stream
+            .events
+            .iter()
+            .any(|event| matches!(event, MdxEvent::Block(BlockEvent::BlockQuoteStart { .. })))
+    );
+    assert!(
+        stream
+            .events
+            .iter()
+            .any(|event| matches!(event, MdxEvent::Inline(InlineEvent::MdxExpression(_))))
+    );
+    assert!(
+        stream
+            .events
+            .iter()
+            .any(|event| matches!(event, MdxEvent::Inline(InlineEvent::MdxJsxOpen(_))))
+    );
+    assert!(
+        stream
+            .events
+            .iter()
+            .any(|event| matches!(event, MdxEvent::Inline(InlineEvent::MdxJsxClose(_))))
+    );
+    assert!(
+        stream
+            .events
+            .iter()
+            .any(|event| matches!(event, MdxEvent::Inline(InlineEvent::Code(_))))
+    );
+
+    let expression = stream
+        .events
+        .iter()
+        .find(|event| matches!(event, MdxEvent::Inline(InlineEvent::MdxExpression(_))))
+        .unwrap();
+    assert_eq!(source(input, expression), Some("{user.name}"));
+
+    for range in stream.events.iter().filter_map(MdxEvent::source_range) {
+        assert!(range.end_usize() <= input.len());
+        assert!(input.is_char_boundary(range.start_usize()));
+        assert!(input.is_char_boundary(range.end_usize()));
+    }
+}
+
+#[test]
+fn reference_consumer_can_collect_translatable_prose_without_code_or_mdx() {
+    let input = "\
+# Hello *world*
+
+> Translate {user.name} with <Badge>care</Badge>.
+
+`literal`
+";
+    let stream = parse_events(input);
+    let units = stream
+        .events
+        .iter()
+        .filter_map(|event| match event {
+            MdxEvent::Inline(InlineEvent::Text(range)) => {
+                Some(range.slice_str(input.as_bytes()).unwrap())
+            }
+            _ => None,
+        })
+        .collect::<Vec<_>>();
+
+    assert_eq!(
+        units,
+        vec!["Hello ", "world", "Translate ", " with ", "care", "."]
+    );
+}
+
+#[test]
+fn links_keep_absolute_urls_and_reference_definitions() {
+    let input = "\
+[inline](/docs) and [reference][guide].
+
+<Divider />
+
+[guide]: /guide \"Guide\"
+";
+    let stream = parse_events(input);
+
+    let inline_url = stream.events.iter().find_map(|event| match event {
+        MdxEvent::Inline(InlineEvent::LinkStart { url, .. }) => {
+            Some(url.slice_str(input.as_bytes()).unwrap())
+        }
+        _ => None,
+    });
+    let reference_index = stream.events.iter().find_map(|event| match event {
+        MdxEvent::Inline(InlineEvent::LinkStartRef { def_index }) => Some(*def_index),
+        _ => None,
+    });
+
+    assert_eq!(inline_url, Some("/docs"));
+    let definition = stream.link_reference(reference_index.unwrap()).unwrap();
+    assert_eq!(definition.url, b"/guide");
+    assert_eq!(definition.title.as_deref(), Some(b"Guide".as_slice()));
+}
+
+#[test]
+fn markdown_block_boundaries_remain_ordered_and_balanced() {
+    let input = "# Heading\n\n- first\n- second\n\nParagraph.\n";
+    let stream = parse_events(input);
+    let mut heading_depth = 0;
+    let mut paragraph_depth = 0;
+    let mut list_depth = 0;
+    let mut item_depth = 0;
+
+    for event in &stream.events {
+        match event {
+            MdxEvent::Block(BlockEvent::HeadingStart { .. }) => heading_depth += 1,
+            MdxEvent::Block(BlockEvent::HeadingEnd { .. }) => heading_depth -= 1,
+            MdxEvent::Block(BlockEvent::ParagraphStart) => paragraph_depth += 1,
+            MdxEvent::Block(BlockEvent::ParagraphEnd) => paragraph_depth -= 1,
+            MdxEvent::Block(BlockEvent::ListStart { .. }) => list_depth += 1,
+            MdxEvent::Block(BlockEvent::ListEnd { .. }) => list_depth -= 1,
+            MdxEvent::Block(BlockEvent::ListItemStart { .. }) => item_depth += 1,
+            MdxEvent::Block(BlockEvent::ListItemEnd) => item_depth -= 1,
+            _ => {}
+        }
+
+        assert!(heading_depth >= 0);
+        assert!(paragraph_depth >= 0);
+        assert!(list_depth >= 0);
+        assert!(item_depth >= 0);
+    }
+
+    assert_eq!(heading_depth, 0);
+    assert_eq!(paragraph_depth, 0);
+    assert_eq!(list_depth, 0);
+    assert_eq!(item_depth, 0);
+}
+
+#[test]
+fn contiguous_multiline_paragraphs_share_one_inline_parse() {
+    let input = "Paragraph with *emphasis\ncontinued* and {name}.\n";
+    let stream = parse_events(input);
+    let inline = stream
+        .events
+        .iter()
+        .filter_map(|event| match event {
+            MdxEvent::Inline(event) => Some(event),
+            _ => None,
+        })
+        .collect::<Vec<_>>();
+
+    assert_eq!(
+        inline
+            .iter()
+            .filter(|event| matches!(event, InlineEvent::EmphasisStart))
+            .count(),
+        1
+    );
+    assert_eq!(
+        inline
+            .iter()
+            .filter(|event| matches!(event, InlineEvent::EmphasisEnd))
+            .count(),
+        1
+    );
+    assert!(
+        inline
+            .iter()
+            .any(|event| matches!(event, InlineEvent::SoftBreak))
+    );
+    assert!(
+        inline
+            .iter()
+            .any(|event| matches!(event, InlineEvent::MdxExpression(range)
+            if range.slice_str(input.as_bytes()).unwrap() == "{name}"))
+    );
+}
+
+#[test]
+fn strict_stream_reports_diagnostics_while_permissive_stream_recovers_as_text() {
+    let input = "# Heading\n\n{user.name\n";
+    let permissive = parse_events(input);
+
+    assert!(permissive.events.iter().any(|event| {
+        matches!(event, MdxEvent::Inline(InlineEvent::Text(range))
+            if range.slice_str(input.as_bytes()).unwrap() == "{user.name")
+    }));
+
+    let diagnostics = parse_events_strict(input).unwrap_err();
+    assert_eq!(diagnostics.len(), 1);
+    assert_eq!(
+        diagnostics[0].code,
+        MdxDiagnosticCode::UnterminatedExpression
+    );
+}
+
+#[test]
+fn strict_diagnostics_after_front_matter_keep_absolute_ranges() {
+    let input = "---\ntitle: Test\n---\n{user.name\n";
+    let diagnostics = parse_events_strict(input).unwrap_err();
+
+    assert_eq!(diagnostics.len(), 1);
+    assert_eq!(
+        diagnostics[0].code,
+        MdxDiagnosticCode::UnterminatedExpression
+    );
+    assert_eq!(
+        diagnostics[0]
+            .primary_range
+            .slice_str(input.as_bytes())
+            .unwrap(),
+        "{user.name\n"
+    );
+}
+
+#[test]
+fn strict_stream_preserves_inline_mdx_text_recovery() {
+    let input = "Paragraph with {unterminated inline expression.\n";
+    let stream = parse_events_strict(input).unwrap();
+
+    assert!(stream.events.iter().any(|event| {
+        matches!(event, MdxEvent::Inline(InlineEvent::Text(range))
+            if range.slice_str(input.as_bytes()).unwrap()
+                == "Paragraph with {unterminated inline expression.")
+    }));
+}


### PR DESCRIPTION
## Summary
- add a versioned, opt-in semantic MDX event buffer that composes flow segments with existing block and inline events
- preserve absolute source ranges, document-wide reference links, front matter, and strict diagnostic recovery
- keep the existing Markdown and MDX HTML rendering paths unchanged

Closes #89.

## Performance
- no calls or branches are added to the default rendering hot path
- semantic prepasses and allocations occur only when `parse_events()` or `parse_events_strict()` is explicitly called

## Validation
- `cargo test --all-features`
- `cargo test --no-default-features`
- `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --features mdx`
- `cargo clippy --all-targets --all-features -- -D warnings`
