### PR TITLE
perf(heading-ids): store dedup slugs in an arena instead of per-heading map keys

### DIFF
--- a/docs/reports/2026-07-25-profiling-hotspots.md
+++ b/docs/reports/2026-07-25-profiling-hotspots.md
@@ -146,6 +146,23 @@ Two of the follow-up candidates were implemented after the first pass merged:
    Silicon (the published benchmark platform), where relative memchr pass
    costs differ.
 
+3. **Heading-ID dedup arena** (third pass, same day) — the remaining
+   allocation source flagged in finding 1 is gone: `HeadingIdTracker` no
+   longer clones each new base slug into a `HashMap<Vec<u8>, usize>` key.
+   Base slugs are appended to a single arena buffer and the dedup map is
+   keyed by the slug's 64-bit Fx hash, storing arena ranges; hash collisions
+   (astronomically rare, but handled) share a map entry and are resolved by
+   comparing arena bytes. On `commonmark-50k` (247 headings) with default
+   options: allocations drop from 363 to 121 blocks per document (−67%),
+   instructions drop 2.6%, and the `heading_ids` flag overhead falls from
+   +8.6% to +5.6% over `Options::commonmark()`. Criterion medians on the
+   container: `parsing/commonmark_5k` −5.4%, `parsing/commonmark_50k` −8.4%
+   (allocator round-trips cost disproportionately more wall-clock than
+   instructions). Rendered HTML is byte-identical across the fixture ×
+   preset matrix including slug-collision edge cases. The flag's remaining
+   cost is the slug scan and heading-content buffering itself, which is
+   proportional to heading text and has no obvious fat left.
+
 ## Reproducing
 
 ```bash

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,6 +29,8 @@ pub mod profiling;
 pub mod range;
 pub mod render;
 
+use smallvec::SmallVec;
+
 // Re-export primary types
 pub use block::{Alignment, BlockEvent, BlockParser, CalloutType, CodeBlockKind, fixup_list_tight};
 pub use footnote::FootnoteStore;
@@ -647,16 +649,34 @@ impl HeadingState {
 ///
 /// Uses the crate's fast non-cryptographic hasher: heading slugs are short
 /// and not a hash-DoS surface, so SipHash's cost is not warranted.
+///
+/// Base slugs live in a single append-only arena; the dedup map is keyed by
+/// the slug's hash and stores arena ranges, so recording a new slug never
+/// allocates a dedicated key. Distinct slugs that collide on the 64-bit hash
+/// share a map entry and are told apart by comparing arena bytes.
 struct HeadingIdTracker {
-    /// Maps a base slug to how many times it has been seen so far.
-    used: std::collections::HashMap<Vec<u8>, usize, rustc_hash::FxBuildHasher>,
+    /// All base slugs seen so far, concatenated.
+    arena: Vec<u8>,
+    /// Maps a slug hash to the entries whose slug has that hash.
+    used: std::collections::HashMap<u64, SmallVec<[SlugEntry; 1]>, rustc_hash::FxBuildHasher>,
     /// Reusable buffer holding the id returned by `make_id`.
     slug_buf: Vec<u8>,
+}
+
+/// One recorded base slug: its bytes in the arena and how often it repeated.
+struct SlugEntry {
+    /// Start offset of the slug in the arena.
+    start: usize,
+    /// Length of the slug in bytes.
+    len: usize,
+    /// How many times this base slug has been seen after the first.
+    seen: usize,
 }
 
 impl HeadingIdTracker {
     fn new() -> Self {
         Self {
+            arena: Vec::with_capacity(256),
             used: std::collections::HashMap::with_capacity_and_hasher(
                 32,
                 rustc_hash::FxBuildHasher,
@@ -667,8 +687,8 @@ impl HeadingIdTracker {
 
     /// Build a unique heading id from raw heading content, appending `-1`,
     /// `-2`, etc. on collision. The returned slice borrows the internal
-    /// buffer and is valid until the next call. Allocates only when a new
-    /// base slug is recorded.
+    /// buffer and is valid until the next call. Recording a slug appends to
+    /// the arena instead of allocating a per-heading map key.
     fn make_id(&mut self, raw: &[u8]) -> &str {
         generate_slug_into(raw, &mut self.slug_buf);
         if self.slug_buf.is_empty() {
@@ -678,15 +698,32 @@ impl HeadingIdTracker {
         // The slug is valid UTF-8 by construction: `generate_slug_into` only
         // removes whole ASCII bytes and lowercases ASCII, which cannot split
         // multibyte sequences in UTF-8 heading text.
-        match self.used.get_mut(self.slug_buf.as_slice()) {
-            Some(count) => {
-                *count += 1;
-                let n = *count;
+        let hash = {
+            use std::hash::{BuildHasher, Hasher};
+            let mut hasher = rustc_hash::FxBuildHasher.build_hasher();
+            hasher.write(&self.slug_buf);
+            hasher.finish()
+        };
+        let entries = self.used.entry(hash).or_default();
+        let arena = &self.arena;
+        let slug = self.slug_buf.as_slice();
+        match entries
+            .iter_mut()
+            .find(|e| &arena[e.start..e.start + e.len] == slug)
+        {
+            Some(entry) => {
+                entry.seen += 1;
+                let n = entry.seen;
                 self.slug_buf.push(b'-');
                 push_decimal(&mut self.slug_buf, n);
             }
             None => {
-                self.used.insert(self.slug_buf.clone(), 0);
+                entries.push(SlugEntry {
+                    start: self.arena.len(),
+                    len: self.slug_buf.len(),
+                    seen: 0,
+                });
+                self.arena.extend_from_slice(&self.slug_buf);
             }
         }
         std::str::from_utf8(&self.slug_buf).unwrap_or("heading")


### PR DESCRIPTION
Third follow-up from the [2026-07-25 profiling pass](docs/reports/2026-07-25-profiling-hotspots.md) (#117, #119): removes the last allocation source flagged there — the per-heading dedup-map key.

## Problem

`HeadingIdTracker::make_id` cloned every new base slug into a `HashMap<Vec<u8>, usize>` key. On heading-heavy input that meant one `malloc` per unique heading (247 on `commonmark-50k` — nearly all of the flag's allocator traffic) plus byte-wise re-hashing of every stored key each time the map grew.

## Change

Base slugs now live in one append-only arena buffer. The dedup map is keyed by the slug's 64-bit Fx hash and stores arena ranges (`SmallVec<[SlugEntry; 1]>`); distinct slugs colliding on the hash — astronomically rare, but handled — share a map entry and are told apart by comparing arena bytes. Recording a new slug is an arena append; map growth re-hashes cheap `u64` keys.

## Results (container: x86-64 AVX2, callgrind / DHAT / criterion)

| Metric (`commonmark-50k`, 247 headings, default options) | Before | After |
|---|---:|---:|
| Allocations per document | 363 blocks | 121 blocks (**−67%**) |
| Instructions (default preset) | 39.20M | 38.18M (**−2.6%**) |
| `heading_ids` flag overhead vs `commonmark()` | +8.6% | +5.6% |

Criterion wall-clock medians: `parsing/commonmark_5k` **−5.4%**, `parsing/commonmark_50k` **−8.4%** (paired vs saved baseline, p < 0.05; allocator round-trips cost disproportionately more wall-clock than instructions).

## Verification

- Full test suite + CommonMark conformance corpus pass unchanged; clippy clean.
- Rendered HTML byte-identical to `main` across the full fixture × preset matrix (7 fixtures × default/gfm/all/cm+headingids) plus slug-collision edge cases (`# Foo` repeated, `# Foo 1` vs `# Foo-1`, case folding, markup stripping, empty slugs).
- Report addendum updated with the numbers and the conclusion that the flag's remaining cost (slug scan + heading-content buffering) is proportional to heading text with no obvious fat left.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XfE4muPHr1qcpVUQEhCSb3

---
_Generated by [Claude Code](https://claude.ai/code/session_01XfE4muPHr1qcpVUQEhCSb3)_