### PR TITLE
chore(ci): update native artifact handoff actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -110,7 +110,7 @@ jobs:
         run: pnpm test
 
       - name: Upload native binary
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: native-${{ matrix.artifact }}
           path: node/ferromark/ferromark.${{ matrix.artifact }}.node
@@ -153,7 +153,7 @@ jobs:
         run: pnpm audit --audit-level high
 
       - name: Download native binaries
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           pattern: native-*
           merge-multiple: true


### PR DESCRIPTION
## What changed

- Upgrade `actions/upload-artifact` from v4 to v7.
- Upgrade `actions/download-artifact` from v4 to v8.
- Preserve artifact names, paths, retention, glob pattern, and merged-download behavior.

## Why

The release workflow gains the current action runtimes and stricter artifact integrity handling without changing the native-binary handoff contract.

## Validation

- `./scripts/check-workflow-pins.sh`
- Parsed the release workflow as YAML.
- Reviewed upload and download inputs against the new major-version contracts.
- Confirmed the release package still downloads merged native artifacts into `node/ferromark`.
