### PR TITLE
perf: profile option combinations, optimize table cell scanning and heading id generation

### DIFF
--- a/benches/fixtures/deflists-5k.md
+++ b/benches/fixtures/deflists-5k.md
@@ -1,0 +1,149 @@
+# Glossary of Distributed Systems
+API Gateway
+: The measured rate at which the system processes requests under sustained load.
+: Ensures repeated delivery of the **same** message produces one effect.
+
+Throughput
+Rate limiting
+: A strategy that spreads records across nodes using a *stable* key function.
+
+Latency budget
+
+: Ensures repeated delivery of the **same** message produces one effect.
+
+  A second paragraph inside the description with `code` and *emphasis*.
+
+*Backpressure*
+: A compact probabilistic structure answering set membership with `O(1)` lookups.
+: The additional bytes written to storage beyond the logical payload size.
+
+**Idempotency**
+Consistent hashing
+: Limits concurrent work so downstream services stay within their [capacity](https://example.com/capacity).
+
+Cache stampede
+
+: The additional bytes written to storage beyond the logical payload size.
+
+  A second paragraph inside the description with `code` and *emphasis*.
+
+Rate limiting
+: The measured rate at which the system processes requests under sustained load.
+: Ensures repeated delivery of the **same** message produces one effect.
+
+`etag` header
+Vector clock
+: A strategy that spreads records across nodes using a *stable* key function.
+
+Sharding
+
+: Ensures repeated delivery of the **same** message produces one effect.
+
+  A second paragraph inside the description with `code` and *emphasis*.
+
+Consistent hashing
+: A compact probabilistic structure answering set membership with `O(1)` lookups.
+: The additional bytes written to storage beyond the logical payload size.
+
+Write amplification
+API Gateway
+: Limits concurrent work so downstream services stay within their [capacity](https://example.com/capacity).
+
+Bloom filter
+
+: The additional bytes written to storage beyond the logical payload size.
+
+  A second paragraph inside the description with `code` and *emphasis*.
+
+Vector clock
+: The measured rate at which the system processes requests under sustained load.
+: Ensures repeated delivery of the **same** message produces one effect.
+
+Quorum read
+*Backpressure*
+: A strategy that spreads records across nodes using a *stable* key function.
+
+Merkle tree
+
+: Ensures repeated delivery of the **same** message produces one effect.
+
+  A second paragraph inside the description with `code` and *emphasis*.
+
+API Gateway
+: A compact probabilistic structure answering set membership with `O(1)` lookups.
+: The additional bytes written to storage beyond the logical payload size.
+
+Throughput
+Rate limiting
+: Limits concurrent work so downstream services stay within their [capacity](https://example.com/capacity).
+
+Latency budget
+
+: The additional bytes written to storage beyond the logical payload size.
+
+  A second paragraph inside the description with `code` and *emphasis*.
+
+*Backpressure*
+: The measured rate at which the system processes requests under sustained load.
+: Ensures repeated delivery of the **same** message produces one effect.
+
+**Idempotency**
+Consistent hashing
+: A strategy that spreads records across nodes using a *stable* key function.
+
+Cache stampede
+
+: Ensures repeated delivery of the **same** message produces one effect.
+
+  A second paragraph inside the description with `code` and *emphasis*.
+
+Rate limiting
+: A compact probabilistic structure answering set membership with `O(1)` lookups.
+: The additional bytes written to storage beyond the logical payload size.
+
+`etag` header
+Vector clock
+: Limits concurrent work so downstream services stay within their [capacity](https://example.com/capacity).
+
+Sharding
+
+: The additional bytes written to storage beyond the logical payload size.
+
+  A second paragraph inside the description with `code` and *emphasis*.
+
+Consistent hashing
+: The measured rate at which the system processes requests under sustained load.
+: Ensures repeated delivery of the **same** message produces one effect.
+
+Write amplification
+API Gateway
+: A strategy that spreads records across nodes using a *stable* key function.
+
+Bloom filter
+
+: Ensures repeated delivery of the **same** message produces one effect.
+
+  A second paragraph inside the description with `code` and *emphasis*.
+
+Vector clock
+: A compact probabilistic structure answering set membership with `O(1)` lookups.
+: The additional bytes written to storage beyond the logical payload size.
+
+Quorum read
+*Backpressure*
+: Limits concurrent work so downstream services stay within their [capacity](https://example.com/capacity).
+
+Merkle tree
+
+: The additional bytes written to storage beyond the logical payload size.
+
+  A second paragraph inside the description with `code` and *emphasis*.
+
+API Gateway
+: The measured rate at which the system processes requests under sustained load.
+: Ensures repeated delivery of the **same** message produces one effect.
+
+Throughput
+Rate limiting
+: A strategy that spreads records across nodes using a *stable* key function.
+

--- a/benches/fixtures/mixed-extended-5k.md
+++ b/benches/fixtures/mixed-extended-5k.md
@@ -1,0 +1,214 @@
+---
+title: Mixed fixture
+---
+
+# Mixed Extended Document
+
+## Deployment {#deploy}
+
+The rollout uses ==staged canaries== with H~2~O-style naming and E=mc^2^ math $x^2 + y^2$.
+
+Term
+: Uses definition lists inside a mixed document.
+
+| Stage | Traffic | Owner |
+| ----- | --- | --- |
+| Canary | 5% | core-team |
+| Shared ownership || platform |
+
+> [!NOTE]
+> Callouts interact with blockquote parsing.
+
+A footnote reference[^r] and an inline note^[written inline] plus a task list:
+
+- [x] Ship parser
+- [ ] Ship docs — see https://example.com/docs and mail ops@example.com
+
+```rust
+fn hot_path(input: &str) -> usize { input.len() }
+```
+
+[^r]: The footnote definition paragraph.
+
+## Deployment {#deploy}
+
+The rollout uses ==staged canaries== with H~2~O-style naming and E=mc^2^ math $x^2 + y^2$.
+
+Term
+: Uses definition lists inside a mixed document.
+
+| Stage | Traffic | Owner |
+| ----- | --- | --- |
+| Canary | 5% | core-team |
+| Shared ownership || platform |
+
+> [!NOTE]
+> Callouts interact with blockquote parsing.
+
+A footnote reference[^r] and an inline note^[written inline] plus a task list:
+
+- [x] Ship parser
+- [ ] Ship docs — see https://example.com/docs and mail ops@example.com
+
+```rust
+fn hot_path(input: &str) -> usize { input.len() }
+```
+
+[^r]: The footnote definition paragraph.
+
+## Deployment {#deploy}
+
+The rollout uses ==staged canaries== with H~2~O-style naming and E=mc^2^ math $x^2 + y^2$.
+
+Term
+: Uses definition lists inside a mixed document.
+
+| Stage | Traffic | Owner |
+| ----- | --- | --- |
+| Canary | 5% | core-team |
+| Shared ownership || platform |
+
+> [!NOTE]
+> Callouts interact with blockquote parsing.
+
+A footnote reference[^r] and an inline note^[written inline] plus a task list:
+
+- [x] Ship parser
+- [ ] Ship docs — see https://example.com/docs and mail ops@example.com
+
+```rust
+fn hot_path(input: &str) -> usize { input.len() }
+```
+
+[^r]: The footnote definition paragraph.
+
+## Deployment {#deploy}
+
+The rollout uses ==staged canaries== with H~2~O-style naming and E=mc^2^ math $x^2 + y^2$.
+
+Term
+: Uses definition lists inside a mixed document.
+
+| Stage | Traffic | Owner |
+| ----- | --- | --- |
+| Canary | 5% | core-team |
+| Shared ownership || platform |
+
+> [!NOTE]
+> Callouts interact with blockquote parsing.
+
+A footnote reference[^r] and an inline note^[written inline] plus a task list:
+
+- [x] Ship parser
+- [ ] Ship docs — see https://example.com/docs and mail ops@example.com
+
+```rust
+fn hot_path(input: &str) -> usize { input.len() }
+```
+
+[^r]: The footnote definition paragraph.
+
+## Deployment {#deploy}
+
+The rollout uses ==staged canaries== with H~2~O-style naming and E=mc^2^ math $x^2 + y^2$.
+
+Term
+: Uses definition lists inside a mixed document.
+
+| Stage | Traffic | Owner |
+| ----- | --- | --- |
+| Canary | 5% | core-team |
+| Shared ownership || platform |
+
+> [!NOTE]
+> Callouts interact with blockquote parsing.
+
+A footnote reference[^r] and an inline note^[written inline] plus a task list:
+
+- [x] Ship parser
+- [ ] Ship docs — see https://example.com/docs and mail ops@example.com
+
+```rust
+fn hot_path(input: &str) -> usize { input.len() }
+```
+
+[^r]: The footnote definition paragraph.
+
+## Deployment {#deploy}
+
+The rollout uses ==staged canaries== with H~2~O-style naming and E=mc^2^ math $x^2 + y^2$.
+
+Term
+: Uses definition lists inside a mixed document.
+
+| Stage | Traffic | Owner |
+| ----- | --- | --- |
+| Canary | 5% | core-team |
+| Shared ownership || platform |
+
+> [!NOTE]
+> Callouts interact with blockquote parsing.
+
+A footnote reference[^r] and an inline note^[written inline] plus a task list:
+
+- [x] Ship parser
+- [ ] Ship docs — see https://example.com/docs and mail ops@example.com
+
+```rust
+fn hot_path(input: &str) -> usize { input.len() }
+```
+
+[^r]: The footnote definition paragraph.
+
+## Deployment {#deploy}
+
+The rollout uses ==staged canaries== with H~2~O-style naming and E=mc^2^ math $x^2 + y^2$.
+
+Term
+: Uses definition lists inside a mixed document.
+
+| Stage | Traffic | Owner |
+| ----- | --- | --- |
+| Canary | 5% | core-team |
+| Shared ownership || platform |
+
+> [!NOTE]
+> Callouts interact with blockquote parsing.
+
+A footnote reference[^r] and an inline note^[written inline] plus a task list:
+
+- [x] Ship parser
+- [ ] Ship docs — see https://example.com/docs and mail ops@example.com
+
+```rust
+fn hot_path(input: &str) -> usize { input.len() }
+```
+
+[^r]: The footnote definition paragraph.
+
+## Deployment {#deploy}
+
+The rollout uses ==staged canaries== with H~2~O-style naming and E=mc^2^ math $x^2 + y^2$.
+
+Term
+: Uses definition lists inside a mixed document.
+
+| Stage | Traffic | Owner |
+| ----- | --- | --- |
+| Canary | 5% | core-team |
+| Shared ownership || platform |
+
+> [!NOTE]
+> Callouts interact with blockquote parsing.
+
+A footnote reference[^r] and an inline note^[written inline] plus a task list:
+
+- [x] Ship parser
+- [ ] Ship docs — see https://example.com/docs and mail ops@example.com
+
+```rust
+fn hot_path(input: &str) -> usize { input.len() }
+```
+
+[^r]: The footnote definition paragraph.
+

--- a/benches/fixtures/tables-merged-5k.md
+++ b/benches/fixtures/tables-merged-5k.md
@@ -1,0 +1,171 @@
+# Capacity Planning Matrix
+
+| Service | Region | Replicas | CPU | Memory |
+| ------ | --- | --- | --- | --- |
+| auth-api | eu-west-1 | 6 | 2.0 | 4Gi |
+| Shared pool ||| 1.5 | 2Gi |
+| billing | us-east-1 | 4 | Burst allowed ||
+| Deprecated tier ||||| 
+
+Narrative between tables keeps the block parser switching modes.
+
+| Metric | Q1 | Q2 |
+| :------- | ---: | ---: |
+| Requests (M) | 12.4 | 14.1 |
+| Combined total || 26.5 |
+
+Narrative between tables keeps the block parser switching modes.
+
+| Service | Region | Replicas | CPU | Memory |
+| ------ | --- | --- | --- | --- |
+| auth-api | eu-west-1 | 6 | 2.0 | 4Gi |
+| Shared pool ||| 1.5 | 2Gi |
+| billing | us-east-1 | 4 | Burst allowed ||
+| Deprecated tier ||||| 
+
+Narrative between tables keeps the block parser switching modes.
+
+| Metric | Q1 | Q2 |
+| :------- | ---: | ---: |
+| Requests (M) | 12.4 | 14.1 |
+| Combined total || 26.5 |
+
+Narrative between tables keeps the block parser switching modes.
+
+| Service | Region | Replicas | CPU | Memory |
+| ------ | --- | --- | --- | --- |
+| auth-api | eu-west-1 | 6 | 2.0 | 4Gi |
+| Shared pool ||| 1.5 | 2Gi |
+| billing | us-east-1 | 4 | Burst allowed ||
+| Deprecated tier ||||| 
+
+Narrative between tables keeps the block parser switching modes.
+
+| Metric | Q1 | Q2 |
+| :------- | ---: | ---: |
+| Requests (M) | 12.4 | 14.1 |
+| Combined total || 26.5 |
+
+Narrative between tables keeps the block parser switching modes.
+
+| Service | Region | Replicas | CPU | Memory |
+| ------ | --- | --- | --- | --- |
+| auth-api | eu-west-1 | 6 | 2.0 | 4Gi |
+| Shared pool ||| 1.5 | 2Gi |
+| billing | us-east-1 | 4 | Burst allowed ||
+| Deprecated tier ||||| 
+
+Narrative between tables keeps the block parser switching modes.
+
+| Metric | Q1 | Q2 |
+| :------- | ---: | ---: |
+| Requests (M) | 12.4 | 14.1 |
+| Combined total || 26.5 |
+
+Narrative between tables keeps the block parser switching modes.
+
+| Service | Region | Replicas | CPU | Memory |
+| ------ | --- | --- | --- | --- |
+| auth-api | eu-west-1 | 6 | 2.0 | 4Gi |
+| Shared pool ||| 1.5 | 2Gi |
+| billing | us-east-1 | 4 | Burst allowed ||
+| Deprecated tier ||||| 
+
+Narrative between tables keeps the block parser switching modes.
+
+| Metric | Q1 | Q2 |
+| :------- | ---: | ---: |
+| Requests (M) | 12.4 | 14.1 |
+| Combined total || 26.5 |
+
+Narrative between tables keeps the block parser switching modes.
+
+| Service | Region | Replicas | CPU | Memory |
+| ------ | --- | --- | --- | --- |
+| auth-api | eu-west-1 | 6 | 2.0 | 4Gi |
+| Shared pool ||| 1.5 | 2Gi |
+| billing | us-east-1 | 4 | Burst allowed ||
+| Deprecated tier ||||| 
+
+Narrative between tables keeps the block parser switching modes.
+
+| Metric | Q1 | Q2 |
+| :------- | ---: | ---: |
+| Requests (M) | 12.4 | 14.1 |
+| Combined total || 26.5 |
+
+Narrative between tables keeps the block parser switching modes.
+
+| Service | Region | Replicas | CPU | Memory |
+| ------ | --- | --- | --- | --- |
+| auth-api | eu-west-1 | 6 | 2.0 | 4Gi |
+| Shared pool ||| 1.5 | 2Gi |
+| billing | us-east-1 | 4 | Burst allowed ||
+| Deprecated tier ||||| 
+
+Narrative between tables keeps the block parser switching modes.
+
+| Metric | Q1 | Q2 |
+| :------- | ---: | ---: |
+| Requests (M) | 12.4 | 14.1 |
+| Combined total || 26.5 |
+
+Narrative between tables keeps the block parser switching modes.
+
+| Service | Region | Replicas | CPU | Memory |
+| ------ | --- | --- | --- | --- |
+| auth-api | eu-west-1 | 6 | 2.0 | 4Gi |
+| Shared pool ||| 1.5 | 2Gi |
+| billing | us-east-1 | 4 | Burst allowed ||
+| Deprecated tier ||||| 
+
+Narrative between tables keeps the block parser switching modes.
+
+| Metric | Q1 | Q2 |
+| :------- | ---: | ---: |
+| Requests (M) | 12.4 | 14.1 |
+| Combined total || 26.5 |
+
+Narrative between tables keeps the block parser switching modes.
+
+| Service | Region | Replicas | CPU | Memory |
+| ------ | --- | --- | --- | --- |
+| auth-api | eu-west-1 | 6 | 2.0 | 4Gi |
+| Shared pool ||| 1.5 | 2Gi |
+| billing | us-east-1 | 4 | Burst allowed ||
+| Deprecated tier ||||| 
+
+Narrative between tables keeps the block parser switching modes.
+
+| Metric | Q1 | Q2 |
+| :------- | ---: | ---: |
+| Requests (M) | 12.4 | 14.1 |
+| Combined total || 26.5 |
+
+Narrative between tables keeps the block parser switching modes.
+
+| Service | Region | Replicas | CPU | Memory |
+| ------ | --- | --- | --- | --- |
+| auth-api | eu-west-1 | 6 | 2.0 | 4Gi |
+| Shared pool ||| 1.5 | 2Gi |
+| billing | us-east-1 | 4 | Burst allowed ||
+| Deprecated tier ||||| 
+
+Narrative between tables keeps the block parser switching modes.
+
+| Metric | Q1 | Q2 |
+| :------- | ---: | ---: |
+| Requests (M) | 12.4 | 14.1 |
+| Combined total || 26.5 |
+
+Narrative between tables keeps the block parser switching modes.
+
+| Service | Region | Replicas | CPU | Memory |
+| ------ | --- | --- | --- | --- |
+| auth-api | eu-west-1 | 6 | 2.0 | 4Gi |
+| Shared pool ||| 1.5 | 2Gi |
+| billing | us-east-1 | 4 | Burst allowed ||
+| Deprecated tier ||||| 
+
+Narrative between tables keeps the block parser switching modes.
+

--- a/benches/parsing.rs
+++ b/benches/parsing.rs
@@ -63,6 +63,15 @@ Thank you for reading!
     /// Table-heavy document (~5KB)
     pub const TABLES_5K: &str = include_str!("fixtures/tables-5k.md");
 
+    /// Definition-list-heavy document (~5KB)
+    pub const DEFLISTS_5K: &str = include_str!("fixtures/deflists-5k.md");
+
+    /// Tables with merged cells and column-width delimiter hints (~5KB)
+    pub const TABLES_MERGED_5K: &str = include_str!("fixtures/tables-merged-5k.md");
+
+    /// Mixed document exercising every extension at once (~5KB)
+    pub const MIXED_EXTENDED_5K: &str = include_str!("fixtures/mixed-extended-5k.md");
+
     /// Generate a large document by repeating sections
     pub fn large() -> String {
         let section = r#"
@@ -172,6 +181,69 @@ fn bench_parsing(c: &mut Criterion) {
     group.finish();
 }
 
+/// Benchmarks for extension-heavy inputs under the options they require.
+fn bench_extensions(c: &mut Criterion) {
+    use ferromark::{Options, RenderPolicy};
+
+    let mut group = c.benchmark_group("extensions");
+
+    let deflist_options = Options {
+        definition_lists: true,
+        ..Options::gfm()
+    };
+    group.throughput(Throughput::Bytes(samples::DEFLISTS_5K.len() as u64));
+    group.bench_function("deflists_5k", |b| {
+        b.iter(|| {
+            ferromark::to_html_with_options(black_box(samples::DEFLISTS_5K), &deflist_options)
+        })
+    });
+
+    let merged_options = Options {
+        merged_table_cells: true,
+        table_column_widths: true,
+        ..Options::gfm()
+    };
+    group.throughput(Throughput::Bytes(samples::TABLES_MERGED_5K.len() as u64));
+    group.bench_function("tables_merged_5k", |b| {
+        b.iter(|| {
+            ferromark::to_html_with_options(black_box(samples::TABLES_MERGED_5K), &merged_options)
+        })
+    });
+
+    let all_options = Options {
+        render_policy: RenderPolicy::Untrusted,
+        allow_html: true,
+        allow_link_refs: true,
+        tables: true,
+        merged_table_cells: true,
+        table_column_widths: true,
+        strikethrough: true,
+        highlight: true,
+        superscript: true,
+        subscript: true,
+        task_lists: true,
+        autolink_literals: true,
+        disallowed_raw_html: true,
+        footnotes: true,
+        inline_footnotes: true,
+        front_matter: true,
+        heading_ids: true,
+        math: true,
+        callouts: true,
+        definition_lists: true,
+        line_comments: true,
+        indented_code_blocks: true,
+    };
+    group.throughput(Throughput::Bytes(samples::MIXED_EXTENDED_5K.len() as u64));
+    group.bench_function("mixed_extended_5k", |b| {
+        b.iter(|| {
+            ferromark::to_html_with_options(black_box(samples::MIXED_EXTENDED_5K), &all_options)
+        })
+    });
+
+    group.finish();
+}
+
 fn bench_escaping(c: &mut Criterion) {
     let mut group = c.benchmark_group("escaping");
 
@@ -245,6 +317,7 @@ fn bench_buffer_reuse(c: &mut Criterion) {
 criterion_group!(
     benches,
     bench_parsing,
+    bench_extensions,
     bench_escaping,
     bench_pathological,
     bench_buffer_reuse

--- a/docs/reports/2026-07-25-profiling-hotspots.md
+++ b/docs/reports/2026-07-25-profiling-hotspots.md
@@ -1,0 +1,137 @@
+# Profiling report: hotspots across option combinations (2026-07-25)
+
+Instruction-level profiling pass over the current feature set, including the
+recently added definition lists, merged table cells, and table column widths.
+Deterministic counts come from `valgrind --tool=callgrind`; allocation
+behavior from `valgrind --tool=dhat`; wall-clock sanity checks from the new
+`profile_harness` example (medians over repeated runs). Wall-clock numbers in
+this report were taken on a shared 4-core x86-64 container and are only
+meaningful relative to each other, not comparable to the published Apple
+Silicon numbers.
+
+## Method
+
+```bash
+cargo build --profile release-debug --example profile_harness
+valgrind --tool=callgrind \
+  target/release-debug/examples/profile_harness benches/fixtures/tables-5k.md gfm 50
+callgrind_annotate callgrind.out.<pid>
+```
+
+Fixtures: the existing `commonmark-{5k,20k,50k}` and `tables-5k`, plus three
+new ones added by this pass — `deflists-5k` (definition lists),
+`tables-merged-5k` (merged cells + column-width hints), and
+`mixed-extended-5k` (every extension in one document, incl. footnotes, math,
+callouts, front matter). Presets cover `minimal`, `commonmark`, `gfm`,
+`default`, `all`, per-feature combos, and single-flag bisection presets
+(`cm+<flag>`).
+
+## Per-flag cost on a text-heavy document
+
+Callgrind totals for `commonmark-50k` (10 iterations), one flag enabled on
+top of `Options::commonmark()`, measured before any of the fixes below:
+
+| Flag | Instruction overhead |
+|------|---------------------:|
+| `heading_ids` | **+11.8%** |
+| `autolink_literals` | +6.7% |
+| `tables` | +6.1% (the fixture contains real tables) |
+| `highlight` | +3.6% (switches the SIMD specials scan variant) |
+| `superscript`+`subscript` | +3.1% |
+| `strikethrough`, `task_lists`, `math`, `callouts`, `disallowed_raw_html` | ~0% |
+
+Notable: `strikethrough`, `math`, and `callouts` are effectively free on
+documents that do not use them. `heading_ids` — enabled in
+`Options::default()` — was the most expensive single flag.
+
+## Hotspots found and fixed in this pass
+
+### 1. Table cell splitting scanned byte-by-byte (largest win)
+
+`split_table_cells` + `advance_table_cell_scan` accounted for ~20% of all
+instructions on table-heavy input. The scanner made one non-inlined call per
+content byte (152k calls per 50 renders of a 4.5 KB document, ~22
+instructions per byte). Both the GFM splitter and the merged-cell splitter
+now jump between structurally relevant bytes with `memchr3(b'|', b'\\',
+b'`')`; plain cell content is skipped at SIMD speed.
+
+### 2. Table cell content was copied per cell
+
+`CellState::add_text` copied every cell into a scratch buffer byte-by-byte
+(with a capacity check per byte) purely to rewrite `\|` escapes. Cells
+almost never contain backslashes: the renderer now keeps a borrowed range
+into the input for the single-text/no-escape case and renders it zero-copy;
+the escape-rewriting copy only happens when a backslash is actually present.
+
+### 3. `heading_ids` slug generation
+
+`HeadingIdTracker::make_id` validated UTF-8 three times per heading,
+allocated a `String` per heading for the dedup map, and classified slug
+bytes through a chain of branches. The slug loop is now driven by a 256-byte
+lookup table, the dedup map is keyed by raw bytes (`Vec<u8>`), and UTF-8 is
+validated once on return. Flag cost dropped from +11.8% to +8.5%.
+
+## Results (callgrind, identical HTML output verified)
+
+| Fixture / preset | Before | After | Δ |
+|------------------|-------:|------:|--:|
+| tables-5k / default | 16.33M | 14.52M | **−11.1%** |
+| tables-merged-5k / gfm-merged | 33.17M | 29.40M | **−11.4%** |
+| tables-5k / gfm | 43.36M | 39.09M | **−9.9%** |
+| commonmark-50k / default | 82.62M | 78.67M | **−4.8%** |
+| mixed-extended-5k / all | 36.21M | 34.87M | −3.7% |
+| commonmark-5k / gfm | 22.10M | 21.48M | −2.8% |
+| deflists-5k / gfm-deflists | 22.23M | 22.27M | ±0% |
+
+Wall-clock medians on the container agreed in direction (tables-5k +15%,
+commonmark-5k +7–10%, merged +5–12%, deflists ±0%). The full test suite and
+CommonMark conformance corpus pass unchanged; rendered HTML is byte-identical
+across the fixture × preset matrix.
+
+## Findings without code changes (candidates for follow-up)
+
+1. **Allocation pressure under `all`** — on `mixed-extended-5k` with every
+   extension on, ~10% of instructions are inside `malloc`/`free` (~483
+   allocations per 5 KB document, DHAT). Main sources: per-heading dedup-map
+   key allocation (reduced but not eliminated by this pass),
+   `normalize_footnote_label` allocating per footnote definition *and*
+   per reference, a fresh `InlineParser` per footnote-section render, and
+   growth of per-parse scratch vectors. An arena or reuse of the
+   footnote-section parser would remove most of this.
+2. **`autolink_literals` candidate scan** — +6.7% on text without a single
+   autolink, spent in extra `memchr` passes over all inline text
+   (`has_autolink_candidates`). Folding the candidate check into the
+   existing SIMD specials scan would make the flag near-free on
+   non-autolink text.
+3. **Definition lists are cheap** — the new feature adds no measurable
+   overhead when unused and no dedicated hotspot when heavily used; no
+   action needed.
+4. **`merged_table_cells` / `table_column_widths`** — +2–4% instructions on
+   table-heavy input, ~0 when unused. Early wall-clock outliers that
+   suggested `table_column_widths` was expensive on non-table documents did
+   not reproduce under callgrind; they were scheduler noise on the shared
+   container.
+5. **`render_block_event` dispatch** — ~1.5% of instructions go to the
+   per-event prologue (destructuring ~20 `&mut` state fields per call).
+   Splitting hot state (text/cell paths) from cold state would shrink this,
+   but the payoff is small relative to the churn.
+
+## Reproducing
+
+```bash
+# throughput matrix
+cargo build --profile release-debug --example profile_harness
+target/release-debug/examples/profile_harness benches/fixtures/<fixture>.md <preset> 2000
+
+# instruction profile for one combination
+valgrind --tool=callgrind --callgrind-out-file=out.cg \
+  target/release-debug/examples/profile_harness benches/fixtures/tables-5k.md default 50
+callgrind_annotate --auto=yes out.cg | less
+
+# allocation profile
+valgrind --tool=dhat \
+  target/release-debug/examples/profile_harness benches/fixtures/mixed-extended-5k.md all 20
+
+# criterion lens on the new fixtures
+cargo bench --bench parsing -- extensions
+```

--- a/examples/profile_harness.rs
+++ b/examples/profile_harness.rs
@@ -1,0 +1,144 @@
+//! Profiling harness: renders a fixture repeatedly under a named option preset.
+//!
+//! Usage: profile_harness <fixture-path> <preset> <iterations>
+//!
+//! Presets: minimal | commonmark | gfm | default | all | gfm-deflists |
+//!          gfm-merged | gfm-widths | gfm-footnotes
+//!
+//! Designed for use under `valgrind --tool=callgrind` or `perf record`:
+//!
+//! ```bash
+//! cargo build --profile release-debug --example profile_harness
+//! valgrind --tool=callgrind \
+//!   target/release-debug/examples/profile_harness benches/fixtures/commonmark-5k.md gfm 200
+//! ```
+
+use std::hint::black_box;
+
+use ferromark::{Options, RenderPolicy};
+
+fn all_extensions() -> Options {
+    Options {
+        render_policy: RenderPolicy::Untrusted,
+        allow_html: true,
+        allow_link_refs: true,
+        tables: true,
+        merged_table_cells: true,
+        table_column_widths: true,
+        strikethrough: true,
+        highlight: true,
+        superscript: true,
+        subscript: true,
+        task_lists: true,
+        autolink_literals: true,
+        disallowed_raw_html: true,
+        footnotes: true,
+        inline_footnotes: true,
+        front_matter: true,
+        heading_ids: true,
+        math: true,
+        callouts: true,
+        definition_lists: true,
+        line_comments: true,
+        indented_code_blocks: true,
+    }
+}
+
+fn preset(name: &str) -> Options {
+    match name {
+        "minimal" => Options::minimal(),
+        "commonmark" => Options::commonmark(),
+        "gfm" => Options::gfm(),
+        "default" => Options::default(),
+        "all" => all_extensions(),
+        "gfm-deflists" => Options {
+            definition_lists: true,
+            ..Options::gfm()
+        },
+        "gfm-merged" => Options {
+            merged_table_cells: true,
+            ..Options::gfm()
+        },
+        "gfm-widths" => Options {
+            table_column_widths: true,
+            ..Options::gfm()
+        },
+        "gfm-footnotes" => Options {
+            footnotes: true,
+            inline_footnotes: true,
+            ..Options::gfm()
+        },
+        "cm+tables" => Options {
+            tables: true,
+            ..Options::commonmark()
+        },
+        "cm+autolink" => Options {
+            autolink_literals: true,
+            ..Options::commonmark()
+        },
+        "cm+strike" => Options {
+            strikethrough: true,
+            ..Options::commonmark()
+        },
+        "cm+tasklists" => Options {
+            task_lists: true,
+            ..Options::commonmark()
+        },
+        "cm+disallowed" => Options {
+            disallowed_raw_html: true,
+            ..Options::commonmark()
+        },
+        "cm+headingids" => Options {
+            heading_ids: true,
+            ..Options::commonmark()
+        },
+        "cm+math" => Options {
+            math: true,
+            ..Options::commonmark()
+        },
+        "cm+highlight" => Options {
+            highlight: true,
+            ..Options::commonmark()
+        },
+        "cm+supsub" => Options {
+            superscript: true,
+            subscript: true,
+            ..Options::commonmark()
+        },
+        "cm+callouts" => Options {
+            callouts: true,
+            ..Options::commonmark()
+        },
+        other => {
+            eprintln!("unknown preset: {other}");
+            std::process::exit(2);
+        }
+    }
+}
+
+fn main() {
+    let mut args = std::env::args().skip(1);
+    let (Some(path), Some(preset_name), Some(iters)) = (args.next(), args.next(), args.next())
+    else {
+        eprintln!("usage: profile_harness <fixture-path> <preset> <iterations>");
+        std::process::exit(2);
+    };
+    let iterations: usize = iters.parse().expect("iterations must be a number");
+    let input = std::fs::read_to_string(&path).expect("fixture must be readable");
+    let options = preset(&preset_name);
+
+    let mut out = Vec::with_capacity(input.len() * 2);
+    let start = std::time::Instant::now();
+    for _ in 0..iterations {
+        out.clear();
+        ferromark::to_html_into_with_options(black_box(&input), &mut out, &options);
+        black_box(&out);
+    }
+    let elapsed = start.elapsed();
+    let bytes = input.len() as f64 * iterations as f64;
+    let mib_s = bytes / elapsed.as_secs_f64() / (1024.0 * 1024.0);
+    eprintln!(
+        "{path} preset={preset_name} iters={iterations} elapsed={elapsed:?} throughput={mib_s:.1} MiB/s out_len={}",
+        out.len()
+    );
+}

--- a/src/block/parser.rs
+++ b/src/block/parser.rs
@@ -3100,17 +3100,20 @@ impl<'a> BlockParser<'a> {
         }
 
         let mut cell_start = pos;
-        while pos <= scan_end {
-            if pos == scan_end {
+        loop {
+            // Jump straight to the next byte that can affect cell structure;
+            // everything in between is plain cell content.
+            let Some(offset) = memchr::memchr3(b'|', b'\\', b'`', &line[pos..scan_end]) else {
                 // End of line - emit last cell
-                let (s, e) = Self::trim_cell(&line[cell_start..pos], cell_start);
+                let (s, e) = Self::trim_cell(&line[cell_start..scan_end], cell_start);
                 cells.push(TableCell {
                     start: s as u32,
                     end: e as u32,
                     colspan: 1,
                 });
                 break;
-            }
+            };
+            pos += offset;
 
             if line[pos] == b'|' {
                 // Cell boundary
@@ -3164,6 +3167,10 @@ impl<'a> BlockParser<'a> {
 
         let mut cell_start = pos;
         while pos < line_end {
+            let Some(offset) = memchr::memchr3(b'|', b'\\', b'`', &line[pos..line_end]) else {
+                break;
+            };
+            pos += offset;
             if line[pos] == b'|' {
                 let mut pipe_count = 0usize;
                 while pos < line_end && line[pos] == b'|' {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -649,7 +649,7 @@ impl HeadingState {
 /// and not a hash-DoS surface, so SipHash's cost is not warranted.
 struct HeadingIdTracker {
     /// Maps a base slug to how many times it has been seen so far.
-    used: std::collections::HashMap<String, usize, rustc_hash::FxBuildHasher>,
+    used: std::collections::HashMap<Vec<u8>, usize, rustc_hash::FxBuildHasher>,
     /// Reusable buffer holding the id returned by `make_id`.
     slug_buf: Vec<u8>,
 }
@@ -671,12 +671,14 @@ impl HeadingIdTracker {
     /// base slug is recorded.
     fn make_id(&mut self, raw: &[u8]) -> &str {
         generate_slug_into(raw, &mut self.slug_buf);
-        if self.slug_buf.is_empty() || std::str::from_utf8(&self.slug_buf).is_err() {
-            self.slug_buf.clear();
+        if self.slug_buf.is_empty() {
             self.slug_buf.extend_from_slice(b"heading");
         }
-        let slug = std::str::from_utf8(&self.slug_buf).unwrap_or("heading");
-        match self.used.get_mut(slug) {
+        // Dedup on raw slug bytes; UTF-8 validity is checked once on return.
+        // The slug is valid UTF-8 by construction: `generate_slug_into` only
+        // removes whole ASCII bytes and lowercases ASCII, which cannot split
+        // multibyte sequences in UTF-8 heading text.
+        match self.used.get_mut(self.slug_buf.as_slice()) {
             Some(count) => {
                 *count += 1;
                 let n = *count;
@@ -684,7 +686,7 @@ impl HeadingIdTracker {
                 push_decimal(&mut self.slug_buf, n);
             }
             None => {
-                self.used.insert(slug.to_string(), 0);
+                self.used.insert(self.slug_buf.clone(), 0);
             }
         }
         std::str::from_utf8(&self.slug_buf).unwrap_or("heading")
@@ -715,31 +717,51 @@ fn push_decimal(buf: &mut Vec<u8>, mut n: usize) {
 /// 4. Remove chars that are not alphanumeric, `-`, `_`, or space
 /// 5. Strip leading/trailing `-`
 fn generate_slug_into(raw: &[u8], slug: &mut Vec<u8>) {
+    /// Skip the byte without touching whitespace state (markup delimiters).
+    const SLUG_MARKUP: u8 = 0;
+    /// Fold a whitespace run into a single `-`.
+    const SLUG_SPACE: u8 = 1;
+    /// Drop the byte but end any pending whitespace run (other punctuation).
+    const SLUG_DROP: u8 = 2;
+    /// Any other value is the (lowercased) byte to append.
+    static SLUG_LUT: [u8; 256] = {
+        let mut table = [SLUG_DROP; 256];
+        let mut i = 0usize;
+        while i < 256 {
+            let b = i as u8;
+            table[i] = match b {
+                // Strip inline markup delimiters (keep _ since it's valid in slugs)
+                b'*' | b'~' | b'`' | b'[' | b']' | b'!' | b'#' => SLUG_MARKUP,
+                b' ' | b'\t' | b'\n' | b'\r' => SLUG_SPACE,
+                // Lowercase ASCII
+                b'A'..=b'Z' => b + 32,
+                // Keep alphanumeric, hyphen, underscore, and multibyte UTF-8
+                b'a'..=b'z' | b'0'..=b'9' | b'-' | b'_' => b,
+                0x80..=0xFF => b,
+                _ => SLUG_DROP,
+            };
+            i += 1;
+        }
+        table
+    };
+
     slug.clear();
     let mut prev_was_space = false;
 
     for &b in raw {
-        // Strip inline markup delimiters (keep _ since it's valid in slugs)
-        if matches!(b, b'*' | b'~' | b'`' | b'[' | b']' | b'!' | b'#') {
-            continue;
-        }
-
-        if b == b' ' || b == b'\t' || b == b'\n' || b == b'\r' {
-            if !prev_was_space && !slug.is_empty() {
-                slug.push(b'-');
-                prev_was_space = true;
+        match SLUG_LUT[b as usize] {
+            SLUG_MARKUP => {}
+            SLUG_SPACE => {
+                if !prev_was_space && !slug.is_empty() {
+                    slug.push(b'-');
+                    prev_was_space = true;
+                }
             }
-            continue;
-        }
-
-        prev_was_space = false;
-
-        // Lowercase ASCII
-        let ch = if b.is_ascii_uppercase() { b + 32 } else { b };
-
-        // Keep alphanumeric, hyphen, underscore, and multibyte UTF-8
-        if ch.is_ascii_alphanumeric() || ch == b'-' || ch == b'_' || ch >= 0x80 {
-            slug.push(ch);
+            SLUG_DROP => prev_was_space = false,
+            ch => {
+                prev_was_space = false;
+                slug.push(ch);
+            }
         }
     }
 
@@ -756,8 +778,10 @@ fn generate_slug_into(raw: &[u8], slug: &mut Vec<u8>) {
 
 /// State for collecting table cell content before inline parsing.
 struct CellState {
-    /// Collected text content.
+    /// Collected text content (only used when escapes force a copy).
     content: Vec<u8>,
+    /// Borrowed input range for the common single-text, no-escape cell.
+    pending: Option<Range>,
     /// Whether we're currently in a cell.
     in_cell: bool,
 }
@@ -766,6 +790,7 @@ impl CellState {
     fn new() -> Self {
         Self {
             content: Vec::with_capacity(64),
+            pending: None,
             in_cell: false,
         }
     }
@@ -773,34 +798,61 @@ impl CellState {
     fn start(&mut self) {
         self.in_cell = true;
         self.content.clear();
+        self.pending = None;
     }
 
-    fn add_text(&mut self, text: &[u8]) {
+    fn add_text(&mut self, range: Range, input: &[u8]) {
+        let text = range.slice(input);
+        // Fast path: a cell is almost always a single text range without a
+        // backslash escape, which can be rendered straight from the input.
+        if self.content.is_empty()
+            && self.pending.is_none()
+            && memchr::memchr(b'\\', text).is_none()
+        {
+            self.pending = Some(range);
+            return;
+        }
+        if let Some(prev) = self.pending.take() {
+            self.content.extend_from_slice(prev.slice(input));
+        }
         // In table cells, \| is a table-level escape meaning literal |
-        // Replace \| with | before inline parsing
+        // Replace \| with | before inline parsing. Bytes between escapes are
+        // copied in bulk.
         let mut i = 0;
-        while i < text.len() {
-            if text[i] == b'\\' && i + 1 < text.len() && text[i + 1] == b'|' {
+        while let Some(offset) = memchr::memchr(b'\\', &text[i..]) {
+            let idx = i + offset;
+            if idx + 1 < text.len() && text[idx + 1] == b'|' {
+                self.content.extend_from_slice(&text[i..idx]);
                 self.content.push(b'|');
-                i += 2;
+                i = idx + 2;
             } else {
-                self.content.push(text[i]);
-                i += 1;
+                self.content.extend_from_slice(&text[i..=idx]);
+                i = idx + 1;
             }
         }
+        self.content.extend_from_slice(&text[i..]);
     }
 
-    fn finish(&mut self) -> &[u8] {
+    fn finish<'a>(&'a mut self, input: &'a [u8]) -> &'a [u8] {
         self.in_cell = false;
-        // Trim trailing whitespace
-        while self
-            .content
-            .last()
-            .is_some_and(|&b| b == b' ' || b == b'\t')
-        {
-            self.content.pop();
+        let mut slice: &[u8] = match self.pending.take() {
+            Some(range) => range.slice(input),
+            None => {
+                // Trim trailing whitespace
+                while self
+                    .content
+                    .last()
+                    .is_some_and(|&b| b == b' ' || b == b'\t')
+                {
+                    self.content.pop();
+                }
+                return &self.content;
+            }
+        };
+        while slice.last().is_some_and(|&b| b == b' ' || b == b'\t') {
+            slice = &slice[..slice.len() - 1];
         }
-        &self.content
+        slice
     }
 }
 
@@ -1122,7 +1174,7 @@ impl<R: FencedCodeRenderer + ?Sized> RenderContext<'_, '_, R> {
                 } else if heading_state.in_heading {
                     heading_state.add_text(text);
                 } else if cell_state.in_cell {
-                    cell_state.add_text(text);
+                    cell_state.add_text(*range, input);
                 } else {
                     render_inline_content(
                         text,
@@ -1380,7 +1432,7 @@ impl<R: FencedCodeRenderer + ?Sized> RenderContext<'_, '_, R> {
                 cell_state.start();
             }
             BlockEvent::TableCellEnd => {
-                let content = cell_state.finish();
+                let content = cell_state.finish(input);
                 if !content.is_empty() {
                     render_inline_content(
                         content,


### PR DESCRIPTION
## Summary

Instruction-level profiling pass (callgrind + DHAT + a new wall-clock harness) over the current option surface, including the recently added definition lists, merged table cells, and table column widths. Full method, per-flag cost table, and findings are in `docs/reports/2026-07-25-profiling-hotspots.md`.

### Hotspots fixed

1. **Table cell splitting scanned byte-by-byte** — `split_table_cells`/`advance_table_cell_scan` made one non-inlined call per content byte (~20% of instructions on table-heavy input). Both the GFM and merged-cell splitters now skip plain content with `memchr3(b'|', b'\\', b'`')`.
2. **Per-cell content copy** — `CellState::add_text` copied every cell byte-by-byte just to rewrite `\|` escapes. Cells without a backslash (the common case) now render zero-copy from the input; the copy path only runs when an escape is present.
3. **`heading_ids` slug generation** — the most expensive single flag (+11.8% instructions on a text-heavy 50 KB document, and it is on in `Options::default()`). It validated UTF-8 three times per heading and allocated a `String` per heading. Slugging is now LUT-driven, the dedup map is keyed by raw bytes, and UTF-8 is validated once. Flag cost drops to +8.5%.

### Results (callgrind, deterministic; identical HTML verified across the fixture × preset matrix)

| Fixture / preset | Δ instructions |
|---|---:|
| tables-merged-5k / gfm+merged | **−11.4%** |
| tables-5k / default | **−11.1%** |
| tables-5k / gfm | −9.9% |
| commonmark-50k / default | −4.8% |
| mixed-extended-5k / all extensions | −3.7% |
| commonmark-5k / gfm | −2.8% |

Definition lists turned out to be cheap: no measurable overhead when unused, no dedicated hotspot when heavy. Early signs that `table_column_widths` slowed non-table documents did not reproduce under callgrind (container scheduling noise).

### Tooling added

- `examples/profile_harness.rs` — renders any fixture under named presets incl. single-flag bisection presets (`cm+headingids`, `cm+autolink`, …), ready for callgrind/perf.
- Three extension-heavy fixtures: `deflists-5k.md`, `tables-merged-5k.md`, `mixed-extended-5k.md`.
- New `extensions` criterion bench group covering those fixtures.
- `docs/reports/2026-07-25-profiling-hotspots.md` with method, numbers, and follow-up candidates (allocation pressure under `all`, folding the autolink-literal candidate scan into the SIMD specials scan).

### Testing

- Full `cargo test` suite (incl. CommonMark conformance) passes; clippy and fmt clean.
- Rendered HTML byte-identical to the pre-change build across 6 fixtures × 5 presets.
- Callgrind instruction counts strictly decreased on every measured combination except the deflists fixture (±0%, expected — it exercises none of the touched paths).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XfE4muPHr1qcpVUQEhCSb3

---
_Generated by [Claude Code](https://claude.ai/code/session_01XfE4muPHr1qcpVUQEhCSb3)_