### PR TITLE
feat: add opt-in definition lists

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ raw-HTML CommonMark output parity. Run `cargo test --test commonmark_spec --
 
 **All five GFM extensions**: Tables, strikethrough, task lists, autolink literals, disallowed raw HTML.
 
-**Beyond GFM**: Footnotes, front matter extraction (`---`/`+++`), heading IDs (GitHub-compatible slugs), math spans (`$`/`$$`), highlight/mark syntax (`==text==`), superscript (`^text^`), subscript (`~text~`), and callouts (`> [!NOTE]`, `> [!WARNING]`, ...).
+**Beyond GFM**: Footnotes, definition lists, front matter extraction (`---`/`+++`), heading IDs (GitHub-compatible slugs), math spans (`$`/`$$`), highlight/mark syntax (`==text==`), superscript (`^text^`), subscript (`~text~`), and callouts (`> [!NOTE]`, `> [!WARNING]`, ...).
 
 **MDX support** (opt-in via `mdx` feature): Segment and render `.mdx` files without a JavaScript toolchain. Covers 90%+ of real-world MDX patterns in Next.js, Docusaurus, and Astro.
 
@@ -95,10 +95,22 @@ Fine-grained options let you turn on exactly what you need:
 ```text
 allow_html · allow_link_refs · tables · strikethrough · highlight · superscript · subscript · task_lists
 autolink_literals · disallowed_raw_html · footnotes · front_matter
-heading_ids · math · callouts
+heading_ids · math · callouts · definition_lists
 ```
 
 Syntax note: ferromark uses `~~text~~` for strikethrough, `~text~` for subscript, and `^text^` for superscript. Single-tilde strikethrough is intentionally not supported.
+
+Enable `definition_lists` for PHP Markdown Extra-style terms and descriptions:
+
+```markdown
+Term
+: A definition with *inline Markdown*.
+```
+
+Markers may have up to three leading spaces and require whitespace after the
+colon. Continuation paragraphs and nested blocks must be indented to the
+description content; lazy continuation is supported only for paragraph text.
+The option is disabled by default and in every dialect constructor.
 
 ## Markdown configuration
 

--- a/benches/options.rs
+++ b/benches/options.rs
@@ -42,6 +42,7 @@ fn all_extensions() -> Options {
         heading_ids: true,
         math: true,
         callouts: true,
+        definition_lists: true,
     }
 }
 
@@ -55,6 +56,13 @@ fn options_cost_benches(c: &mut Criterion) {
         ("commonmark", Options::commonmark()),
         ("gfm", Options::gfm()),
         ("default", Options::default()),
+        (
+            "default_definition_lists",
+            Options {
+                definition_lists: true,
+                ..Options::default()
+            },
+        ),
         ("all_extensions", all_extensions()),
     ] {
         let mut output = Vec::with_capacity(input.len() + input.len() / 4);

--- a/benchmarks/pulldown-comparison/src/lib.rs
+++ b/benchmarks/pulldown-comparison/src/lib.rs
@@ -48,6 +48,9 @@ pub fn ferromark_options(config: ParityConfig) -> FerromarkOptions {
         heading_ids: false,
         math,
         callouts,
+        definition_lists: false,
+        line_comments: false,
+        indented_code_blocks: true,
     }
 }
 

--- a/benchmarks/pulldown-comparison/src/model.rs
+++ b/benchmarks/pulldown-comparison/src/model.rs
@@ -192,6 +192,7 @@ fn all_extensions() -> Options {
         heading_ids: true,
         math: true,
         callouts: true,
+        definition_lists: true,
     }
 }
 

--- a/benchmarks/pulldown-comparison/src/model.rs
+++ b/benchmarks/pulldown-comparison/src/model.rs
@@ -193,6 +193,8 @@ fn all_extensions() -> Options {
         math: true,
         callouts: true,
         definition_lists: true,
+        line_comments: true,
+        indented_code_blocks: true,
     }
 }
 

--- a/homepage/app/routes/guide/features.mdx
+++ b/homepage/app/routes/guide/features.mdx
@@ -24,6 +24,7 @@ title: Features and Flags
 - Highlight (`==text==` renders `<mark>`)
 - Superscript (`^text^` renders `<sup>`)
 - Subscript (`~text~` renders `<sub>`)
+- Definition lists (`Term` followed by `: Definition`)
 
 ## Configuration flags
 
@@ -33,35 +34,24 @@ Enable only what your workload needs:
 allow_html · allow_link_refs · tables · strikethrough · highlight
 superscript · subscript · task_lists · autolink_literals
 disallowed_raw_html · footnotes · front_matter · heading_ids
-math · callouts
+math · callouts · definition_lists
 ```
 
-## Curated profiles
-
-Use a profile when a stable feature bundle communicates intent better than a
-long option list:
-
-| Feature | Essentials | Extended | Full |
-| --- | :---: | :---: | :---: |
-| Tables, strikethrough, task lists | ✓ | ✓ | ✓ |
-| Raw HTML parsing, reference links | — | ✓ | ✓ |
-| Heading IDs, callouts | — | ✓ | ✓ |
-| Autolink literals, footnotes, front matter | — | — | ✓ |
-| Math, highlight, subscript, superscript | — | — | ✓ |
+Definition lists are an independent opt-in extension:
 
 ```rust
-use ferromark::{Options, Profile};
+use ferromark::Options;
 
-let options = Options::from(Profile::Essentials);
+let options = Options {
+    definition_lists: true,
+    ..Options::commonmark()
+};
 let html = ferromark::to_html_with_options(markdown, &options);
 ```
 
-`Essentials` targets common documentation syntax, `Extended` matches the
-current default feature mix, and `Full` enables everything. Individual fields
-can still be overridden with Rust's struct update syntax.
-
-Profiles never change the rendering trust boundary. Every profile starts with
-`RenderPolicy::Untrusted`; trusted raw HTML remains an explicit caller choice.
+Start from `Options::minimal()`, `Options::commonmark()`, or `Options::gfm()`
+and override only the syntax flags your documents use. These are dialect
+constructors, not performance profiles.
 
 ## Rendering policy
 

--- a/node/ferromark/index.d.mts
+++ b/node/ferromark/index.d.mts
@@ -17,6 +17,7 @@ export interface Options {
   headingIds?: boolean
   math?: boolean
   callouts?: boolean
+  definitionLists?: boolean
 }
 
 export interface CodeHighlighter {

--- a/node/ferromark/native.d.ts
+++ b/node/ferromark/native.d.ts
@@ -17,6 +17,7 @@ export interface Options {
   headingIds?: boolean
   math?: boolean
   callouts?: boolean
+  definitionLists?: boolean
 }
 
 export declare function toHtml(markdown: string, options?: Options | undefined | null): string

--- a/node/ferromark/test/index.test.mjs
+++ b/node/ferromark/test/index.test.mjs
@@ -9,6 +9,10 @@ test('renders Markdown through the native binding', () => {
 
 test('maps typed options to the Rust surface', () => {
   assert.equal(toHtml('==mark==', { highlight: true }), '<p><mark>mark</mark></p>\n')
+  assert.equal(
+    toHtml('Term\n: Definition', { definitionLists: true }),
+    '<dl>\n<dt>Term</dt>\n<dd>Definition</dd>\n</dl>\n',
+  )
   assert.throws(
     () => toHtml('text', { renderPolicy: 'invalid' }),
     /renderPolicy must be either 'untrusted' or 'trusted'/,

--- a/node/ferromark/test/types.test.mts
+++ b/node/ferromark/test/types.test.mts
@@ -4,6 +4,7 @@ import { toHtml, toHtmlWithHighlighter } from '../index.mjs'
 const options: Options = {
   renderPolicy: 'untrusted',
   tables: true,
+  definitionLists: true,
 }
 const highlighter: CodeHighlighter = {
   codeToHtml: (code, { lang, theme }) => `${lang}:${theme}:${code}`,

--- a/node/native/src/lib.rs
+++ b/node/native/src/lib.rs
@@ -22,6 +22,7 @@ pub struct Options {
     pub heading_ids: Option<bool>,
     pub math: Option<bool>,
     pub callouts: Option<bool>,
+    pub definition_lists: Option<bool>,
 }
 
 impl Options {
@@ -56,6 +57,7 @@ impl Options {
         apply(&mut options.heading_ids, self.heading_ids);
         apply(&mut options.math, self.math);
         apply(&mut options.callouts, self.callouts);
+        apply(&mut options.definition_lists, self.definition_lists);
 
         Ok(options)
     }

--- a/src/block/event.rs
+++ b/src/block/event.rs
@@ -125,6 +125,22 @@ pub enum BlockEvent {
     /// End of a list item.
     ListItemEnd,
 
+    /// Start of a definition list.
+    DefinitionListStart,
+    /// End of a definition list.
+    DefinitionListEnd,
+    /// Start of a definition term.
+    DefinitionTermStart,
+    /// End of a definition term.
+    DefinitionTermEnd,
+    /// Start of a definition description.
+    DefinitionDescriptionStart {
+        /// Whether the first paragraph should omit its `<p>` wrapper.
+        tight: bool,
+    },
+    /// End of a definition description.
+    DefinitionDescriptionEnd,
+
     /// A thematic break (horizontal rule).
     ThematicBreak,
 

--- a/src/block/parser.rs
+++ b/src/block/parser.rs
@@ -77,6 +77,11 @@ enum ContainerType {
         /// Column where content starts (after `[^label]: `)
         content_indent: usize,
     },
+    /// Definition-list description (`: content`).
+    DefinitionDescription {
+        /// Column where continuation content starts.
+        content_indent: usize,
+    },
 }
 
 /// An open container on the stack.
@@ -102,6 +107,22 @@ struct OpenList {
     blank_in_item: bool,
     /// Number of items so far.
     item_count: u32,
+}
+
+/// A definition list that may accept another term or description.
+#[derive(Debug, Clone, Copy)]
+struct OpenDefinitionList {
+    /// Container depth outside the definition list.
+    outer_depth: usize,
+}
+
+/// A paragraph emitted before a possible blank-separated definition marker.
+#[derive(Debug, Clone, Copy)]
+struct PendingDefinitionTerm {
+    /// First event of the emitted paragraph.
+    event_start: usize,
+    /// Container depth at which the paragraph was emitted.
+    outer_depth: usize,
 }
 
 /// Block parser state.
@@ -162,6 +183,14 @@ pub struct BlockParser<'a> {
     footnote_event_start: Option<usize>,
     /// Pending label for the current footnote definition (normalized, original).
     pending_footnote_label: Option<(String, String)>,
+    /// Definition lists that may accept another term or description.
+    open_definition_lists: SmallVec<[OpenDefinitionList; 2]>,
+    /// Paragraph immediately before a blank line that may become definition terms.
+    pending_definition_term: Option<PendingDefinitionTerm>,
+    /// Whether the next non-blank physical line follows a blank line.
+    definition_blank_before_next: bool,
+    /// Blank-line state captured for the physical line currently being parsed.
+    definition_current_line_loose: bool,
 }
 
 impl<'a> BlockParser<'a> {
@@ -199,6 +228,10 @@ impl<'a> BlockParser<'a> {
             footnote_store: FootnoteStore::new(),
             footnote_event_start: None,
             pending_footnote_label: None,
+            open_definition_lists: SmallVec::new(),
+            pending_definition_term: None,
+            definition_blank_before_next: false,
+            definition_current_line_loose: false,
         }
     }
 
@@ -210,6 +243,14 @@ impl<'a> BlockParser<'a> {
 
         // Close any open table at end of input
         self.close_table(events);
+
+        self.resolve_pending_definition_term_as_paragraph(events);
+
+        // A paragraph after a completed definition description is ordinary
+        // content unless a following `:` marker converted it into terms.
+        if self.in_paragraph && self.has_waiting_definition_list() {
+            self.close_waiting_definition_lists(events);
+        }
 
         // Close any open paragraph at end of input
         self.close_paragraph(events);
@@ -235,6 +276,7 @@ impl<'a> BlockParser<'a> {
 
         // Close all open containers
         self.close_all_containers(events);
+        self.close_all_definition_lists(events);
     }
 
     /// Take the collected link reference definitions.
@@ -254,6 +296,10 @@ impl<'a> BlockParser<'a> {
         }
 
         let line_start = self.cursor.offset();
+        if self.options.definition_lists {
+            self.definition_current_line_loose =
+                std::mem::take(&mut self.definition_blank_before_next);
+        }
 
         // Reset column tracking at the start of each line
         self.partial_tab_cols = 0;
@@ -320,9 +366,19 @@ impl<'a> BlockParser<'a> {
             }
 
             self.close_table(events);
+            let definition_candidate_start = events.len();
+            let had_paragraph = self.in_paragraph;
             self.close_paragraph(events);
             // This is a truly blank line (no container markers) - close blockquotes
             self.handle_blank_line_containers(events, true);
+            self.remember_definition_term_after_blank(
+                had_paragraph,
+                definition_candidate_start,
+                events,
+            );
+            if self.options.definition_lists {
+                self.definition_blank_before_next = true;
+            }
             return;
         }
 
@@ -376,9 +432,19 @@ impl<'a> BlockParser<'a> {
                 parser_cursor_bump!(self.cursor);
             }
             self.close_table(events);
+            let definition_candidate_start = events.len();
+            let had_paragraph = self.in_paragraph;
             self.close_paragraph(events);
             // Container markers were present, so don't close blockquotes
             self.handle_blank_line_containers(events, false);
+            self.remember_definition_term_after_blank(
+                had_paragraph,
+                definition_candidate_start,
+                events,
+            );
+            if self.options.definition_lists {
+                self.definition_blank_before_next = true;
+            }
             return;
         }
 
@@ -410,6 +476,10 @@ impl<'a> BlockParser<'a> {
             // close_containers_from is smart about keeping lists open when starting new items
             // Pass indent so it knows if a new item is actually possible (only at indent < 4)
             self.close_containers_from(matched_containers, indent, events);
+        }
+
+        if self.options.definition_lists {
+            self.prepare_definition_lists_for_line(indent, events);
         }
 
         // If we're in an indented code block and containers matched, handle continuation
@@ -474,6 +544,15 @@ impl<'a> BlockParser<'a> {
                 self.emit_table_row(events);
                 return;
             }
+        }
+
+        if self.options.definition_lists
+            && indent < 4
+            && self.cursor.at(b':')
+            && self.try_definition_description(indent, events)
+        {
+            self.parse_line_content(events);
+            return;
         }
 
         // Check for setext heading underline (when in a paragraph)
@@ -590,6 +669,7 @@ impl<'a> BlockParser<'a> {
             || self.in_indented_code
             || self.in_table
             || !self.container_stack.is_empty()
+            || !self.open_definition_lists.is_empty()
         {
             return false;
         }
@@ -610,7 +690,17 @@ impl<'a> BlockParser<'a> {
                 if !self.cursor.is_eof() && self.cursor.at(b'\n') {
                     parser_cursor_bump!(self.cursor);
                 }
+                let definition_candidate_start = events.len();
+                let had_paragraph = self.in_paragraph;
                 self.close_paragraph(events);
+                self.remember_definition_term_after_blank(
+                    had_paragraph,
+                    definition_candidate_start,
+                    events,
+                );
+                if self.options.definition_lists {
+                    self.definition_blank_before_next = true;
+                }
                 return true;
             }
 
@@ -622,7 +712,9 @@ impl<'a> BlockParser<'a> {
             // When tables are enabled and we're in a paragraph, bail on lines
             // that could be delimiter rows (starting with ':' or '-')
             // '-' is already caught by is_simple_line_start above.
-            if self.options.tables && self.in_paragraph && first == b':' {
+            if first == b':'
+                && ((self.options.tables && self.in_paragraph) || self.options.definition_lists)
+            {
                 self.cursor = Cursor::new_at(self.input, line_start);
                 return consumed_any;
             }
@@ -806,6 +898,10 @@ impl<'a> BlockParser<'a> {
             return;
         }
 
+        if self.options.definition_lists {
+            self.prepare_definition_lists_for_line(indent, events);
+        }
+
         // If we're in a table, check for continuation or termination
         if self.in_table {
             // Check if the line starts a block construct that would terminate the table
@@ -824,6 +920,7 @@ impl<'a> BlockParser<'a> {
         if indent < 4 {
             if is_simple_line_start(first)
                 && !(self.options.tables && (first == b'|' || (first == b':' && self.in_paragraph)))
+                && !(self.options.definition_lists && first == b':')
                 && !(self.options.footnotes && first == b'[')
             {
                 let line_start = self.cursor.offset();
@@ -846,6 +943,14 @@ impl<'a> BlockParser<'a> {
                     self.close_paragraph_as_setext_heading(level, events);
                     return;
                 }
+            }
+
+            if self.options.definition_lists
+                && first == b':'
+                && self.try_definition_description(indent, events)
+            {
+                self.parse_line_content(events);
+                return;
             }
 
             // Check for GFM table delimiter row (when in a paragraph)
@@ -1078,6 +1183,33 @@ impl<'a> BlockParser<'a> {
                         }
                     }
                 }
+                ContainerType::DefinitionDescription { content_indent } => {
+                    let remaining = self.cursor.remaining_slice();
+                    let is_blank = Self::is_blank_remaining_line(remaining);
+
+                    if is_blank {
+                        matched += 1;
+                    } else {
+                        let save_pos = self.cursor.offset();
+                        let save_partial = self.partial_tab_cols;
+                        let save_col = self.current_col;
+                        let (cols, _bytes) = self.skip_indent();
+
+                        if cols >= content_indent {
+                            self.cursor = Cursor::new_at(self.input, save_pos);
+                            self.partial_tab_cols = save_partial;
+                            self.current_col = save_col;
+                            let (_skipped_cols, _skipped_bytes) =
+                                self.skip_indent_max(content_indent);
+                            matched += 1;
+                        } else {
+                            self.cursor = Cursor::new_at(self.input, save_pos);
+                            self.partial_tab_cols = save_partial;
+                            self.current_col = save_col;
+                            break;
+                        }
+                    }
+                }
             }
         }
 
@@ -1177,12 +1309,14 @@ impl<'a> BlockParser<'a> {
             return false;
         }
 
-        // The first unmatched container must be a blockquote or list item
-        // (CommonMark allows lazy continuation for paragraphs in both)
+        // Definition descriptions deliberately follow list-style lazy
+        // paragraph continuation when the extension is enabled.
         let container = &self.container_stack[matched];
         let is_lazy_container = matches!(
             container.typ,
-            ContainerType::BlockQuote | ContainerType::ListItem { .. }
+            ContainerType::BlockQuote
+                | ContainerType::ListItem { .. }
+                | ContainerType::DefinitionDescription { .. }
         );
         if !is_lazy_container {
             return false;
@@ -1264,6 +1398,9 @@ impl<'a> BlockParser<'a> {
             // HTML block (only types that can interrupt paragraphs) - only at indent < 4
             b'<' => {
                 self.options.allow_html && indent < 4 && self.peek_html_block_start(true).is_some()
+            }
+            b':' => {
+                self.options.definition_lists && indent < 4 && self.is_definition_marker_candidate()
             }
             // Note: We don't check for setext underlines (= or plain line of -) here because
             // setext underlines can't interrupt lazy continuation. They only work when the
@@ -1824,6 +1961,11 @@ impl<'a> BlockParser<'a> {
 
     /// Close the topmost container.
     fn close_top_container(&mut self, events: &mut Vec<BlockEvent>) {
+        // Close a completed nested definition list before its enclosing
+        // container emits an end event.
+        let enclosing_depth = self.container_stack.len().saturating_sub(1);
+        self.close_definition_lists_deeper_than(enclosing_depth, events);
+
         if let Some(container) = self.container_stack.pop() {
             // Close table first
             self.close_table(events);
@@ -1864,7 +2006,13 @@ impl<'a> BlockParser<'a> {
                 ContainerType::FootnoteDefinition { .. } => {
                     self.close_footnote_definition(events);
                 }
+                ContainerType::DefinitionDescription { .. } => {
+                    events.push(BlockEvent::DefinitionDescriptionEnd);
+                }
             }
+
+            let remaining_depth = self.container_stack.len();
+            self.close_definition_lists_deeper_than(remaining_depth, events);
         }
     }
 
@@ -3213,6 +3361,220 @@ impl<'a> BlockParser<'a> {
         }
 
         events.push(BlockEvent::ParagraphEnd);
+    }
+
+    /// Return whether `:` at the current cursor is a definition marker.
+    #[inline]
+    fn is_definition_marker_candidate(&self) -> bool {
+        self.cursor.at(b':') && matches!(self.cursor.peek_ahead(1), Some(b' ' | b'\t'))
+    }
+
+    fn active_definition_description_count(&self) -> usize {
+        self.container_stack
+            .iter()
+            .filter(|container| {
+                matches!(container.typ, ContainerType::DefinitionDescription { .. })
+            })
+            .count()
+    }
+
+    fn definition_list_is_waiting(&self, list: OpenDefinitionList) -> bool {
+        !matches!(
+            self.container_stack.get(list.outer_depth),
+            Some(Container {
+                typ: ContainerType::DefinitionDescription { .. },
+                ..
+            })
+        )
+    }
+
+    fn has_waiting_definition_list(&self) -> bool {
+        self.open_definition_lists
+            .last()
+            .is_some_and(|list| self.definition_list_is_waiting(*list))
+    }
+
+    /// Remember a paragraph closed by a blank line as a possible term block.
+    fn remember_definition_term_after_blank(
+        &mut self,
+        had_paragraph: bool,
+        event_start: usize,
+        events: &[BlockEvent],
+    ) {
+        if !self.options.definition_lists
+            || !had_paragraph
+            || self.active_definition_description_count() > 0
+            || event_start >= events.len()
+            || !matches!(events.get(event_start), Some(BlockEvent::ParagraphStart))
+            || !matches!(events.last(), Some(BlockEvent::ParagraphEnd))
+        {
+            return;
+        }
+
+        if events[event_start + 1..events.len() - 1]
+            .iter()
+            .all(|event| matches!(event, BlockEvent::Text(_) | BlockEvent::SoftBreak))
+        {
+            self.pending_definition_term = Some(PendingDefinitionTerm {
+                event_start,
+                outer_depth: self.container_stack.len(),
+            });
+        }
+    }
+
+    /// Close an open definition list before a paragraph that did not become terms.
+    fn resolve_pending_definition_term_as_paragraph(&mut self, events: &mut Vec<BlockEvent>) {
+        let Some(pending) = self.pending_definition_term.take() else {
+            return;
+        };
+
+        let Some(list) = self.open_definition_lists.last().copied() else {
+            return;
+        };
+        if list.outer_depth != pending.outer_depth || !self.definition_list_is_waiting(list) {
+            return;
+        }
+
+        events.insert(pending.event_start, BlockEvent::DefinitionListEnd);
+        self.open_definition_lists.pop();
+    }
+
+    /// Keep a waiting definition list open only while a possible next term is parsed.
+    fn prepare_definition_lists_for_line(&mut self, indent: usize, events: &mut Vec<BlockEvent>) {
+        let marker = indent < 4 && self.is_definition_marker_candidate();
+        let outer_depth = self.container_stack.len();
+
+        if let Some(pending) = self.pending_definition_term {
+            if marker && pending.outer_depth == outer_depth {
+                return;
+            }
+            self.resolve_pending_definition_term_as_paragraph(events);
+        }
+
+        let Some(list) = self.open_definition_lists.last().copied() else {
+            return;
+        };
+        if list.outer_depth != outer_depth || !self.definition_list_is_waiting(list) || marker {
+            return;
+        }
+
+        // Plain paragraph lines may be the next one or more terms. Any
+        // unambiguous block start ends the definition list before that block.
+        if indent < 4 && !self.would_start_block(indent) {
+            return;
+        }
+
+        self.close_waiting_definition_lists(events);
+    }
+
+    /// Start a new definition description, converting the preceding paragraph
+    /// into one or more single-line terms when present.
+    fn try_definition_description(&mut self, indent: usize, events: &mut Vec<BlockEvent>) -> bool {
+        if !self.is_definition_marker_candidate() {
+            return false;
+        }
+
+        let outer_depth = self.container_stack.len();
+        let waiting_list = self
+            .open_definition_lists
+            .last()
+            .copied()
+            .is_some_and(|list| {
+                list.outer_depth == outer_depth && self.definition_list_is_waiting(list)
+            });
+
+        let mut terms = Vec::new();
+        if self.in_paragraph {
+            self.in_paragraph = false;
+            terms.append(&mut self.paragraph_lines);
+            self.pending_definition_term = None;
+        } else if let Some(pending) = self.pending_definition_term {
+            if pending.outer_depth == outer_depth
+                && matches!(
+                    events.get(pending.event_start),
+                    Some(BlockEvent::ParagraphStart)
+                )
+                && matches!(events.last(), Some(BlockEvent::ParagraphEnd))
+            {
+                for event in events.drain(pending.event_start..) {
+                    if let BlockEvent::Text(range) = event {
+                        terms.push(range);
+                    }
+                }
+                self.pending_definition_term = None;
+            }
+        }
+
+        if terms.is_empty() && !waiting_list {
+            return false;
+        }
+
+        if !waiting_list {
+            self.close_orphaned_lists(events);
+            self.mark_container_has_content();
+            events.push(BlockEvent::DefinitionListStart);
+            self.open_definition_lists
+                .push(OpenDefinitionList { outer_depth });
+        }
+
+        for mut term in terms {
+            while term.end > term.start
+                && matches!(self.input[(term.end - 1) as usize], b' ' | b'\t')
+            {
+                term.end -= 1;
+            }
+            events.push(BlockEvent::DefinitionTermStart);
+            events.push(BlockEvent::Text(term));
+            events.push(BlockEvent::DefinitionTermEnd);
+        }
+
+        parser_cursor_bump!(self.cursor);
+        self.current_col += 1;
+        let (content_space, _bytes) = self.skip_indent();
+        debug_assert!(content_space > 0);
+        let content_indent = indent + 1 + content_space;
+
+        events.push(BlockEvent::DefinitionDescriptionStart {
+            tight: !self.definition_current_line_loose,
+        });
+        self.container_stack.push(Container {
+            typ: ContainerType::DefinitionDescription { content_indent },
+            has_content: false,
+        });
+        true
+    }
+
+    fn close_waiting_definition_lists(&mut self, events: &mut Vec<BlockEvent>) {
+        while self
+            .open_definition_lists
+            .last()
+            .copied()
+            .is_some_and(|list| self.definition_list_is_waiting(list))
+        {
+            self.open_definition_lists.pop();
+            events.push(BlockEvent::DefinitionListEnd);
+        }
+    }
+
+    fn close_definition_lists_deeper_than(
+        &mut self,
+        container_depth: usize,
+        events: &mut Vec<BlockEvent>,
+    ) {
+        while self
+            .open_definition_lists
+            .last()
+            .is_some_and(|list| list.outer_depth > container_depth)
+        {
+            self.open_definition_lists.pop();
+            events.push(BlockEvent::DefinitionListEnd);
+        }
+    }
+
+    fn close_all_definition_lists(&mut self, events: &mut Vec<BlockEvent>) {
+        while self.open_definition_lists.pop().is_some() {
+            events.push(BlockEvent::DefinitionListEnd);
+        }
     }
 
     /// Close the current footnote definition, draining captured events into the store.

--- a/src/block/parser.rs
+++ b/src/block/parser.rs
@@ -1439,6 +1439,8 @@ impl<'a> BlockParser<'a> {
 
                     if is_same_list {
                         // Just close the item, not the list
+                        let enclosing_depth = self.container_stack.len() - 1;
+                        self.close_definition_lists_deeper_than(enclosing_depth, events);
                         self.container_stack.pop();
                         self.close_paragraph(events);
                         events.push(BlockEvent::ListItemEnd);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -133,6 +133,8 @@ pub struct Options {
     pub math: bool,
     /// Enable GitHub-style callouts/admonitions (`> [!NOTE]`, `> [!WARNING]`, etc.).
     pub callouts: bool,
+    /// Enable PHP Markdown Extra-style definition lists.
+    pub definition_lists: bool,
 }
 
 impl Options {
@@ -160,6 +162,7 @@ impl Options {
             heading_ids: false,
             math: false,
             callouts: false,
+            definition_lists: false,
         }
     }
 
@@ -187,6 +190,7 @@ impl Options {
             heading_ids: false,
             math: false,
             callouts: false,
+            definition_lists: false,
         }
     }
 
@@ -214,6 +218,7 @@ impl Options {
             heading_ids: false,
             math: false,
             callouts: false,
+            definition_lists: false,
         }
     }
 }
@@ -237,6 +242,7 @@ impl Default for Options {
             heading_ids: true,
             math: false,
             callouts: true,
+            definition_lists: false,
         }
     }
 }
@@ -792,6 +798,8 @@ struct RenderContext<'a, 'r, R: FencedCodeRenderer + ?Sized> {
     heading_id_tracker: Option<HeadingIdTracker>,
     callout_stack: Vec<Option<block::CalloutType>>,
     pending_footnote_backref: Option<(String, usize)>,
+    definition_description_stack: Vec<bool>,
+    paragraph_tags_suppressed: bool,
     options: &'a Options,
     fenced_code_renderer: Option<&'r mut R>,
     fenced_code_state: Option<FencedCodeState>,
@@ -826,6 +834,8 @@ impl<'a, 'r, R: FencedCodeRenderer + ?Sized> RenderContext<'a, 'r, R> {
             heading_id_tracker: options.heading_ids.then(HeadingIdTracker::new),
             callout_stack: Vec::new(),
             pending_footnote_backref: None,
+            definition_description_stack: Vec::new(),
+            paragraph_tags_suppressed: false,
             options,
             fenced_code_renderer,
             fenced_code_state: None,
@@ -920,6 +930,8 @@ impl<R: FencedCodeRenderer + ?Sized> RenderContext<'_, '_, R> {
         let heading_id_tracker = &mut self.heading_id_tracker;
         let callout_stack = &mut self.callout_stack;
         let pending_footnote_backref = &mut self.pending_footnote_backref;
+        let definition_description_stack = &mut self.definition_description_stack;
+        let paragraph_tags_suppressed = &mut self.paragraph_tags_suppressed;
         let options = self.options;
         let fenced_code_renderer = &mut self.fenced_code_renderer;
         let fenced_code_state = &mut self.fenced_code_state;
@@ -940,8 +952,15 @@ impl<R: FencedCodeRenderer + ?Sized> RenderContext<'_, '_, R> {
                     writer.newline();
                     *pending_loose_li_newline = false;
                 }
-                // In tight lists, don't emit <p> tags
-                if !in_tight_list {
+                let in_tight_definition = definition_description_stack.last_mut().is_some_and(
+                    |suppress_first_paragraph| {
+                        let suppress = *suppress_first_paragraph;
+                        *suppress_first_paragraph = false;
+                        suppress
+                    },
+                );
+                *paragraph_tags_suppressed = in_tight_list || in_tight_definition;
+                if !*paragraph_tags_suppressed {
                     writer.paragraph_start();
                 }
                 para_state.start();
@@ -949,15 +968,6 @@ impl<R: FencedCodeRenderer + ?Sized> RenderContext<'_, '_, R> {
                 *at_tight_li_start = false;
             }
             BlockEvent::ParagraphEnd => {
-                // Check if we're in a tight list (innermost list is tight)
-                // BUT: paragraphs inside blockquotes that started AFTER the list need </p> tags
-                let in_tight_list =
-                    tight_list_stack
-                        .last()
-                        .is_some_and(|(tight, bq_depth_at_start)| {
-                            *tight && *blockquote_depth <= *bq_depth_at_start
-                        });
-
                 // Parse all accumulated paragraph content at once
                 let content = para_state.finish();
 
@@ -979,13 +989,13 @@ impl<R: FencedCodeRenderer + ?Sized> RenderContext<'_, '_, R> {
                 if let Some((label, number)) = pending_footnote_backref.take() {
                     write_footnote_backref(writer, &label, number);
                 }
-                // In tight lists, don't emit </p> tags
-                if !in_tight_list {
+                if !*paragraph_tags_suppressed {
                     writer.paragraph_end();
                 } else {
                     // Mark that we need newline before next block element
                     *need_newline_before_block = true;
                 }
+                *paragraph_tags_suppressed = false;
             }
             BlockEvent::HeadingStart { level } => {
                 if *need_newline_before_block {
@@ -1238,6 +1248,32 @@ impl<R: FencedCodeRenderer + ?Sized> RenderContext<'_, '_, R> {
                 *pending_loose_li_newline = false;
                 *pending_task = block::TaskState::None;
                 writer.li_end();
+            }
+
+            BlockEvent::DefinitionListStart => {
+                if *need_newline_before_block {
+                    writer.newline();
+                    *need_newline_before_block = false;
+                }
+                writer.dl_start();
+            }
+            BlockEvent::DefinitionListEnd => {
+                writer.dl_end();
+            }
+            BlockEvent::DefinitionTermStart => {
+                writer.dt_start();
+            }
+            BlockEvent::DefinitionTermEnd => {
+                writer.dt_end();
+            }
+            BlockEvent::DefinitionDescriptionStart { tight } => {
+                writer.dd_start(*tight);
+                definition_description_stack.push(*tight);
+            }
+            BlockEvent::DefinitionDescriptionEnd => {
+                definition_description_stack.pop();
+                *need_newline_before_block = false;
+                writer.dd_end();
             }
 
             // --- Table events ---

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1251,6 +1251,10 @@ impl<R: FencedCodeRenderer + ?Sized> RenderContext<'_, '_, R> {
             }
 
             BlockEvent::DefinitionListStart => {
+                if *pending_loose_li_newline {
+                    writer.newline();
+                    *pending_loose_li_newline = false;
+                }
                 if *need_newline_before_block {
                     writer.newline();
                     *need_newline_before_block = false;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1259,6 +1259,10 @@ impl<R: FencedCodeRenderer + ?Sized> RenderContext<'_, '_, R> {
                     writer.newline();
                     *need_newline_before_block = false;
                 }
+                if *at_tight_li_start {
+                    writer.newline();
+                    *at_tight_li_start = false;
+                }
                 writer.dl_start();
             }
             BlockEvent::DefinitionListEnd => {

--- a/src/profiling.rs
+++ b/src/profiling.rs
@@ -99,7 +99,13 @@ pub(crate) fn record_block_events(events: &[BlockEvent], capacity: usize) {
                 | BlockEvent::ListStart { .. }
                 | BlockEvent::ListEnd { .. }
                 | BlockEvent::ListItemStart { .. }
-                | BlockEvent::ListItemEnd => counters.block_container_events += 1,
+                | BlockEvent::ListItemEnd
+                | BlockEvent::DefinitionListStart
+                | BlockEvent::DefinitionListEnd
+                | BlockEvent::DefinitionTermStart
+                | BlockEvent::DefinitionTermEnd
+                | BlockEvent::DefinitionDescriptionStart { .. }
+                | BlockEvent::DefinitionDescriptionEnd => counters.block_container_events += 1,
                 BlockEvent::TableStart
                 | BlockEvent::TableEnd
                 | BlockEvent::TableHeadStart

--- a/src/render.rs
+++ b/src/render.rs
@@ -654,6 +654,45 @@ impl HtmlWriter {
         self.write_str("</li>\n");
     }
 
+    /// Write definition list start: `<dl>\n`
+    #[inline]
+    pub fn dl_start(&mut self) {
+        self.write_str("<dl>\n");
+    }
+
+    /// Write definition list end: `</dl>\n`
+    #[inline]
+    pub fn dl_end(&mut self) {
+        self.write_str("</dl>\n");
+    }
+
+    /// Write definition term start: `<dt>`
+    #[inline]
+    pub fn dt_start(&mut self) {
+        self.write_str("<dt>");
+    }
+
+    /// Write definition term end: `</dt>\n`
+    #[inline]
+    pub fn dt_end(&mut self) {
+        self.write_str("</dt>\n");
+    }
+
+    /// Write definition description start.
+    #[inline]
+    pub fn dd_start(&mut self, tight: bool) {
+        self.write_str("<dd>");
+        if !tight {
+            self.newline();
+        }
+    }
+
+    /// Write definition description end: `</dd>\n`
+    #[inline]
+    pub fn dd_end(&mut self) {
+        self.write_str("</dd>\n");
+    }
+
     // --- Table Elements ---
 
     /// Write table start: `<table>\n`

--- a/tests/definition_list_tests.rs
+++ b/tests/definition_list_tests.rs
@@ -112,6 +112,14 @@ fn definition_lists_work_inside_blockquotes_and_list_items() {
 }
 
 #[test]
+fn definition_lists_start_on_a_new_line_inside_loose_list_items() {
+    assert_eq!(
+        render("- Term\n  : Definition\n\n- Other"),
+        "<ul>\n<li>\n<dl>\n<dt>Term</dt>\n<dd>Definition</dd>\n</dl>\n</li>\n<li>\n<p>Other</p>\n</li>\n</ul>\n"
+    );
+}
+
+#[test]
 fn descriptions_can_contain_nested_definition_lists() {
     let html = render("Outer\n: Outer definition\n\n    Inner\n    : Inner definition");
 

--- a/tests/definition_list_tests.rs
+++ b/tests/definition_list_tests.rs
@@ -107,7 +107,15 @@ fn definition_lists_work_inside_blockquotes_and_list_items() {
     );
     assert_eq!(
         render("- Term\n  : Definition"),
-        "<ul>\n<li><dl>\n<dt>Term</dt>\n<dd>Definition</dd>\n</dl>\n</li>\n</ul>\n"
+        "<ul>\n<li>\n<dl>\n<dt>Term</dt>\n<dd>Definition</dd>\n</dl>\n</li>\n</ul>\n"
+    );
+}
+
+#[test]
+fn definition_lists_consume_tight_list_item_block_spacing() {
+    assert_eq!(
+        render("- Term\n  : # Heading"),
+        "<ul>\n<li>\n<dl>\n<dt>Term</dt>\n<dd><h1 id=\"heading\">Heading</h1>\n</dd>\n</dl>\n</li>\n</ul>\n"
     );
 }
 

--- a/tests/definition_list_tests.rs
+++ b/tests/definition_list_tests.rs
@@ -1,0 +1,157 @@
+use ferromark::{BlockEvent, BlockParser, Options, to_html_with_options};
+
+fn options() -> Options {
+    Options {
+        definition_lists: true,
+        ..Options::default()
+    }
+}
+
+fn render(input: &str) -> String {
+    to_html_with_options(input, &options())
+}
+
+#[test]
+fn definition_lists_are_disabled_by_default() {
+    assert_eq!(
+        to_html_with_options("Term\n: Definition", &Options::default()),
+        "<p>Term\n: Definition</p>\n"
+    );
+}
+
+#[test]
+fn basic_definition_list_renders_semantic_html() {
+    assert_eq!(
+        render("Term\n: Definition"),
+        "<dl>\n<dt>Term</dt>\n<dd>Definition</dd>\n</dl>\n"
+    );
+}
+
+#[test]
+fn terms_and_descriptions_support_inline_markdown() {
+    assert_eq!(
+        render("**Term**\n: A *definition*"),
+        "<dl>\n<dt><strong>Term</strong></dt>\n<dd>A <em>definition</em></dd>\n</dl>\n"
+    );
+}
+
+#[test]
+fn multiple_terms_and_definitions_share_one_list() {
+    let input = "\
+Term one
+Term *two*
+: First definition
+: Second definition
+
+Term three
+: Third definition";
+    let html = render(input);
+
+    assert_eq!(html.matches("<dl>").count(), 1);
+    assert_eq!(html.matches("<dt>").count(), 3);
+    assert_eq!(html.matches("<dd>").count(), 3);
+    assert!(html.contains("<dt>Term <em>two</em></dt>"));
+    assert!(html.contains("<dd>Second definition</dd>"));
+}
+
+#[test]
+fn blank_before_definition_makes_its_paragraph_loose() {
+    assert_eq!(
+        render("Term\n\n: Definition"),
+        "<dl>\n<dt>Term</dt>\n<dd>\n<p>Definition</p>\n</dd>\n</dl>\n"
+    );
+}
+
+#[test]
+fn descriptions_support_lazy_continuation() {
+    assert_eq!(
+        render("Term\n: First line\nlazy continuation"),
+        "<dl>\n<dt>Term</dt>\n<dd>First line\nlazy continuation</dd>\n</dl>\n"
+    );
+}
+
+#[test]
+fn descriptions_support_multiple_blocks_and_nested_lists() {
+    let input = "\
+Term
+: First paragraph.
+
+    Second paragraph.
+
+    - nested item";
+    let html = render(input);
+
+    assert_eq!(
+        html,
+        "<dl>\n<dt>Term</dt>\n<dd>First paragraph.<p>Second paragraph.</p>\n\n<ul>\n<li>nested item</li>\n</ul>\n</dd>\n</dl>\n"
+    );
+}
+
+#[test]
+fn ordinary_paragraphs_after_a_definition_list_stay_outside_the_dl() {
+    assert_eq!(
+        render("Term\n: Definition\n\nOrdinary paragraph."),
+        "<dl>\n<dt>Term</dt>\n<dd>Definition</dd>\n</dl>\n<p>Ordinary paragraph.</p>\n"
+    );
+    assert_eq!(
+        render("Term\n: Definition\n\nOrdinary paragraph.\n\n# Heading"),
+        "<dl>\n<dt>Term</dt>\n<dd>Definition</dd>\n</dl>\n<p>Ordinary paragraph.</p>\n<h1 id=\"heading\">Heading</h1>\n"
+    );
+}
+
+#[test]
+fn definition_lists_work_inside_blockquotes_and_list_items() {
+    assert_eq!(
+        render("> Term\n> : Definition"),
+        "<blockquote>\n<dl>\n<dt>Term</dt>\n<dd>Definition</dd>\n</dl>\n</blockquote>\n"
+    );
+    assert_eq!(
+        render("- Term\n  : Definition"),
+        "<ul>\n<li><dl>\n<dt>Term</dt>\n<dd>Definition</dd>\n</dl>\n</li>\n</ul>\n"
+    );
+}
+
+#[test]
+fn descriptions_can_contain_nested_definition_lists() {
+    let html = render("Outer\n: Outer definition\n\n    Inner\n    : Inner definition");
+
+    assert_eq!(html.matches("<dl>").count(), 2);
+    assert!(
+        html.contains(
+            "<dd>Outer definition\n<dl>\n<dt>Inner</dt>\n<dd>Inner definition</dd>\n</dl>\n</dd>"
+        ),
+        "{html}"
+    );
+}
+
+#[test]
+fn colon_prefixed_prose_and_indented_markers_stay_commonmark() {
+    assert!(!render(": ordinary prose").contains("<dl>"));
+    assert!(render("Term\n   : definition").contains("<dl>"));
+    assert!(!render("Term\n    : indented continuation").contains("<dl>"));
+    assert!(!render("Term\n\\: escaped marker").contains("<dl>"));
+}
+
+#[test]
+fn parser_emits_definition_structure_as_block_events() {
+    let input = b"Term\n: Definition";
+    let mut parser = BlockParser::new_with_options(input, options());
+    let mut events = Vec::new();
+    parser.parse(&mut events);
+
+    assert!(matches!(events[0], BlockEvent::DefinitionListStart));
+    assert!(matches!(events[1], BlockEvent::DefinitionTermStart));
+    assert!(matches!(events[3], BlockEvent::DefinitionTermEnd));
+    assert!(matches!(
+        events[4],
+        BlockEvent::DefinitionDescriptionStart { tight: true }
+    ));
+    assert!(matches!(
+        events[events.len() - 2],
+        BlockEvent::DefinitionDescriptionEnd
+    ));
+    assert!(matches!(
+        events[events.len() - 1],
+        BlockEvent::DefinitionListEnd
+    ));
+}

--- a/tests/options_tests.rs
+++ b/tests/options_tests.rs
@@ -23,6 +23,7 @@ fn minimal_should_disable_every_optional_syntax_feature() {
             heading_ids: false,
             math: false,
             callouts: false,
+            definition_lists: false,
         }
     );
 }
@@ -87,6 +88,7 @@ fn default_should_retain_the_existing_feature_mix() {
             heading_ids: true,
             math: false,
             callouts: true,
+            definition_lists: false,
         }
     );
 }


### PR DESCRIPTION
## Summary

- add an opt-in `definition_lists` parser flag (disabled by default and in every dialect constructor)
- parse PHP Markdown Extra-style terms/descriptions, including multiple terms and descriptions, loose definitions, lazy paragraph continuation, nested blocks, and nested definition lists
- expose semantic `DefinitionList*`, `DefinitionTerm*`, and `DefinitionDescription*` block events
- wire the option through the Node binding and document the syntax and indentation contract

## Performance

On the shared option benchmark corpus without definition-list syntax, enabling the flag measured about **1.5%** above the default configuration (`188.74 µs` vs `185.98 µs`). The default-disabled path showed no Criterion-detectable regression.

## Validation

- `cargo test --all-features`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo fmt --all --check`
- Node native build, runtime tests, and TypeScript type-check
- option benchmark suite

Closes #15