### PR TITLE
feat: add indented code block option

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,10 +95,14 @@ Fine-grained options let you turn on exactly what you need:
 ```text
 allow_html · allow_link_refs · tables · strikethrough · highlight · superscript · subscript · task_lists
 autolink_literals · disallowed_raw_html · footnotes · front_matter
-heading_ids · math · callouts
+heading_ids · math · callouts · indented_code_blocks
 ```
 
 Syntax note: ferromark uses `~~text~~` for strikethrough, `~text~` for subscript, and `^text^` for superscript. Single-tilde strikethrough is intentionally not supported.
+
+Set `indented_code_blocks: false` for dialects that require fenced code blocks
+and interpret four-space indentation as ordinary paragraph content. Fenced code
+blocks remain available.
 
 ## Markdown configuration
 

--- a/benches/options.rs
+++ b/benches/options.rs
@@ -40,6 +40,7 @@ fn all_extensions() -> Options {
         heading_ids: true,
         math: true,
         callouts: true,
+        indented_code_blocks: true,
     }
 }
 
@@ -53,6 +54,13 @@ fn options_cost_benches(c: &mut Criterion) {
         ("commonmark", Options::commonmark()),
         ("gfm", Options::gfm()),
         ("default", Options::default()),
+        (
+            "default_no_indented_code",
+            Options {
+                indented_code_blocks: false,
+                ..Options::default()
+            },
+        ),
         ("all_extensions", all_extensions()),
     ] {
         let mut output = Vec::with_capacity(input.len() + input.len() / 4);

--- a/node/ferromark/index.d.mts
+++ b/node/ferromark/index.d.mts
@@ -17,6 +17,7 @@ export interface Options {
   headingIds?: boolean
   math?: boolean
   callouts?: boolean
+  indentedCodeBlocks?: boolean
 }
 
 export interface CodeHighlighter {

--- a/node/ferromark/native.d.ts
+++ b/node/ferromark/native.d.ts
@@ -17,6 +17,7 @@ export interface Options {
   headingIds?: boolean
   math?: boolean
   callouts?: boolean
+  indentedCodeBlocks?: boolean
 }
 
 export declare function toHtml(markdown: string, options?: Options | undefined | null): string

--- a/node/ferromark/test/index.test.mjs
+++ b/node/ferromark/test/index.test.mjs
@@ -9,6 +9,10 @@ test('renders Markdown through the native binding', () => {
 
 test('maps typed options to the Rust surface', () => {
   assert.equal(toHtml('==mark==', { highlight: true }), '<p><mark>mark</mark></p>\n')
+  assert.equal(
+    toHtml('    code', { indentedCodeBlocks: false }),
+    '<p>code</p>\n',
+  )
   assert.throws(
     () => toHtml('text', { renderPolicy: 'invalid' }),
     /renderPolicy must be either 'untrusted' or 'trusted'/,

--- a/node/ferromark/test/types.test.mts
+++ b/node/ferromark/test/types.test.mts
@@ -4,6 +4,7 @@ import { toHtml, toHtmlWithHighlighter } from '../index.mjs'
 const options: Options = {
   renderPolicy: 'untrusted',
   tables: true,
+  indentedCodeBlocks: false,
 }
 const highlighter: CodeHighlighter = {
   codeToHtml: (code, { lang, theme }) => `${lang}:${theme}:${code}`,

--- a/node/native/src/lib.rs
+++ b/node/native/src/lib.rs
@@ -22,6 +22,7 @@ pub struct Options {
     pub heading_ids: Option<bool>,
     pub math: Option<bool>,
     pub callouts: Option<bool>,
+    pub indented_code_blocks: Option<bool>,
 }
 
 impl Options {
@@ -56,6 +57,7 @@ impl Options {
         apply(&mut options.heading_ids, self.heading_ids);
         apply(&mut options.math, self.math);
         apply(&mut options.callouts, self.callouts);
+        apply(&mut options.indented_code_blocks, self.indented_code_blocks);
 
         Ok(options)
     }

--- a/src/block/parser.rs
+++ b/src/block/parser.rs
@@ -573,7 +573,7 @@ impl<'a> BlockParser<'a> {
         }
 
         // Check for indented code block (4+ spaces, not in paragraph)
-        if indent >= 4 && !self.in_paragraph {
+        if self.options.indented_code_blocks && indent >= 4 && !self.in_paragraph {
             self.start_indented_code(indent, events);
             return;
         }
@@ -943,7 +943,7 @@ impl<'a> BlockParser<'a> {
         }
 
         // Check for indented code block (4+ spaces, not in paragraph)
-        if indent >= 4 && !self.in_paragraph {
+        if self.options.indented_code_blocks && indent >= 4 && !self.in_paragraph {
             self.start_indented_code(indent, events);
             return;
         }

--- a/src/block/parser.rs
+++ b/src/block/parser.rs
@@ -614,7 +614,7 @@ impl<'a> BlockParser<'a> {
                 return true;
             }
 
-            if indent >= 4 || !is_simple_line_start(first) {
+            if (indent >= 4 && self.options.indented_code_blocks) || !is_simple_line_start(first) {
                 self.cursor = Cursor::new_at(self.input, line_start);
                 return consumed_any;
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -133,6 +133,11 @@ pub struct Options {
     pub math: bool,
     /// Enable GitHub-style callouts/admonitions (`> [!NOTE]`, `> [!WARNING]`, etc.).
     pub callouts: bool,
+    /// Enable CommonMark indented code blocks (four or more leading spaces).
+    ///
+    /// Disable this for dialects that reserve indentation for other block
+    /// semantics and require fenced code blocks instead.
+    pub indented_code_blocks: bool,
 }
 
 impl Options {
@@ -160,6 +165,7 @@ impl Options {
             heading_ids: false,
             math: false,
             callouts: false,
+            indented_code_blocks: true,
         }
     }
 
@@ -187,6 +193,7 @@ impl Options {
             heading_ids: false,
             math: false,
             callouts: false,
+            indented_code_blocks: true,
         }
     }
 
@@ -214,6 +221,7 @@ impl Options {
             heading_ids: false,
             math: false,
             callouts: false,
+            indented_code_blocks: true,
         }
     }
 }
@@ -237,6 +245,7 @@ impl Default for Options {
             heading_ids: true,
             math: false,
             callouts: true,
+            indented_code_blocks: true,
         }
     }
 }

--- a/tests/indented_code_options_tests.rs
+++ b/tests/indented_code_options_tests.rs
@@ -1,0 +1,75 @@
+use ferromark::{Options, to_html, to_html_with_options};
+
+fn without_indented_code(input: &str) -> String {
+    to_html_with_options(
+        input,
+        &Options {
+            indented_code_blocks: false,
+            ..Options::default()
+        },
+    )
+}
+
+#[test]
+fn indented_code_blocks_remain_enabled_by_default() {
+    assert_eq!(
+        to_html("    fn main() {}\n"),
+        "<pre><code>fn main() {}\n</code></pre>\n"
+    );
+}
+
+#[test]
+fn top_level_indented_code_falls_back_to_paragraph_when_disabled() {
+    assert_eq!(
+        without_indented_code("    fn main() {}\n"),
+        "<p>fn main() {}</p>\n"
+    );
+}
+
+#[test]
+fn multiline_indented_code_falls_back_to_one_paragraph_when_disabled() {
+    assert_eq!(
+        without_indented_code("    first line\n    second line\n"),
+        "<p>first line\nsecond line</p>\n"
+    );
+}
+
+#[test]
+fn fenced_code_blocks_still_work_when_indented_code_is_disabled() {
+    assert_eq!(
+        without_indented_code("```rust\nfn main() {}\n```\n"),
+        "<pre><code class=\"language-rust\">fn main() {}\n</code></pre>\n"
+    );
+}
+
+#[test]
+fn nested_list_indented_code_falls_back_to_paragraph_when_disabled() {
+    assert_eq!(
+        without_indented_code("- item\n\n        nested\n"),
+        "<ul>\n<li>\n<p>item</p>\n<p>nested</p>\n</li>\n</ul>\n"
+    );
+}
+
+#[test]
+fn blockquote_indented_code_falls_back_to_paragraph_when_disabled() {
+    assert_eq!(
+        without_indented_code("> quote\n>\n>     nested\n"),
+        "<blockquote>\n<p>quote</p>\n<p>nested</p>\n</blockquote>\n"
+    );
+}
+
+#[test]
+fn footnote_indented_code_falls_back_to_paragraph_when_disabled() {
+    let result = to_html_with_options(
+        "[^1]: note\n\n        nested\n\nText[^1].\n",
+        &Options {
+            footnotes: true,
+            indented_code_blocks: false,
+            ..Options::default()
+        },
+    );
+
+    assert!(result.contains("<p>note</p>"), "{result}");
+    assert!(result.contains("<p>nested"), "{result}");
+    assert!(!result.contains("<pre><code>nested"), "{result}");
+}

--- a/tests/options_tests.rs
+++ b/tests/options_tests.rs
@@ -23,6 +23,7 @@ fn minimal_should_disable_every_optional_syntax_feature() {
             heading_ids: false,
             math: false,
             callouts: false,
+            indented_code_blocks: true,
         }
     );
 }
@@ -87,6 +88,7 @@ fn default_should_retain_the_existing_feature_mix() {
             heading_ids: true,
             math: false,
             callouts: true,
+            indented_code_blocks: true,
         }
     );
 }


### PR DESCRIPTION
## What changed

- add `Options::indented_code_blocks`, enabled by default in every public preset
- gate both indented-code entry points without changing the continuation state machine
- fall back to paragraph content when the option is disabled while preserving fenced code blocks
- document the option and include it in the shared options benchmark
- cover top-level, multiline, list, blockquote, fenced-code, and footnote behavior

## Why

Some Markdown dialects, including MDX-oriented and presentation-oriented formats, reserve indentation for other semantics and require fenced code blocks. An independent option keeps CommonMark behavior unchanged while allowing those callers to opt out without introducing a broad parser profile.

## Performance

The default path adds one boolean guard at each of the two existing indented-code entry points. The options benchmark now includes the disabled configuration so its cost remains visible.

## Validation

- `cargo fmt --check`
- `cargo test --test indented_code_options_tests --test options_tests`
- `cargo test --all-features`
- `cargo clippy --all-targets --all-features -- -D warnings`

Closes #17.

Supersedes the stale implementation in #32, which targets the removed `Profile` API.