### PR TITLE
perf(footnotes): reuse parsers and avoid per-reference label allocation

### DIFF
--- a/docs/reports/2026-07-25-profiling-hotspots.md
+++ b/docs/reports/2026-07-25-profiling-hotspots.md
@@ -116,6 +116,36 @@ across the fixture × preset matrix.
    Splitting hot state (text/cell paths) from cold state would shrink this,
    but the payoff is small relative to the churn.
 
+## Addendum: follow-up pass (same day)
+
+Two of the follow-up candidates were implemented after the first pass merged:
+
+1. **Footnote allocation pressure** — footnote *reference* resolution no
+   longer allocates: `FootnoteStore::get_index_bytes` normalizes the label
+   into a stack buffer instead of building a `String` per `[^…]` candidate.
+   The footnote section renderer now reuses the parent context's idle
+   `InlineParser` (via `mem::swap`) for reference footnotes and the parent's
+   parser + event buffer for inline footnotes, instead of allocating a fresh
+   parser (10+ vectors) per footnote. On `mixed-extended-5k` with every
+   extension on: allocations drop from 483 to 251 per document (108 → 60
+   KiB), instructions drop 5.5%, and wall-clock on footnote-heavy input
+   improves ~6% (paired-ratio median vs merged main).
+
+2. **Autolink candidate scan: attempted, reverted.** Folding the three
+   single-needle passes of `has_autolink_candidates` into one
+   `memchr3(b'@', b':', b'.')` pass (or a `memchr2` + dot-loop hybrid) cuts
+   the flag's instruction cost from +6.7% to +4.4% — but measured
+   consistently *slower* in paired wall-clock runs on x86-64 AVX2. Multi-
+   needle memchr runs at a lower per-byte rate than single-needle, and `.`
+   is frequent in prose, so the combined scan stops constantly while the
+   `@`/`:` passes it replaces run essentially stop-free. The three-pass
+   structure is now documented in the code as deliberate. The remaining
+   real opportunity is folding the candidate check into the SIMD specials
+   scan itself (one shared pass over the text), which is a larger refactor
+   of `collect_marks` — and any such change should be validated on Apple
+   Silicon (the published benchmark platform), where relative memchr pass
+   costs differ.
+
 ## Reproducing
 
 ```bash

--- a/src/footnote.rs
+++ b/src/footnote.rs
@@ -39,6 +39,26 @@ impl FootnoteStore {
         self.by_label.get(label).copied()
     }
 
+    /// Look up a definition by raw (unnormalized) label bytes.
+    ///
+    /// Normalizes into a stack buffer, so reference-resolution lookups do not
+    /// allocate. Returns `None` for labels with invalid characters.
+    pub fn get_index_bytes(&self, label_bytes: &[u8]) -> Option<usize> {
+        if label_bytes.is_empty() {
+            return None;
+        }
+        let mut buf = smallvec::SmallVec::<[u8; 32]>::with_capacity(label_bytes.len());
+        for &b in label_bytes {
+            if !b.is_ascii_alphanumeric() && b != b'-' && b != b'_' {
+                return None;
+            }
+            buf.push(b.to_ascii_lowercase());
+        }
+        // Labels are validated ASCII above, so this cannot fail.
+        let normalized = std::str::from_utf8(&buf).ok()?;
+        self.by_label.get(normalized).copied()
+    }
+
     pub fn get(&self, idx: usize) -> Option<&FootnoteDef> {
         self.defs.get(idx)
     }

--- a/src/inline/mod.rs
+++ b/src/inline/mod.rs
@@ -21,7 +21,7 @@ pub use event::InlineEvent;
 pub use links::AutolinkLiteralKind;
 
 use crate::Range;
-use crate::footnote::{FootnoteStore, normalize_footnote_label};
+use crate::footnote::FootnoteStore;
 use crate::link_ref::LinkRefStore;
 use code_span::{CodeSpan, extract_code_spans, resolve_code_spans};
 use emphasis::{EmphasisMatch, EmphasisStacks, resolve_emphasis_with_stacks_into};
@@ -639,14 +639,12 @@ impl InlineParser {
             }
 
             let label_bytes = &text[label_start..label_end];
-            if let Some(normalized) = normalize_footnote_label(label_bytes) {
-                if let Some(idx) = footnote_store.get_index(&normalized) {
-                    out.push(FootnoteRef {
-                        start: open_pos,
-                        end: close_pos + 1,
-                        def_index: idx as u32,
-                    });
-                }
+            if let Some(idx) = footnote_store.get_index_bytes(label_bytes) {
+                out.push(FootnoteRef {
+                    start: open_pos,
+                    end: close_pos + 1,
+                    def_index: idx as u32,
+                });
             }
         }
     }
@@ -1547,6 +1545,11 @@ fn has_inline_specials_highlight_superscript(input: &[u8]) -> bool {
 /// instead of matching common letters like 'h' and 'w'.
 #[inline]
 fn has_autolink_candidates(input: &[u8]) -> bool {
+    // Deliberately three separate single-byte passes: `@` and `:` are rare,
+    // so their passes run at full single-needle SIMD speed. Folding the
+    // needles into one memchr2/memchr3 pass executes fewer instructions but
+    // measured slower on x86-64 AVX2 (frequent `.` stops throttle the
+    // combined scan); see docs/reports/2026-07-25-profiling-hotspots.md.
     // Check for @ (email autolinks) — rare in normal prose
     if memchr(b'@', input).is_some() {
         return true;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2019,12 +2019,16 @@ impl<R: FencedCodeRenderer + ?Sized> RenderContext<'_, '_, R> {
                         &nested_options,
                         renderer,
                     );
+                    // Reuse the parent's inline parser (idle by now) so each
+                    // footnote does not pay for a fresh set of scratch buffers.
+                    std::mem::swap(&mut nested.inline_parser, &mut self.inline_parser);
                     for (index, event) in def.events.iter().enumerate() {
                         if Some(index) == last_paragraph_end {
                             nested.pending_footnote_backref = Some((def.label.clone(), number));
                         }
                         nested.render_block_event(input, event);
                     }
+                    std::mem::swap(&mut nested.inline_parser, &mut self.inline_parser);
                 }
                 FootnoteTarget::Inline(definition_index) => {
                     let Some(content) = self
@@ -2040,19 +2044,19 @@ impl<R: FencedCodeRenderer + ?Sized> RenderContext<'_, '_, R> {
                         .write_string(&(definition_index + 1).to_string());
                     self.writer.write_str("\">\n<p>");
 
-                    let mut inline_parser = InlineParser::new();
-                    let mut inline_events = Vec::with_capacity(16);
                     let mut nested_numbers = FootnoteNumbers::new(0);
                     let nested_options = Options {
                         footnotes: false,
                         inline_footnotes: false,
                         ..*self.options
                     };
+                    // Reuse the parent's idle inline parser and event buffer
+                    // instead of allocating fresh ones per inline footnote.
                     render_inline_content(
                         &content,
                         &mut *self.writer,
-                        &mut inline_parser,
-                        &mut inline_events,
+                        &mut self.inline_parser,
+                        &mut self.inline_events,
                         self.link_refs,
                         None,
                         &mut nested_numbers,


### PR DESCRIPTION
## Summary

Follow-up to #117, implementing the allocation-pressure candidates from `docs/reports/2026-07-25-profiling-hotspots.md`:

1. **Footnote reference lookups no longer allocate** — `FootnoteStore::get_index_bytes` normalizes the label into a stack buffer (`SmallVec<[u8; 32]>`) instead of building a `String` per `[^…]` lookup candidate. Definitions keep the owned-`String` path since those strings live in the store anyway.
2. **Footnote section rendering reuses scratch buffers** — reference footnotes `mem::swap` the parent context's idle `InlineParser` into the nested render context (instead of allocating a fresh parser with 10+ vectors per footnote); inline footnotes reuse the parent's parser and event buffer directly.

### Measured (mixed-extended-5k fixture, every extension enabled)

- Allocations: **483 → 251 per document** (108 KiB → 60 KiB) — DHAT
- Instructions: **−5.5%** vs merged main — callgrind, deterministic
- Wall-clock on footnote-heavy input: **~+6%** (paired-ratio median vs main binary)
- Rendered HTML byte-identical across the 6-fixture × 6-preset matrix

### Autolink candidate scan: attempted, deliberately reverted

Folding the three single-needle passes of `has_autolink_candidates` into one `memchr3` pass cut the flag's instruction cost from +6.7% to +4.4% — but measured consistently *slower* in paired wall-clock runs on x86-64 AVX2: multi-needle memchr runs at a lower per-byte rate, and frequent `.` hits in prose throttle the combined scan while the `@`/`:` passes it would replace run essentially stop-free. The three-pass structure is now documented in the code as intentional, and the report's addendum records the experiment so it isn't retried blindly. The remaining opportunity (folding the check into the SIMD specials scan) should be validated on Apple Silicon, the published benchmark platform.

### Testing

- Full `cargo test` suite (incl. CommonMark conformance) passes; clippy and fmt clean.
- Output identity verified against the merged-main binary across all fixtures × presets, including `gfm-footnotes`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XfE4muPHr1qcpVUQEhCSb3

---
_Generated by [Claude Code](https://claude.ai/code/session_01XfE4muPHr1qcpVUQEhCSb3)_