### PR TITLE
feat(mdx): promote container-local flow events

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,6 +309,9 @@ The event path is fully opt-in and does not alter the normal Markdown or MDX
 HTML renderer. `parse_events_strict()` applies the same structural diagnostics
 as `segment_strict()` before producing events. Its strict validation covers
 flow constructs; malformed inline MDX retains the documented text fallback.
+Inside blockquotes and list items, a paragraph containing only one JSX tag or
+expression is promoted to the corresponding flow event. Mixed prose remains
+inline MDX, and the surrounding Markdown container events stay balanced.
 
 Full example: `cargo run --features mdx --example mdx_segment`
 
@@ -326,7 +329,7 @@ What the segmenter deliberately skips — and why that's fine for most use cases
 | **Inline JSX** (`text <em>here</em>`) | Stays in `segment()` Markdown blocks; `parse_events()` and `InlineParser::parse_mdx()` expose typed MDX inline events | Use the opt-in event APIs when a downstream consumer must distinguish prose and components |
 | **JS validation** | Heuristic detection (keyword + brace counting) instead of acorn/swc | Only if you need to report syntax errors in user-authored MDX at parse time |
 | **Markdown grammar** | Standard CommonMark/GFM rules | Official mdxjs disables indented code and HTML syntax — relevant if your content relies on `<div>` being JSX, not HTML |
-| **Container nesting** | `> <Component>` stays Markdown flow; `parse_events()` still exposes the tag as inline MDX | Full flow semantics matter only when JSX inside blockquotes or list items must alter rendering |
+| **Container nesting** | `> <Component>` stays Markdown to the renderer; `parse_events()` promotes tag-only or expression-only container paragraphs to semantic flow events | Rendering-level container MDX, multiline constructs across prefixes, and container-local ESM remain out of scope |
 | **TypeScript generics** | `<Component<T>>` not parsed | Only relevant for TSX-heavy content pages — very rare in docs |
 | **Error reporting** | Permissive fallback by default; opt-in structural diagnostics with `segment_strict()` | Use strict mode when broken MDX must fail a content pipeline |
 

--- a/src/mdx/events.rs
+++ b/src/mdx/events.rs
@@ -20,10 +20,12 @@ pub const MDX_EVENT_STREAM_VERSION: u16 = 1;
 
 /// A semantic event in an MDX document.
 ///
-/// Flow-level MDX and ESM events appear between balanced Markdown block
-/// streams. Within a Markdown block, [`BlockEvent::Text`] placeholders are
-/// replaced by their resolved [`InlineEvent`] sequence so source text is not
-/// emitted twice.
+/// Root-level MDX and ESM events appear between balanced Markdown block
+/// streams. A tag-only or expression-only paragraph inside a blockquote or
+/// list item is normalized to the corresponding flow event while its
+/// surrounding container events remain balanced. Within other Markdown
+/// blocks, [`BlockEvent::Text`] placeholders are replaced by their resolved
+/// [`InlineEvent`] sequence so source text is not emitted twice.
 ///
 /// Ranges embedded in any event are absolute byte ranges into the original
 /// input passed to [`parse_events`](super::parse_events).
@@ -38,13 +40,13 @@ pub enum MdxEvent {
     },
     /// Root-level ESM statement.
     Esm(Range),
-    /// Flow-level JavaScript expression.
+    /// Root-level or promoted container-local JavaScript expression.
     FlowExpression(Range),
-    /// Flow-level JSX opening tag.
+    /// Root-level or promoted container-local JSX opening tag.
     FlowJsxOpen(Range),
-    /// Flow-level JSX closing tag.
+    /// Root-level or promoted container-local JSX closing tag.
     FlowJsxClose(Range),
-    /// Flow-level self-closing JSX tag.
+    /// Root-level or promoted container-local self-closing JSX tag.
     FlowJsxSelfClose(Range),
     /// Markdown block structure or block-owned source.
     Block(BlockEvent),
@@ -79,8 +81,10 @@ impl MdxEvent {
 ///
 /// Events are ordered in source order. Markdown block start/end events and
 /// inline formatting start/end events retain the balancing guarantees of the
-/// existing parsers. Each Markdown segment is closed before the following
-/// flow-level MDX or ESM event.
+/// existing parsers. Each Markdown segment is closed before a root-level MDX
+/// or ESM event. Inside blockquotes and list items, a paragraph whose only
+/// significant inline event is one JSX tag or expression is replaced by the
+/// corresponding flow event. The surrounding container events stay in place.
 ///
 /// A paragraph whose physical source is contiguous is inline-parsed as one
 /// unit, including line endings. When Markdown container prefixes make its
@@ -222,7 +226,89 @@ fn build_event_stream(
     }
     debug_assert!(markdown_block_events.next().is_none());
 
+    promote_container_flow_events(input.as_bytes(), &mut stream.events);
     stream
+}
+
+fn promote_container_flow_events(source: &[u8], events: &mut Vec<MdxEvent>) {
+    let input = std::mem::take(events);
+    let mut output = Vec::with_capacity(input.len());
+    let mut paragraph = Vec::new();
+    let mut input = input.into_iter();
+    let mut container_depth = 0usize;
+
+    while let Some(event) = input.next() {
+        match event {
+            MdxEvent::Block(BlockEvent::BlockQuoteStart { .. })
+            | MdxEvent::Block(BlockEvent::ListItemStart { .. }) => {
+                container_depth += 1;
+                output.push(event);
+            }
+            MdxEvent::Block(BlockEvent::BlockQuoteEnd)
+            | MdxEvent::Block(BlockEvent::ListItemEnd) => {
+                container_depth = container_depth
+                    .checked_sub(1)
+                    .expect("Markdown container events must be balanced");
+                output.push(event);
+            }
+            MdxEvent::Block(BlockEvent::ParagraphStart) if container_depth > 0 => {
+                paragraph.clear();
+                let mut found_end = false;
+                for paragraph_event in input.by_ref() {
+                    if paragraph_event == MdxEvent::Block(BlockEvent::ParagraphEnd) {
+                        found_end = true;
+                        break;
+                    }
+                    paragraph.push(paragraph_event);
+                }
+
+                if found_end {
+                    if let Some(promoted) = promotable_paragraph(source, &paragraph) {
+                        output.push(promoted);
+                    } else {
+                        output.push(MdxEvent::Block(BlockEvent::ParagraphStart));
+                        output.append(&mut paragraph);
+                        output.push(MdxEvent::Block(BlockEvent::ParagraphEnd));
+                    }
+                } else {
+                    output.push(MdxEvent::Block(BlockEvent::ParagraphStart));
+                    output.append(&mut paragraph);
+                }
+            }
+            event => output.push(event),
+        }
+    }
+
+    debug_assert_eq!(container_depth, 0);
+    *events = output;
+}
+
+fn promotable_paragraph(source: &[u8], events: &[MdxEvent]) -> Option<MdxEvent> {
+    let mut promoted = None;
+
+    for event in events {
+        let candidate = match event {
+            MdxEvent::Inline(InlineEvent::Text(range))
+                if range.slice(source).iter().all(u8::is_ascii_whitespace) =>
+            {
+                continue;
+            }
+            MdxEvent::Inline(InlineEvent::SoftBreak) => continue,
+            MdxEvent::Inline(InlineEvent::MdxExpression(range)) => MdxEvent::FlowExpression(*range),
+            MdxEvent::Inline(InlineEvent::MdxJsxOpen(range)) => MdxEvent::FlowJsxOpen(*range),
+            MdxEvent::Inline(InlineEvent::MdxJsxClose(range)) => MdxEvent::FlowJsxClose(*range),
+            MdxEvent::Inline(InlineEvent::MdxJsxSelfClose(range)) => {
+                MdxEvent::FlowJsxSelfClose(*range)
+            }
+            _ => return None,
+        };
+
+        if promoted.replace(candidate).is_some() {
+            return None;
+        }
+    }
+
+    promoted
 }
 
 fn front_matter_event(input: &str) -> (usize, Option<MdxEvent>) {

--- a/src/mdx/events.rs
+++ b/src/mdx/events.rs
@@ -252,6 +252,7 @@ fn promote_container_flow_events(source: &[u8], events: &mut Vec<MdxEvent>) {
                 output.push(event);
             }
             MdxEvent::Block(BlockEvent::ParagraphStart) if container_depth > 0 => {
+                // Successful promotion borrows rather than drains this reusable buffer.
                 paragraph.clear();
                 let mut found_end = false;
                 for paragraph_event in input.by_ref() {

--- a/src/mdx/mod.rs
+++ b/src/mdx/mod.rs
@@ -93,10 +93,12 @@
 //! ```
 //!
 //! The official compiler tracks container context (blockquote markers, list
-//! indentation) and can detect JSX/ESM inside them. [`parse_events`] still
-//! exposes well-delimited tags and expressions in container prose as inline
-//! MDX events, which is sufficient for consumers that need to separate
-//! translatable text from syntax without changing Markdown flow semantics.
+//! indentation) and can detect JSX/ESM inside them. [`parse_events`] promotes a
+//! container paragraph containing only one well-delimited tag or expression to
+//! a flow event while preserving the surrounding Markdown container events.
+//! Mixed prose keeps its inline MDX events. Multiline constructs split across
+//! repeated container prefixes and container-local ESM remain Markdown
+//! recovery.
 //!
 //! ## No TypeScript generics in JSX
 //!

--- a/tests/mdx_event_tests.rs
+++ b/tests/mdx_event_tests.rs
@@ -290,3 +290,213 @@ fn fenced_code_info_exposes_its_absolute_source_range() {
 
     assert_eq!(source(input, event), Some("rust,ignore"));
 }
+
+#[test]
+fn tag_only_blockquote_paragraphs_promote_around_markdown_blocks() {
+    let input = "\
+> <Card>
+>
+> Hello *world*.
+>
+> </Card>
+";
+    let stream = parse_events(input);
+    let open = stream
+        .events
+        .iter()
+        .position(|event| matches!(event, MdxEvent::FlowJsxOpen(_)))
+        .unwrap();
+    let paragraph = stream
+        .events
+        .iter()
+        .position(|event| matches!(event, MdxEvent::Block(BlockEvent::ParagraphStart)))
+        .unwrap();
+    let close = stream
+        .events
+        .iter()
+        .position(|event| matches!(event, MdxEvent::FlowJsxClose(_)))
+        .unwrap();
+
+    assert!(matches!(
+        stream.events.first(),
+        Some(MdxEvent::Block(BlockEvent::BlockQuoteStart { .. }))
+    ));
+    assert!(matches!(
+        stream.events.last(),
+        Some(MdxEvent::Block(BlockEvent::BlockQuoteEnd))
+    ));
+    assert!(open < paragraph && paragraph < close);
+    assert_eq!(source(input, &stream.events[open]), Some("<Card>"));
+    assert_eq!(source(input, &stream.events[close]), Some("</Card>"));
+    assert!(!stream.events.iter().any(|event| {
+        matches!(
+            event,
+            MdxEvent::Inline(InlineEvent::MdxJsxOpen(_))
+                | MdxEvent::Inline(InlineEvent::MdxJsxClose(_))
+        )
+    }));
+}
+
+#[test]
+fn list_and_nested_container_units_promote_with_exact_ranges() {
+    let input = concat!(
+        "Intro ä.\n\n",
+        "-   <Badge />   \n\n",
+        "1. {value}\n\n",
+        "- <Open>\n",
+        "- </Open>\n\n",
+        "> - <Nested />\n",
+    );
+    let stream = parse_events(input);
+    let promoted = stream
+        .events
+        .iter()
+        .filter(|event| {
+            matches!(
+                event,
+                MdxEvent::FlowJsxOpen(_)
+                    | MdxEvent::FlowJsxClose(_)
+                    | MdxEvent::FlowJsxSelfClose(_)
+                    | MdxEvent::FlowExpression(_)
+            )
+        })
+        .filter_map(|event| source(input, event))
+        .collect::<Vec<_>>();
+
+    assert_eq!(
+        promoted,
+        vec!["<Badge />", "{value}", "<Open>", "</Open>", "<Nested />"]
+    );
+    assert_eq!(
+        stream
+            .events
+            .iter()
+            .filter(|event| matches!(event, MdxEvent::Block(BlockEvent::ListItemStart { .. })))
+            .count(),
+        5
+    );
+    assert!(
+        stream
+            .events
+            .iter()
+            .filter_map(|event| match event {
+                MdxEvent::Block(BlockEvent::ListStart { tight, .. }) => Some(*tight),
+                _ => None,
+            })
+            .all(|tight| tight)
+    );
+}
+
+#[test]
+fn list_item_component_wrappers_promote_around_multiple_blocks() {
+    let input = "\
+> 1. <Panel>
+>
+>    Body
+>
+>    </Panel>
+";
+    let stream = parse_events(input);
+    let open = stream
+        .events
+        .iter()
+        .position(|event| matches!(event, MdxEvent::FlowJsxOpen(_)))
+        .unwrap();
+    let body = stream
+        .events
+        .iter()
+        .position(|event| {
+            matches!(event, MdxEvent::Inline(InlineEvent::Text(range))
+                if range.slice_str(input.as_bytes()).unwrap() == "Body")
+        })
+        .unwrap();
+    let close = stream
+        .events
+        .iter()
+        .position(|event| matches!(event, MdxEvent::FlowJsxClose(_)))
+        .unwrap();
+
+    assert!(open < body && body < close);
+    assert_eq!(source(input, &stream.events[open]), Some("<Panel>"));
+    assert_eq!(source(input, &stream.events[close]), Some("</Panel>"));
+    assert!(matches!(
+        stream.events.first(),
+        Some(MdxEvent::Block(BlockEvent::BlockQuoteStart { .. }))
+    ));
+    assert!(stream.events.iter().any(|event| {
+        matches!(
+            event,
+            MdxEvent::Block(BlockEvent::ListStart { tight: false, .. })
+        )
+    }));
+}
+
+#[test]
+fn mixed_prose_code_and_multiline_container_mdx_are_not_promoted() {
+    let input = "\
+> Read <Badge>new</Badge> today.
+>
+> `<Card />`
+>
+> \\<Escaped />
+>
+> ```mdx
+> <Code />
+> ```
+>
+>     <Indented />
+>
+> <Multiline
+>   prop={value}
+> />
+";
+    let stream = parse_events(input);
+
+    assert!(!stream.events.iter().any(|event| {
+        matches!(
+            event,
+            MdxEvent::FlowJsxOpen(_)
+                | MdxEvent::FlowJsxClose(_)
+                | MdxEvent::FlowJsxSelfClose(_)
+                | MdxEvent::FlowExpression(_)
+        )
+    }));
+    assert!(stream.events.iter().any(|event| {
+        matches!(event, MdxEvent::Inline(InlineEvent::MdxJsxOpen(range))
+            if range.slice_str(input.as_bytes()).unwrap() == "<Badge>")
+    }));
+    assert!(stream.events.iter().any(|event| {
+        matches!(event, MdxEvent::Inline(InlineEvent::Code(range))
+            if range.slice_str(input.as_bytes()).unwrap() == "<Card />")
+    }));
+    assert!(
+        stream
+            .events
+            .iter()
+            .any(|event| { matches!(event, MdxEvent::Block(BlockEvent::CodeBlockStart { .. })) })
+    );
+    assert!(stream.events.iter().any(|event| {
+        matches!(event, MdxEvent::Block(BlockEvent::Code(range))
+            if range.slice_str(input.as_bytes()).unwrap().contains("<Indented />"))
+    }));
+}
+
+#[test]
+fn semantic_normalization_does_not_change_mdx_rendering() {
+    let input = "> <Card />\n";
+    let event_stream = parse_events(input);
+    let rendered = ferromark::mdx::render::render(input);
+
+    assert!(
+        event_stream
+            .events
+            .iter()
+            .any(|event| matches!(event, MdxEvent::FlowJsxSelfClose(_)))
+    );
+    assert!(rendered.body.contains("<blockquote>"));
+    assert!(
+        rendered.body.contains("<Card />"),
+        "container JSX must remain in rendered output: {}",
+        rendered.body
+    );
+}


### PR DESCRIPTION
## Summary
- promote tag-only and expression-only paragraphs inside blockquotes and list items to semantic flow events
- preserve exact construct ranges and all surrounding Markdown container and tightness events
- keep mixed prose, code, escaped syntax, and multiline container recovery unchanged

Closes #88.

## Performance
- normalization is a linear pass over the opt-in semantic event buffer
- no AST is introduced
- the core segmenter, block parser, and Markdown/MDX HTML rendering paths are unchanged
- the event stream is not released yet, so this behavior completes its version-1 ordering contract before publication

## Validation
- `cargo test --all-features`
- `cargo test --no-default-features`
- `cargo test --features mdx --test mdx_event_tests`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --features mdx`
