### PR TITLE
chore(ci): upgrade release-please action to v5

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
     steps:
       - name: Run release-please
         id: release
-        uses: googleapis/release-please-action@5c625bfb5d1ff62eadeeb3772007f7f66fdcf071 # v4
+        uses: googleapis/release-please-action@0dfd8538845b8e92600d271a895a5372865d4062 # v5
         with:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json


### PR DESCRIPTION
## What changed

- Upgrade `googleapis/release-please-action` from v4 to v5 at an immutable commit SHA.
- Preserve the manifest, configuration, token, and `releases_created` output contract.

## Why

Release Please v5 moves the action to its current Node 24 runtime while retaining the repository's existing manifest-driven release flow.

## Validation

- `./scripts/check-workflow-pins.sh`
- Parsed the release workflow as YAML.
- Verified the action inputs and downstream `releases_created` output usage remain unchanged.
