### PR TITLE
chore(deps): refresh isbot resolution

### DIFF
--- a/homepage/pnpm-lock.yaml
+++ b/homepage/pnpm-lock.yaml
@@ -27,7 +27,7 @@ importers:
         version: 4.1.0(@react-router/dev@8.3.0(react-router@8.3.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(typescript@5.9.3)(vite@8.1.4(@types/node@26.1.1)(esbuild@0.28.1)(yaml@2.8.3)))(@types/node@26.1.1)(@types/react@19.2.13)(esbuild@0.28.1)(lightningcss@1.32.0)(lucide-react@1.24.0(react@19.2.7))(mermaid@11.16.0)(react-dom@19.2.7(react@19.2.7))(react-router@8.3.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)(rollup@4.59.0)(typescript@5.9.3)(vite@8.1.4(@types/node@26.1.1)(esbuild@0.28.1)(yaml@2.8.3))(yaml@2.8.3)
       isbot:
         specifier: '*'
-        version: 5.1.34
+        version: 5.2.1
       lucide-react:
         specifier: ^1.24.0
         version: 1.24.0(react@19.2.7)
@@ -1605,12 +1605,8 @@ packages:
     resolution: {integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==}
     engines: {node: '>=12'}
 
-  isbot@5.1.34:
-    resolution: {integrity: sha512-aCMIBSKd/XPRYdiCQTLC8QHH4YT8B3JUADu+7COgYIZPvkeoMcUHMRjZLM9/7V8fCj+l7FSREc1lOPNjzogo/A==}
-    engines: {node: '>=18'}
-
-  isbot@5.2.0:
-    resolution: {integrity: sha512-gbZiGCb4B5xaoxg9mS7koAyRdvJnArk10VLSHOgz6rtBG93/pi1xOFaVvXMKZ7JXgyZ8zAbNRK5uIBdIUTFSqw==}
+  isbot@5.2.1:
+    resolution: {integrity: sha512-dJ+LpKyClQZ7NG+j3OensC/mAZkGpukE9YUrgPYvAZj2doVL0edfDgywTUh5CXa0o+nW9a1V9e5+CJTX8+SxRw==}
     engines: {node: '>=18'}
 
   javascript-stringify@2.1.0:
@@ -2891,7 +2887,7 @@ snapshots:
       dedent: 1.7.2
       es-module-lexer: 2.3.0
       exit-hook: 5.1.0
-      isbot: 5.2.0
+      isbot: 5.2.1
       jsesc: 3.1.0
       lodash: 4.18.1
       p-map: 7.0.4
@@ -4049,9 +4045,7 @@ snapshots:
 
   is-plain-obj@4.1.0: {}
 
-  isbot@5.1.34: {}
-
-  isbot@5.2.0: {}
+  isbot@5.2.1: {}
 
   javascript-stringify@2.1.0: {}
 


### PR DESCRIPTION
## What changed

Refresh the homepage lockfile from isbot 5.1.34 to 5.2.1 while preserving the existing wildcard manifest policy.

## Why

Pick up the current bot-detection pattern update without coupling it to the broader framework stack.

## Impact

No manifest or application API changes.

## Validation

- frozen pnpm install
- TypeScript check
- complete production build and six-page prerender verification
- `pnpm audit --prod --audit-level low`: no known vulnerabilities

## Security base

Rebased after #101 merged. The current frozen graph retains DOMPurify 3.4.12 and the brace-expansion 5.0.8 security override.