### PR TITLE
perf(escape): scan short text segments with the escape LUT instead of dual memchr passes

### DIFF
--- a/docs/reports/2026-07-25-profiling-hotspots.md
+++ b/docs/reports/2026-07-25-profiling-hotspots.md
@@ -163,6 +163,24 @@ Two of the follow-up candidates were implemented after the first pass merged:
    cost is the slug scan and heading-content buffering itself, which is
    proportional to heading text and has no obvious fat left.
 
+4. **HTML escaping scanned every text segment twice via SIMD dispatch**
+   (fourth pass, same day) — `first_text_escape` ran two full memchr passes
+   per text segment (`memchr3(<,>,&)` plus `memchr(")`), and segments
+   between escapes are short: median 17 bytes, >95% under 64 bytes on the
+   prose fixtures. At those lengths memchr's per-call cost is dominated by
+   its ifunc trampoline (indirect call through an `AtomicPtr`) and SIMD
+   setup, paid twice per segment — measured ~60 instructions per call
+   against a ~20-instruction payload. Both escape scanners now use a
+   table-driven scalar scan for segments ≤64 bytes (reusing the existing
+   escape LUTs) and, on the rare long segment, bound the second pass by the
+   first `memchr3` hit so it never scans past the earliest match.
+   Instructions: −3.7% (commonmark-50k/gfm), −4.2% (commonmark-5k/default),
+   −6.6% (tables-5k/gfm). Wall-clock across the whole parsing suite: −6.5%
+   to −12.6% with no regressions — the win exceeds the instruction delta
+   because the removed indirect calls also cost branch-prediction and
+   pipeline stalls that callgrind does not model. Output byte-identical
+   across the fixture × preset matrix.
+
 ## Reproducing
 
 ```bash

--- a/src/escape.rs
+++ b/src/escape.rs
@@ -120,28 +120,32 @@ pub fn needs_attr_escape(input: &[u8]) -> bool {
     input.iter().any(|&b| ATTR_ESCAPE_TABLE[b as usize])
 }
 
+/// Below this length a table-driven scalar scan beats SIMD memchr passes,
+/// whose per-call dispatch and setup cost more than the scan itself. Inline
+/// text segments between escapes are short in practice (median ~17 bytes,
+/// >95% under 64 on prose corpora).
+const SHORT_SCAN_MAX: usize = 64;
+
 #[inline]
 fn first_text_escape(input: &[u8]) -> Option<usize> {
+    if input.len() <= SHORT_SCAN_MAX {
+        return input.iter().position(|&b| TEXT_ESCAPE_TABLE[b as usize]);
+    }
     let a = memchr3(b'<', b'>', b'&', input);
-    let b = memchr(b'"', input);
-    min_opt(a, b)
+    // A '"' is only relevant if it appears before the first <>& hit, so the
+    // second pass never scans past it.
+    let limit = a.unwrap_or(input.len());
+    memchr(b'"', &input[..limit]).or(a)
 }
 
 #[inline]
 fn first_attr_escape(input: &[u8]) -> Option<usize> {
-    let a = memchr3(b'<', b'>', b'&', input);
-    let b = memchr2(b'"', b'\'', input);
-    min_opt(a, b)
-}
-
-#[inline]
-fn min_opt(a: Option<usize>, b: Option<usize>) -> Option<usize> {
-    match (a, b) {
-        (Some(a), Some(b)) => Some(a.min(b)),
-        (Some(a), None) => Some(a),
-        (None, Some(b)) => Some(b),
-        (None, None) => None,
+    if input.len() <= SHORT_SCAN_MAX {
+        return input.iter().position(|&b| ATTR_ESCAPE_TABLE[b as usize]);
     }
+    let a = memchr3(b'<', b'>', b'&', input);
+    let limit = a.unwrap_or(input.len());
+    memchr2(b'"', b'\'', &input[..limit]).or(a)
 }
 
 /// Escape and return as a new Vec.

--- a/src/escape.rs
+++ b/src/escape.rs
@@ -467,4 +467,95 @@ mod tests {
         escape_text_into(&mut out, "Hallo Welt! <tag>".as_bytes());
         assert_eq!(out, b"Hallo Welt! &lt;tag&gt;");
     }
+
+    /// Build an input of `len` filler bytes with `payload` spliced in at `at`.
+    fn padded(len: usize, at: usize, payload: &[u8]) -> Vec<u8> {
+        let mut v = vec![b'x'; len];
+        v[at..at + payload.len()].copy_from_slice(payload);
+        v
+    }
+
+    /// The scalar and memchr scanners must agree for every escape character
+    /// at every position across the length threshold.
+    #[test]
+    fn test_scanner_threshold_boundary() {
+        for len in [SHORT_SCAN_MAX - 1, SHORT_SCAN_MAX, SHORT_SCAN_MAX + 1] {
+            for &c in b"<>&\"" {
+                for at in [0, len / 2, len - 1] {
+                    let input = padded(len, at, &[c]);
+                    assert_eq!(
+                        first_text_escape(&input),
+                        Some(at),
+                        "text: len={len} at={at} c={}",
+                        c as char
+                    );
+                }
+            }
+            for &c in b"<>&\"'" {
+                let input = padded(len, len - 1, &[c]);
+                assert_eq!(first_attr_escape(&input), Some(len - 1));
+            }
+            assert_eq!(first_text_escape(&vec![b'x'; len]), None);
+            assert_eq!(first_attr_escape(&vec![b'x'; len]), None);
+        }
+    }
+
+    /// Long-input path: a quote before the first `<>&` hit must win, and a
+    /// quote after it must not mask it (the bounded second pass).
+    #[test]
+    fn test_long_input_quote_ordering() {
+        let long = 4 * SHORT_SCAN_MAX;
+
+        let quote_first = padded(long, 10, b"\"");
+        let quote_first = {
+            let mut v = quote_first;
+            v[long - 10] = b'<';
+            v
+        };
+        assert_eq!(first_text_escape(&quote_first), Some(10));
+
+        let angle_first = padded(long, 10, b"<");
+        let angle_first = {
+            let mut v = angle_first;
+            v[long - 10] = b'"';
+            v
+        };
+        assert_eq!(first_text_escape(&angle_first), Some(10));
+
+        let quote_only = padded(long, long - 1, b"\"");
+        assert_eq!(first_text_escape(&quote_only), Some(long - 1));
+
+        let single_quote_late = padded(long, long - 1, b"'");
+        assert_eq!(first_attr_escape(&single_quote_late), Some(long - 1));
+        // '\'' is not escaped in text context
+        assert_eq!(first_text_escape(&single_quote_late), None);
+    }
+
+    /// End-to-end escaping of a long segment goes through the memchr path.
+    #[test]
+    fn test_escape_long_input_end_to_end() {
+        let long = 3 * SHORT_SCAN_MAX;
+        let mut input = vec![b'a'; long];
+        input[SHORT_SCAN_MAX + 5] = b'"';
+        input[2 * SHORT_SCAN_MAX] = b'&';
+        let mut out = Vec::new();
+        escape_text_into(&mut out, &input);
+
+        let mut expected = Vec::new();
+        for (i, &b) in input.iter().enumerate() {
+            match i {
+                _ if b == b'"' => expected.extend_from_slice(b"&quot;"),
+                _ if b == b'&' => expected.extend_from_slice(b"&amp;"),
+                _ => expected.push(b),
+            }
+        }
+        assert_eq!(out, expected);
+
+        let mut attr_out = Vec::new();
+        input[10] = b'\'';
+        escape_full_into(&mut attr_out, &input);
+        assert!(attr_out.windows(5).any(|w| w == b"&#39;"));
+        assert!(attr_out.windows(6).any(|w| w == b"&quot;"));
+        assert!(attr_out.windows(5).any(|w| w == b"&amp;"));
+    }
 }


### PR DESCRIPTION
Fourth follow-up from the [2026-07-25 profiling pass](docs/reports/2026-07-25-profiling-hotspots.md) (#117, #119, #125) — and the largest single win of the series.

## Problem

`first_text_escape` ran **two full memchr passes** over every inline text segment: `memchr3(b'<', b'>', b'&', …)` plus `memchr(b'"', …)`, taking the minimum. But segments between escapes are short — median 17 bytes, >95% under 64 bytes on the prose fixtures (measured with an instrumented build). At those lengths each memchr call is dominated by its ifunc trampoline (indirect call through an `AtomicPtr`) and SIMD setup: ~60 instructions per call, paid twice, for a ~20-instruction payload. Escaping accounted for ~7% of all instructions on `commonmark-50k`/gfm.

## Change

- Segments ≤ 64 bytes: table-driven scalar scan (`iter().position(...)` over the existing `TEXT_ESCAPE_TABLE`/`ATTR_ESCAPE_TABLE` LUTs) — no dispatch, no setup.
- Longer segments: keep `memchr3`, but bound the second pass (`"` / `"`+`'`) by the first `memchr3` hit, since a quote only matters if it appears *before* the first `<>&` match — the second pass never scans past the earliest hit.

Same treatment for both the text and attribute escapers.

## Results

Callgrind instructions vs `main`:

| Fixture / preset | Before | After | Δ |
|---|---:|---:|--:|
| tables-5k / gfm | 38.75M | 36.19M | **−6.6%** |
| commonmark-5k / default | 20.38M | 19.53M | −4.2% |
| mixed-extended-5k / all | 32.62M | 31.39M | −3.8% |
| commonmark-50k / gfm | 38.99M | 37.56M | −3.7% |

Criterion wall-clock (paired vs saved `main` baseline, p < 0.05), **entire parsing suite, no regressions**:

| Benchmark | Δ median |
|---|--:|
| parsing/commonmark_20k | **−12.6%** |
| parsing/tables_5k | −10.8% |
| parsing/commonmark_5k | −10.1% |
| parsing/thematic_breaks | −9.6% |
| parsing/commonmark_50k | −8.9% |
| parsing/large | −7.5% |
| parsing/medium | −7.4% |
| parsing/small | −6.7% |
| parsing/tiny | −6.5% |

The wall-clock win exceeds the instruction delta because the removed indirect calls also cost branch prediction and pipeline stalls that callgrind does not model.

## Verification

- Rendered HTML byte-identical to `main` across the full fixture × preset matrix (7 fixtures × default/gfm/all/cm+headingids).
- Full test suite + CommonMark conformance corpus pass unchanged; fmt and clippy clean.
- Report addendum updated (finding 4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XfE4muPHr1qcpVUQEhCSb3

---
_Generated by [Claude Code](https://claude.ai/code/session_01XfE4muPHr1qcpVUQEhCSb3)_