### PR TITLE
feat: add opt-in source-only line comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,10 +95,23 @@ Fine-grained options let you turn on exactly what you need:
 ```text
 allow_html · allow_link_refs · tables · strikethrough · highlight · superscript · subscript · task_lists
 autolink_literals · disallowed_raw_html · footnotes · front_matter
-heading_ids · math · callouts
+heading_ids · math · callouts · line_comments
 ```
 
 Syntax note: ferromark uses `~~text~~` for strikethrough, `~text~` for subscript, and `^text^` for superscript. Single-tilde strikethrough is intentionally not supported.
+
+Enable `line_comments` to omit source-only note lines from HTML:
+
+```markdown
+Published text.
+
+// Review this wording before publishing.
+```
+
+Only `//` at the physical line start (after at most three spaces) is a
+comment. URLs, trailing `//`, code blocks, raw HTML blocks, and explicit
+container-prefixed lines remain ordinary Markdown. Comment text remains in the
+source and is not suitable for secrets.
 
 ## Markdown configuration
 

--- a/benches/options.rs
+++ b/benches/options.rs
@@ -40,6 +40,7 @@ fn all_extensions() -> Options {
         heading_ids: true,
         math: true,
         callouts: true,
+        line_comments: true,
     }
 }
 
@@ -53,6 +54,13 @@ fn options_cost_benches(c: &mut Criterion) {
         ("commonmark", Options::commonmark()),
         ("gfm", Options::gfm()),
         ("default", Options::default()),
+        (
+            "default_line_comments",
+            Options {
+                line_comments: true,
+                ..Options::default()
+            },
+        ),
         ("all_extensions", all_extensions()),
     ] {
         let mut output = Vec::with_capacity(input.len() + input.len() / 4);

--- a/homepage/app/routes/guide/features.mdx
+++ b/homepage/app/routes/guide/features.mdx
@@ -33,7 +33,7 @@ Enable only what your workload needs:
 allow_html · allow_link_refs · tables · strikethrough · highlight
 superscript · subscript · task_lists · autolink_literals
 disallowed_raw_html · footnotes · front_matter · heading_ids
-math · callouts
+math · callouts · line_comments
 ```
 
 ## Curated profiles

--- a/node/ferromark/index.d.mts
+++ b/node/ferromark/index.d.mts
@@ -17,6 +17,7 @@ export interface Options {
   headingIds?: boolean
   math?: boolean
   callouts?: boolean
+  lineComments?: boolean
 }
 
 export interface CodeHighlighter {

--- a/node/ferromark/native.d.ts
+++ b/node/ferromark/native.d.ts
@@ -17,6 +17,7 @@ export interface Options {
   headingIds?: boolean
   math?: boolean
   callouts?: boolean
+  lineComments?: boolean
 }
 
 export declare function toHtml(markdown: string, options?: Options | undefined | null): string

--- a/node/ferromark/test/index.test.mjs
+++ b/node/ferromark/test/index.test.mjs
@@ -9,6 +9,7 @@ test('renders Markdown through the native binding', () => {
 
 test('maps typed options to the Rust surface', () => {
   assert.equal(toHtml('==mark==', { highlight: true }), '<p><mark>mark</mark></p>\n')
+  assert.equal(toHtml('// private note', { lineComments: true }), '')
   assert.throws(
     () => toHtml('text', { renderPolicy: 'invalid' }),
     /renderPolicy must be either 'untrusted' or 'trusted'/,

--- a/node/ferromark/test/types.test.mts
+++ b/node/ferromark/test/types.test.mts
@@ -4,6 +4,7 @@ import { toHtml, toHtmlWithHighlighter } from '../index.mjs'
 const options: Options = {
   renderPolicy: 'untrusted',
   tables: true,
+  lineComments: true,
 }
 const highlighter: CodeHighlighter = {
   codeToHtml: (code, { lang, theme }) => `${lang}:${theme}:${code}`,

--- a/node/native/src/lib.rs
+++ b/node/native/src/lib.rs
@@ -22,6 +22,7 @@ pub struct Options {
     pub heading_ids: Option<bool>,
     pub math: Option<bool>,
     pub callouts: Option<bool>,
+    pub line_comments: Option<bool>,
 }
 
 impl Options {
@@ -56,6 +57,7 @@ impl Options {
         apply(&mut options.heading_ids, self.heading_ids);
         apply(&mut options.math, self.math);
         apply(&mut options.callouts, self.callouts);
+        apply(&mut options.line_comments, self.line_comments);
 
         Ok(options)
     }

--- a/src/block/event.rs
+++ b/src/block/event.rs
@@ -128,6 +128,9 @@ pub enum BlockEvent {
     /// A thematic break (horizontal rule).
     ThematicBreak,
 
+    /// A source-only line comment omitted by the HTML renderer.
+    Comment(Range),
+
     /// Start of an HTML block.
     HtmlBlockStart,
     /// End of an HTML block.

--- a/src/block/parser.rs
+++ b/src/block/parser.rs
@@ -114,6 +114,8 @@ pub struct BlockParser<'a> {
     in_paragraph: bool,
     /// Accumulated paragraph text ranges.
     paragraph_lines: Vec<Range>,
+    /// Source-only comments encountered while paragraph text is buffered.
+    paragraph_comments: Vec<Range>,
     /// Current fenced code block state, if inside one.
     fence_state: Option<FenceState>,
     /// Whether we're in an indented code block.
@@ -177,6 +179,7 @@ impl<'a> BlockParser<'a> {
             cursor: Cursor::new(input),
             in_paragraph: false,
             paragraph_lines: Vec::new(),
+            paragraph_comments: Vec::new(),
             fence_state: None,
             in_indented_code: false,
             indented_code_extra_spaces: 0,
@@ -258,6 +261,12 @@ impl<'a> BlockParser<'a> {
         // Reset column tracking at the start of each line
         self.partial_tab_cols = 0;
         self.current_col = 0;
+
+        // Source-only comments are removed before block/container matching so
+        // they do not alter the surrounding Markdown structure.
+        if self.try_line_comment(line_start, events) {
+            return;
+        }
 
         // Check for blank line first (before any space skipping), unless we're in an HTML block
         if self.html_block.is_none() && self.is_blank_line() {
@@ -612,6 +621,15 @@ impl<'a> BlockParser<'a> {
                 }
                 self.close_paragraph(events);
                 return true;
+            }
+
+            if self.options.line_comments
+                && indent < 4
+                && first == b'/'
+                && self.cursor.remaining_slice().starts_with(b"//")
+            {
+                self.cursor = Cursor::new_at(self.input, line_start);
+                return consumed_any;
             }
 
             if indent >= 4 || !is_simple_line_start(first) {
@@ -2111,26 +2129,7 @@ impl<'a> BlockParser<'a> {
 
         events.push(BlockEvent::HeadingStart { level });
 
-        // Emit text ranges for each line with soft breaks between
-        // Trim trailing spaces/tabs from the last line
-        let line_count = self.paragraph_lines.len();
-        for (i, mut range) in self.paragraph_lines.drain(..).enumerate() {
-            if i > 0 {
-                events.push(BlockEvent::SoftBreak);
-            }
-            // Trim trailing whitespace from the last line
-            if i == line_count - 1 {
-                while range.end > range.start {
-                    let b = self.input[(range.end - 1) as usize];
-                    if b == b' ' || b == b'\t' {
-                        range.end -= 1;
-                    } else {
-                        break;
-                    }
-                }
-            }
-            events.push(BlockEvent::Text(range));
-        }
+        self.emit_paragraph_items(events, true);
 
         events.push(BlockEvent::HeadingEnd { level });
     }
@@ -2833,6 +2832,59 @@ impl<'a> BlockParser<'a> {
         }
     }
 
+    /// Consume an enabled source-only line comment.
+    ///
+    /// Recognition is deliberately physical-line based: up to three leading
+    /// spaces are accepted, while tabs, four-space indentation, and explicit
+    /// block container markers remain ordinary Markdown syntax.
+    fn try_line_comment(&mut self, line_start: usize, events: &mut Vec<BlockEvent>) -> bool {
+        if !self.options.line_comments
+            || self.fence_state.is_some()
+            || self.in_indented_code
+            || self.html_block.is_some()
+        {
+            return false;
+        }
+
+        let mut marker_start = line_start;
+        let mut spaces = 0usize;
+        while marker_start < self.input.len() && self.input[marker_start] == b' ' && spaces < 4 {
+            marker_start += 1;
+            spaces += 1;
+        }
+        if spaces > 3
+            || !self
+                .input
+                .get(marker_start..)
+                .is_some_and(|rest| rest.starts_with(b"//"))
+        {
+            return false;
+        }
+
+        let mut line_end = marker_start + 2;
+        while line_end < self.input.len() && self.input[line_end] != b'\n' {
+            line_end += 1;
+        }
+        let comment_end = if line_end > marker_start + 2 && self.input[line_end - 1] == b'\r' {
+            line_end - 1
+        } else {
+            line_end
+        };
+        let range = Range::from_usize(marker_start, comment_end);
+
+        if line_end < self.input.len() {
+            line_end += 1;
+        }
+        self.cursor = Cursor::new_at(self.input, line_end);
+
+        if self.in_paragraph {
+            self.paragraph_comments.push(range);
+        } else {
+            events.push(BlockEvent::Comment(range));
+        }
+        true
+    }
+
     // --- Table parsing ---
 
     /// Split a table line by unescaped `|` outside backtick code spans.
@@ -3065,6 +3117,10 @@ impl<'a> BlockParser<'a> {
     ) {
         // Extract the last paragraph line for use as header
         let header_range = self.paragraph_lines.pop().unwrap();
+        let table_comment_start = self
+            .paragraph_comments
+            .partition_point(|range| range.start < header_range.start);
+        let table_comments = self.paragraph_comments.split_off(table_comment_start);
 
         // Close any remaining paragraph content (lines before the header line)
         // These stay as a normal paragraph
@@ -3072,13 +3128,10 @@ impl<'a> BlockParser<'a> {
             // Emit those lines as a paragraph
             self.mark_container_has_content();
             events.push(BlockEvent::ParagraphStart);
-            for (i, range) in self.paragraph_lines.drain(..).enumerate() {
-                if i > 0 {
-                    events.push(BlockEvent::SoftBreak);
-                }
-                events.push(BlockEvent::Text(range));
-            }
+            self.emit_paragraph_items(events, false);
             events.push(BlockEvent::ParagraphEnd);
+        } else {
+            events.extend(self.paragraph_comments.drain(..).map(BlockEvent::Comment));
         }
         self.in_paragraph = false;
 
@@ -3106,6 +3159,7 @@ impl<'a> BlockParser<'a> {
         }
 
         events.push(BlockEvent::TableRowEnd);
+        events.extend(table_comments.into_iter().map(BlockEvent::Comment));
         events.push(BlockEvent::TableHeadEnd);
 
         // Set table state
@@ -3184,6 +3238,7 @@ impl<'a> BlockParser<'a> {
         self.in_paragraph = false;
 
         if self.paragraph_lines.is_empty() {
+            events.extend(self.paragraph_comments.drain(..).map(BlockEvent::Comment));
             return;
         }
 
@@ -3203,16 +3258,44 @@ impl<'a> BlockParser<'a> {
 
         events.push(BlockEvent::ParagraphStart);
 
-        // Emit text ranges for each line with soft breaks between
-        for (i, range) in self.paragraph_lines.drain(..).enumerate() {
-            if i > 0 {
-                // Add soft break between lines
+        self.emit_paragraph_items(events, false);
+
+        events.push(BlockEvent::ParagraphEnd);
+    }
+
+    /// Emit buffered paragraph text and comments in source order.
+    fn emit_paragraph_items(&mut self, events: &mut Vec<BlockEvent>, trim_last_line: bool) {
+        let mut comments = std::mem::take(&mut self.paragraph_comments)
+            .into_iter()
+            .peekable();
+        let line_count = self.paragraph_lines.len();
+
+        for (index, mut range) in self.paragraph_lines.drain(..).enumerate() {
+            while comments
+                .peek()
+                .is_some_and(|comment| comment.start < range.start)
+            {
+                events.push(BlockEvent::Comment(comments.next().unwrap()));
+            }
+
+            if index > 0 {
                 events.push(BlockEvent::SoftBreak);
+            }
+
+            if trim_last_line && index == line_count - 1 {
+                while range.end > range.start {
+                    let byte = self.input[(range.end - 1) as usize];
+                    if byte == b' ' || byte == b'\t' {
+                        range.end -= 1;
+                    } else {
+                        break;
+                    }
+                }
             }
             events.push(BlockEvent::Text(range));
         }
 
-        events.push(BlockEvent::ParagraphEnd);
+        events.extend(comments.map(BlockEvent::Comment));
     }
 
     /// Close the current footnote definition, draining captured events into the store.

--- a/src/block/parser.rs
+++ b/src/block/parser.rs
@@ -2815,6 +2815,8 @@ impl<'a> BlockParser<'a> {
                 content_start + remaining
             }
         };
+        let content_end = line_end
+            - usize::from(line_end > content_start && self.input.get(line_end - 1) == Some(&b'\r'));
 
         // If we weren't in a paragraph, we are now
         if !self.in_paragraph {
@@ -2826,9 +2828,9 @@ impl<'a> BlockParser<'a> {
         // Add this line to paragraph content
         // We include from original line_start to capture any leading spaces we skipped
         // Actually, use content_start which is after indent
-        if line_end > content_start {
+        if content_end > content_start {
             self.paragraph_lines
-                .push(Range::from_usize(content_start, line_end));
+                .push(Range::from_usize(content_start, content_end));
         }
     }
 
@@ -3250,6 +3252,7 @@ impl<'a> BlockParser<'a> {
         }
 
         if self.paragraph_lines.is_empty() {
+            events.extend(self.paragraph_comments.drain(..).map(BlockEvent::Comment));
             return;
         }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -133,6 +133,8 @@ pub struct Options {
     pub math: bool,
     /// Enable GitHub-style callouts/admonitions (`> [!NOTE]`, `> [!WARNING]`, etc.).
     pub callouts: bool,
+    /// Enable source-only line comments beginning with `//`.
+    pub line_comments: bool,
 }
 
 impl Options {
@@ -160,6 +162,7 @@ impl Options {
             heading_ids: false,
             math: false,
             callouts: false,
+            line_comments: false,
         }
     }
 
@@ -187,6 +190,7 @@ impl Options {
             heading_ids: false,
             math: false,
             callouts: false,
+            line_comments: false,
         }
     }
 
@@ -214,6 +218,7 @@ impl Options {
             heading_ids: false,
             math: false,
             callouts: false,
+            line_comments: false,
         }
     }
 }
@@ -237,6 +242,7 @@ impl Default for Options {
             heading_ids: true,
             math: false,
             callouts: true,
+            line_comments: false,
         }
     }
 }
@@ -1034,6 +1040,7 @@ impl<R: FencedCodeRenderer + ?Sized> RenderContext<'_, '_, R> {
                 }
                 writer.thematic_break();
             }
+            BlockEvent::Comment(_) => {}
             BlockEvent::HtmlBlockStart => {
                 // Write pending newline from loose list item start
                 if *pending_loose_li_newline {

--- a/src/mdx/events.rs
+++ b/src/mdx/events.rs
@@ -517,6 +517,7 @@ fn offset_block_event(mut event: BlockEvent, offset: usize) -> BlockEvent {
             kind: CodeBlockKind::Fenced { info: Some(range) },
         }
         | BlockEvent::HtmlBlockText(range)
+        | BlockEvent::Comment(range)
         | BlockEvent::Code(range) => *range = offset_range(*range, offset),
         _ => {}
     }
@@ -554,6 +555,7 @@ fn block_event_range(event: &BlockEvent) -> Option<Range> {
             kind: CodeBlockKind::Fenced { info: Some(range) },
         }
         | BlockEvent::HtmlBlockText(range)
+        | BlockEvent::Comment(range)
         | BlockEvent::Text(range)
         | BlockEvent::Code(range) => Some(*range),
         _ => None,

--- a/src/profiling.rs
+++ b/src/profiling.rs
@@ -91,7 +91,10 @@ pub(crate) fn record_block_events(events: &[BlockEvent], capacity: usize) {
         counters.max_block_event_capacity = counters.max_block_event_capacity.max(capacity as u64);
         for event in events {
             match event {
-                BlockEvent::Text(_) | BlockEvent::SoftBreak | BlockEvent::HtmlBlockText(_) => {
+                BlockEvent::Text(_)
+                | BlockEvent::SoftBreak
+                | BlockEvent::Comment(_)
+                | BlockEvent::HtmlBlockText(_) => {
                     counters.block_text_events += 1;
                 }
                 BlockEvent::BlockQuoteStart { .. }

--- a/src/profiling.rs
+++ b/src/profiling.rs
@@ -91,10 +91,7 @@ pub(crate) fn record_block_events(events: &[BlockEvent], capacity: usize) {
         counters.max_block_event_capacity = counters.max_block_event_capacity.max(capacity as u64);
         for event in events {
             match event {
-                BlockEvent::Text(_)
-                | BlockEvent::SoftBreak
-                | BlockEvent::Comment(_)
-                | BlockEvent::HtmlBlockText(_) => {
+                BlockEvent::Text(_) | BlockEvent::SoftBreak | BlockEvent::HtmlBlockText(_) => {
                     counters.block_text_events += 1;
                 }
                 BlockEvent::BlockQuoteStart { .. }
@@ -198,5 +195,15 @@ mod tests {
         reset();
 
         assert_eq!(snapshot().paragraph_copied_bytes, 0);
+    }
+
+    #[test]
+    fn comments_should_not_count_as_block_text_work() {
+        reset();
+        record_block_events(&[BlockEvent::Comment(crate::Range::new(0, 4))], 1);
+
+        let counters = snapshot();
+        assert_eq!(counters.block_events, 1);
+        assert_eq!(counters.block_text_events, 0);
     }
 }

--- a/tests/line_comment_tests.rs
+++ b/tests/line_comment_tests.rs
@@ -1,0 +1,153 @@
+use ferromark::{BlockEvent, BlockParser, Options, Range, RenderPolicy, to_html_with_options};
+
+fn with_line_comments(input: &str) -> String {
+    to_html_with_options(
+        input,
+        &Options {
+            line_comments: true,
+            ..Options::default()
+        },
+    )
+}
+
+#[test]
+fn line_comments_are_disabled_by_default() {
+    assert_eq!(
+        to_html_with_options("// private note", &Options::default()),
+        "<p>// private note</p>\n"
+    );
+}
+
+#[test]
+fn enabled_line_comments_emit_no_html() {
+    assert_eq!(with_line_comments("// first\n   // second\n//\n"), "");
+}
+
+#[test]
+fn comments_between_paragraph_lines_behave_like_removed_source_lines() {
+    assert_eq!(
+        with_line_comments("first\n// private\nsecond\n"),
+        "<p>first\nsecond</p>\n"
+    );
+}
+
+#[test]
+fn explicit_blank_lines_still_separate_paragraphs() {
+    assert_eq!(
+        with_line_comments("first\n\n// private\n\nsecond\n"),
+        "<p>first</p>\n<p>second</p>\n"
+    );
+}
+
+#[test]
+fn urls_trailing_slashes_and_escaped_markers_remain_text() {
+    assert_eq!(
+        with_line_comments("https://example.com\nText // ordinary\n\\// escaped\n"),
+        "<p>https://example.com\nText // ordinary\n// escaped</p>\n"
+    );
+}
+
+#[test]
+fn four_space_indentation_remains_code() {
+    assert_eq!(
+        with_line_comments("   // hidden\n    // code\n"),
+        "<pre><code>// code\n</code></pre>\n"
+    );
+}
+
+#[test]
+fn fenced_code_and_raw_html_blocks_remain_opaque() {
+    assert_eq!(
+        with_line_comments("```\n// code\n```\n"),
+        "<pre><code>// code\n</code></pre>\n"
+    );
+
+    let html = to_html_with_options(
+        "<div>\n// html content\n</div>\n",
+        &Options {
+            line_comments: true,
+            render_policy: RenderPolicy::Trusted,
+            ..Options::default()
+        },
+    );
+    assert_eq!(html, "<div>\n// html content\n</div>\n");
+}
+
+#[test]
+fn comments_do_not_break_existing_container_structure() {
+    assert_eq!(
+        with_line_comments("> first\n// private\n> second\n"),
+        "<blockquote>\n<p>first\nsecond</p>\n</blockquote>\n"
+    );
+    assert_eq!(
+        with_line_comments("- first\n// private\n- second\n"),
+        "<ul>\n<li>first</li>\n<li>second</li>\n</ul>\n"
+    );
+}
+
+#[test]
+fn explicit_container_prefixes_are_not_comment_markers() {
+    assert_eq!(
+        with_line_comments("> // visible\n"),
+        "<blockquote>\n<p>// visible</p>\n</blockquote>\n"
+    );
+}
+
+#[test]
+fn comments_do_not_prevent_setext_headings_or_tables() {
+    assert_eq!(
+        with_line_comments("Heading\n// private\n---\n"),
+        "<h2 id=\"heading\">Heading</h2>\n"
+    );
+
+    let table = with_line_comments("A | B\n// private\n- | -\n1 | 2\n");
+    assert!(table.starts_with("<table>\n<thead>\n<tr>\n<th>A</th>\n<th>B</th>"));
+    assert!(!table.contains("private"));
+}
+
+#[test]
+fn semantic_comment_events_keep_exact_source_order_and_range() {
+    let input = "first\n// private\nsecond\n";
+    let mut parser = BlockParser::new_with_options(
+        input.as_bytes(),
+        Options {
+            line_comments: true,
+            ..Options::default()
+        },
+    );
+    let mut events = Vec::new();
+    parser.parse(&mut events);
+
+    assert_eq!(
+        events,
+        vec![
+            BlockEvent::ParagraphStart,
+            BlockEvent::Text(Range::new(0, 5)),
+            BlockEvent::Comment(Range::new(6, 16)),
+            BlockEvent::SoftBreak,
+            BlockEvent::Text(Range::new(17, 23)),
+            BlockEvent::ParagraphEnd,
+        ]
+    );
+    assert_eq!(
+        Range::new(6, 16).slice_str(input.as_bytes()).unwrap(),
+        "// private"
+    );
+}
+
+#[test]
+fn crlf_comment_ranges_exclude_the_line_ending() {
+    let input = "// private\r\nvisible\r\n";
+    let mut parser = BlockParser::new_with_options(
+        input.as_bytes(),
+        Options {
+            line_comments: true,
+            ..Options::default()
+        },
+    );
+    let mut events = Vec::new();
+    parser.parse(&mut events);
+
+    assert!(events.contains(&BlockEvent::Comment(Range::new(0, 10))));
+    assert_eq!(with_line_comments(input), "<p>visible\r</p>\n");
+}

--- a/tests/line_comment_tests.rs
+++ b/tests/line_comment_tests.rs
@@ -149,5 +149,30 @@ fn crlf_comment_ranges_exclude_the_line_ending() {
     parser.parse(&mut events);
 
     assert!(events.contains(&BlockEvent::Comment(Range::new(0, 10))));
-    assert_eq!(with_line_comments(input), "<p>visible\r</p>\n");
+    assert_eq!(with_line_comments(input), "<p>visible</p>\n");
+}
+
+#[test]
+fn comments_before_link_reference_definitions_do_not_leak() {
+    let input = "// private\n[target]: /url\n\nvisible\n";
+    let mut parser = BlockParser::new_with_options(
+        input.as_bytes(),
+        Options {
+            line_comments: true,
+            ..Options::default()
+        },
+    );
+    let mut events = Vec::new();
+    parser.parse(&mut events);
+
+    assert_eq!(
+        events,
+        vec![
+            BlockEvent::Comment(Range::new(0, 10)),
+            BlockEvent::ParagraphStart,
+            BlockEvent::Text(Range::new(27, 34)),
+            BlockEvent::ParagraphEnd,
+        ]
+    );
+    assert_eq!(with_line_comments(input), "<p>visible</p>\n");
 }

--- a/tests/options_tests.rs
+++ b/tests/options_tests.rs
@@ -23,6 +23,7 @@ fn minimal_should_disable_every_optional_syntax_feature() {
             heading_ids: false,
             math: false,
             callouts: false,
+            line_comments: false,
         }
     );
 }
@@ -87,6 +88,7 @@ fn default_should_retain_the_existing_feature_mix() {
             heading_ids: true,
             math: false,
             callouts: true,
+            line_comments: false,
         }
     );
 }


### PR DESCRIPTION
## Summary

- add an opt-in `line_comments` parser option (disabled in every preset and by default)
- recognize `//` only at a physical line start after at most three spaces
- omit comments from HTML while preserving exact `BlockEvent::Comment(Range)` source spans
- expose the option in the Node binding and document the deliberately narrow syntax

Comments behave like removed source lines: URLs, inline/trailing `//`, four-space indented code, fenced code, raw HTML, and explicit container-prefixed lines remain ordinary Markdown. Comment text stays in the source and is not a security boundary.

## Validation

- `cargo test --all-features`
- `cargo clippy --all-targets --all-features -- -D warnings`
- Node native build, 4 runtime tests, and TypeScript typecheck
- 12 focused integration tests covering defaults, paragraph continuity, blank lines, code/HTML opacity, containers, setext headings, tables, source ordering/ranges, and CRLF

## Performance

Criterion `options/shared_corpus` (comment-free input):

- default: 185.83 µs
- default + line comments: 186.78 µs

That is about 0.5% in this run, within normal benchmark noise and isolated to the enabled option.

Closes #9