### PR TITLE
rfc: define an event-based presentation adapter

### DIFF
--- a/benches/parsing.rs
+++ b/benches/parsing.rs
@@ -102,6 +102,11 @@ to handle longer documents efficiently.
     pub fn pathological_nested() -> String {
         "> ".repeat(100) + "deep\n"
     }
+
+    /// Presentation-like input that exercises semantic slide boundaries.
+    pub fn thematic_breaks() -> String {
+        "Slide content with **formatting**.\n\n---\n\n".repeat(500)
+    }
 }
 
 fn bench_parsing(c: &mut Criterion) {
@@ -156,6 +161,12 @@ fn bench_parsing(c: &mut Criterion) {
     group.throughput(Throughput::Bytes(tables_5k.len() as u64));
     group.bench_function("tables_5k", |b| {
         b.iter(|| ferromark::to_html(black_box(tables_5k)))
+    });
+
+    let thematic_breaks = samples::thematic_breaks();
+    group.throughput(Throughput::Bytes(thematic_breaks.len() as u64));
+    group.bench_function("thematic_breaks", |b| {
+        b.iter(|| ferromark::to_html(black_box(&thematic_breaks)))
     });
 
     group.finish();

--- a/docs/arch/ADR-0011-event-based-presentation-adapter.md
+++ b/docs/arch/ADR-0011-event-based-presentation-adapter.md
@@ -1,0 +1,171 @@
+# ADR-0011: Event-Based Presentation Adapter
+
+**Status:** Proposed
+**Date:** 2026-07-25
+
+## Context
+
+An iA Presenter-like consumer needs to split one MDX document into slides and
+separate audience content from moderator-only notes. Ferromark already exposes
+an opt-in, source-ranged MDX event stream. Explicit flow components such as
+`<Moderator>...</Moderator>` can identify notes without adding
+presentation-specific punctuation to Markdown.
+
+Two gaps prevent a clean downstream adapter:
+
+- `BlockEvent::ThematicBreak` did not carry the source range needed to retain
+  exact slide boundaries.
+- The current renderer owns document-wide link references, footnote
+  definitions, heading identifiers, and block state. Rendering arbitrary
+  subsets of a flat event stream as if they were independent documents would
+  expose an API whose balancing and identifier guarantees are unclear.
+
+Reparsing source slices for every slide would avoid the second problem, but
+would duplicate parsing work, lose the original container context, and make
+slide splitting dependent on raw `---` scanning. A presentation-specific
+parser mode would duplicate MDX grammar and add another compatibility surface.
+
+## Decision
+
+Ferromark will treat presentations as an opt-in adapter over the semantic MDX
+event stream, not as a parser mode and not as new core Markdown syntax.
+
+The reusable core event now records a thematic break as
+`BlockEvent::ThematicBreak(Range)`. The range covers the marker run and
+intervening/trailing horizontal whitespace, excluding container indentation
+and the line ending. The MDX event-stream contract is bumped to version 2
+because this changes a public event variant.
+
+The proposed adapter API is:
+
+```rust
+pub struct PresentationOptions<'a> {
+    pub moderator_components: &'a [&'a str],
+}
+
+pub struct Presentation {
+    pub stream: MdxEventStream,
+    pub shared_events: EventSelection,
+    pub slides: Vec<Slide>,
+}
+
+pub struct Slide {
+    pub source_range: Range,
+    pub opening_boundary: Option<Range>,
+    pub audience: EventSelection,
+    pub moderator: EventSelection,
+}
+
+pub struct EventSelection {
+    pub event_ranges: Vec<std::ops::Range<usize>>,
+}
+
+pub fn parse_presentation(
+    input: &str,
+    options: &PresentationOptions<'_>,
+) -> Result<Presentation, Vec<PresentationDiagnostic>>;
+```
+
+Selections contain indices into the one owned `MdxEventStream`; they do not
+clone source text or semantic events. Front matter and ESM are shared document
+events rather than slide content. Component names are explicit configuration;
+Ferromark does not assign special meaning to a generic `<Notes>` component
+unless the caller requests it.
+
+A generic public event-substream-to-HTML renderer is deferred. It should only
+be added after its link, footnote, heading-ID, JSX-context, and balanced-event
+contracts can be stated independently of presentations. The presentation
+adapter should first expose structured selections; an eager HTML convenience
+layer can then be built on the same renderer contract.
+
+## Slide and channel rules
+
+- Only a thematic-break event at Markdown container depth zero and JSX flow
+  depth zero splits a slide.
+- A boundary at the beginning or end creates an empty first or last slide.
+  Consecutive boundaries preserve the empty slide between them.
+- A Setext underline is a heading event, never a slide boundary.
+- Thematic breaks in block quotes, lists, moderator content, or any other flow
+  component remain content of the current slide.
+- A configured moderator component must be a balanced root-level flow JSX
+  container. Its wrapper events are structural and omitted from both channel
+  selections; all nested Markdown and JSX content belongs to the moderator
+  selection.
+- Other JSX containers remain in their current channel. A moderator component
+  nested inside a Markdown container is diagnosed rather than silently
+  changing container balance.
+- Malformed or mismatched flow JSX uses the strict MDX diagnostics and produces
+  no partial presentation.
+
+These rules deliberately do not use `//` comments as moderator notes. Line
+comments are source annotations with no rendered output and a separate option.
+
+## Footnotes
+
+Footnotes are slide-local at rendering time. Each slide numbers references in
+first-reference order, emits only definitions referenced by that slide, and
+prefixes generated IDs with the slide ordinal. A definition may therefore be
+rendered on more than one slide without cross-slide links.
+
+Implementing this without reparsing requires `MdxEventStream` to retain the
+footnote definition store just as it already retains link-reference
+definitions. The adapter must not ship eager HTML until that prerequisite is
+implemented and tested. Documents without footnotes are unaffected.
+
+## Considered options
+
+### Add presentation syntax to the block parser
+
+Rejected. It would make a presentation concern part of every Markdown parse
+and compete with CommonMark meanings for indentation and thematic breaks.
+
+### Reparse each slide source range
+
+Rejected as the primary design. It repeats parsing, complicates references
+across boundaries, and cannot reliably recover JSX/container context from an
+arbitrary slice.
+
+### Render arbitrary cloned event vectors
+
+Deferred. A vector alone does not carry the stores and state needed for
+correct links, footnotes, identifiers, or balanced containers.
+
+### Return event selections over one semantic stream
+
+Chosen. It preserves one parse, exact source identity, and document-level
+semantic stores while keeping presentation policy outside the hot Markdown
+path.
+
+## Consequences
+
+- Existing `to_html*` and MDX rendering entry points keep their behavior and do
+  not run presentation analysis.
+- The ordinary block parser stores one range in thematic-break events but adds
+  no pass, allocation, or source scan.
+- Consumers can identify exact semantic slide boundaries immediately.
+- Audience/moderator HTML remains follow-up work rather than being exposed with
+  underspecified renderer semantics.
+- Implementing slide-local footnotes requires the MDX semantic stream to retain
+  footnote definitions.
+- Accepting this proposal will require tests for all boundary and channel rules
+  before the adapter becomes stable.
+
+## Validation and review triggers
+
+- On 2026-07-25, the `parsing/thematic_breaks` fixture (500 boundaries,
+  approximately 20.5 KB) measured 103.25 µs on `main` and 103.67 µs with
+  source-ranged events. Criterion reported no performance change (95%
+  confidence interval: -0.04% to +0.50%).
+- Benchmark normal Markdown rendering with a thematic-break-heavy fixture
+  before accepting the event-shape change; no material regression is allowed.
+- Benchmark the adapter separately from `mdx::parse_events`.
+- Revisit the selection model if a renderer cannot preserve balanced
+  containers without copying events.
+- Revisit shared events if ESM or front matter gains slide-local semantics.
+
+## References
+
+- Issue #5: event-based presentation output
+- ADR-0001: Core Architecture — Streaming, No AST
+- ADR-0009: MDX Compatibility and Performance Boundaries
+- iA Presenter Markdown Guide: <https://ia.net/presenter/support/basics/markdown>

--- a/src/block/event.rs
+++ b/src/block/event.rs
@@ -125,8 +125,8 @@ pub enum BlockEvent {
     /// End of a list item.
     ListItemEnd,
 
-    /// A thematic break (horizontal rule).
-    ThematicBreak,
+    /// A thematic break (horizontal rule) and its exact marker range.
+    ThematicBreak(Range),
 
     /// Start of an HTML block.
     HtmlBlockStart,

--- a/src/block/event.rs
+++ b/src/block/event.rs
@@ -125,7 +125,12 @@ pub enum BlockEvent {
     /// End of a list item.
     ListItemEnd,
 
-    /// A thematic break (horizontal rule) and its exact marker range.
+    /// A thematic break (horizontal rule).
+    ///
+    /// The `Range` covers the marker run and any intervening or trailing
+    /// horizontal whitespace on the same line. It excludes container
+    /// indentation (leading spaces already consumed by the block loop) and
+    /// the line ending character.
     ThematicBreak(Range),
 
     /// Start of an HTML block.

--- a/src/block/parser.rs
+++ b/src/block/parser.rs
@@ -1908,7 +1908,7 @@ impl<'a> BlockParser<'a> {
     /// Try to parse a thematic break.
     /// Returns true if successful.
     fn try_thematic_break(&mut self, events: &mut Vec<BlockEvent>) -> bool {
-        let _start_pos = self.cursor.offset();
+        let start_pos = self.cursor.offset();
 
         // Must start with -, *, or _
         let marker = match self.cursor.peek() {
@@ -1951,7 +1951,10 @@ impl<'a> BlockParser<'a> {
         // Mark the current container as having content
         self.mark_container_has_content();
 
-        events.push(BlockEvent::ThematicBreak);
+        events.push(BlockEvent::ThematicBreak(Range::from_usize(
+            start_pos,
+            temp_cursor.offset(),
+        )));
         true
     }
 
@@ -3852,31 +3855,46 @@ mod tests {
     #[test]
     fn test_thematic_break_dashes() {
         let events = parse("---");
-        assert_eq!(events, vec![BlockEvent::ThematicBreak]);
+        assert_eq!(
+            events,
+            vec![BlockEvent::ThematicBreak(Range::from_usize(0, 3))]
+        );
     }
 
     #[test]
     fn test_thematic_break_asterisks() {
         let events = parse("***");
-        assert_eq!(events, vec![BlockEvent::ThematicBreak]);
+        assert_eq!(
+            events,
+            vec![BlockEvent::ThematicBreak(Range::from_usize(0, 3))]
+        );
     }
 
     #[test]
     fn test_thematic_break_underscores() {
         let events = parse("___");
-        assert_eq!(events, vec![BlockEvent::ThematicBreak]);
+        assert_eq!(
+            events,
+            vec![BlockEvent::ThematicBreak(Range::from_usize(0, 3))]
+        );
     }
 
     #[test]
     fn test_thematic_break_with_spaces() {
         let events = parse("- - -");
-        assert_eq!(events, vec![BlockEvent::ThematicBreak]);
+        assert_eq!(
+            events,
+            vec![BlockEvent::ThematicBreak(Range::from_usize(0, 5))]
+        );
     }
 
     #[test]
     fn test_thematic_break_many() {
         let events = parse("----------");
-        assert_eq!(events, vec![BlockEvent::ThematicBreak]);
+        assert_eq!(
+            events,
+            vec![BlockEvent::ThematicBreak(Range::from_usize(0, 10))]
+        );
     }
 
     #[test]
@@ -3985,7 +4003,10 @@ mod tests {
         assert_eq!(events.len(), 4);
         assert_eq!(events[0], BlockEvent::ParagraphStart);
         assert_eq!(events[2], BlockEvent::ParagraphEnd);
-        assert_eq!(events[3], BlockEvent::ThematicBreak);
+        assert_eq!(
+            events[3],
+            BlockEvent::ThematicBreak(Range::from_usize(6, 9))
+        );
     }
 
     #[test]
@@ -4011,7 +4032,19 @@ mod tests {
     #[test]
     fn test_thematic_break_with_leading_spaces() {
         let events = parse("   ---");
-        assert_eq!(events, vec![BlockEvent::ThematicBreak]);
+        assert_eq!(
+            events,
+            vec![BlockEvent::ThematicBreak(Range::from_usize(3, 6))]
+        );
+    }
+
+    #[test]
+    fn test_thematic_break_range_includes_trailing_horizontal_whitespace() {
+        let events = parse("  - - - \t\n");
+        assert_eq!(
+            events,
+            vec![BlockEvent::ThematicBreak(Range::from_usize(2, 9))]
+        );
     }
 
     // Fenced code block tests

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1026,7 +1026,7 @@ impl<R: FencedCodeRenderer + ?Sized> RenderContext<'_, '_, R> {
                 }
                 writer.heading_end(*level);
             }
-            BlockEvent::ThematicBreak => {
+            BlockEvent::ThematicBreak(_) => {
                 // If we're at the start of a tight list item, add newline before block content
                 if *at_tight_li_start {
                     writer.newline();

--- a/src/mdx/events.rs
+++ b/src/mdx/events.rs
@@ -16,7 +16,7 @@ use super::{MdxDiagnostic, Segment, segment_spanned};
 ///
 /// Consumers that persist or exchange event data can record this value
 /// alongside their derived representation.
-pub const MDX_EVENT_STREAM_VERSION: u16 = 1;
+pub const MDX_EVENT_STREAM_VERSION: u16 = 2;
 
 /// A semantic event in an MDX document.
 ///
@@ -517,7 +517,8 @@ fn offset_block_event(mut event: BlockEvent, offset: usize) -> BlockEvent {
             kind: CodeBlockKind::Fenced { info: Some(range) },
         }
         | BlockEvent::HtmlBlockText(range)
-        | BlockEvent::Code(range) => *range = offset_range(*range, offset),
+        | BlockEvent::Code(range)
+        | BlockEvent::ThematicBreak(range) => *range = offset_range(*range, offset),
         _ => {}
     }
     event
@@ -555,7 +556,8 @@ fn block_event_range(event: &BlockEvent) -> Option<Range> {
         }
         | BlockEvent::HtmlBlockText(range)
         | BlockEvent::Text(range)
-        | BlockEvent::Code(range) => Some(*range),
+        | BlockEvent::Code(range)
+        | BlockEvent::ThematicBreak(range) => Some(*range),
         _ => None,
     }
 }

--- a/tests/mdx_event_tests.rs
+++ b/tests/mdx_event_tests.rs
@@ -190,6 +190,33 @@ fn markdown_block_boundaries_remain_ordered_and_balanced() {
 }
 
 #[test]
+fn thematic_breaks_expose_exact_absolute_source_ranges() {
+    let input = concat!(
+        "# Intro\n\n",
+        "  - - - \t\n\n",
+        "> ***\n\n",
+        "Setext heading\n",
+        "---\n\n",
+        "<Panel>\n\n",
+        "___\n\n",
+        "</Panel>\n",
+    );
+    let stream = parse_events(input);
+    let breaks = stream
+        .events
+        .iter()
+        .filter_map(|event| match event {
+            MdxEvent::Block(BlockEvent::ThematicBreak(range)) => {
+                Some(range.slice_str(input.as_bytes()).unwrap())
+            }
+            _ => None,
+        })
+        .collect::<Vec<_>>();
+
+    assert_eq!(breaks, vec!["- - - \t", "***", "___"]);
+}
+
+#[test]
 fn contiguous_multiline_paragraphs_share_one_inline_parse() {
     let input = "Paragraph with *emphasis\ncontinued* and {name}.\n";
     let stream = parse_events(input);


### PR DESCRIPTION
## Summary

- add exact source ranges to `BlockEvent::ThematicBreak` and expose them through the MDX event stream
- bump the public MDX event-stream contract to version 2
- propose the smallest presentation API as event selections over one owned semantic stream
- define slide splitting, `<Moderator>` channel semantics, empty/consecutive boundaries, nested containers, Setext headings, strict diagnostics, and slide-local footnotes
- deliberately defer a generic event-substream HTML renderer until its document stores and balancing contract are explicit

The ADR keeps presentations out of the Markdown grammar and normal render path. It also records why reparsing each slide or rendering arbitrary cloned event vectors would be misleading APIs.

## Validation

- `cargo test --all-features`
- `cargo clippy --all-targets --all-features -- -D warnings`
- exact range tests for indented/spaced thematic breaks, nested block quotes, Setext headings, and thematic breaks inside JSX components

## Performance

A new 20.5 KB fixture with 500 thematic breaks was measured against unchanged `main`:

- main: 103.25 µs
- source-ranged events: 103.67 µs
- Criterion 95% confidence interval: -0.04% to +0.50%

Criterion reported no performance change. The implementation adds no pass, allocation, or source scan.

Closes #5