### PR TITLE
perf(escape): vectorize the short escape scan with baseline SIMD

### DIFF
--- a/docs/reports/2026-07-25-profiling-hotspots.md
+++ b/docs/reports/2026-07-25-profiling-hotspots.md
@@ -181,6 +181,23 @@ Two of the follow-up candidates were implemented after the first pass merged:
    pipeline stalls that callgrind does not model. Output byte-identical
    across the fixture × preset matrix.
 
+5. **Escape short-scan vectorized without dispatch** (fifth pass, same
+   day) — after finding 4 the scalar LUT loop itself became the #2 cost on
+   the pure `commonmark` preset (~9% of instructions at ~4.6 per byte). The
+   short scan now uses compile-time SIMD: SSE2 on x86-64 and NEON on
+   AArch64 are baseline features, so a 16-byte-chunk comparison loop needs
+   no runtime feature detection — the exact overhead that made per-call
+   memchr expensive here. Sub-16-byte inputs go through a NUL-padded stack
+   buffer (NUL is never an escape byte); longer inputs end with one
+   overlapping chunk. The threshold to the memchr path rose from 64 to 128
+   bytes; the LUT loop remains as the portable fallback. On this
+   container (x86-64): instructions −5.2% (commonmark-50k/commonmark),
+   −4.2% (gfm), −3.5% (commonmark-5k/default); wall-clock −6.3%
+   (commonmark_50k) and −4.9% (commonmark_20k), smaller fixtures within
+   noise, no regressions. The NEON variant follows the crate's existing
+   `is_blank_line_simd` pattern and is exercised by the macOS CI runners;
+   its wall-clock effect on Apple Silicon was not measured here.
+
 ## Reproducing
 
 ```bash

--- a/src/escape.rs
+++ b/src/escape.rs
@@ -120,16 +120,17 @@ pub fn needs_attr_escape(input: &[u8]) -> bool {
     input.iter().any(|&b| ATTR_ESCAPE_TABLE[b as usize])
 }
 
-/// Below this length a table-driven scalar scan beats SIMD memchr passes,
-/// whose per-call dispatch and setup cost more than the scan itself. Inline
-/// text segments between escapes are short in practice (median ~17 bytes,
-/// >95% under 64 on prose corpora).
-const SHORT_SCAN_MAX: usize = 64;
+/// Below this length the local short scan beats SIMD memchr passes, whose
+/// per-call dispatch and setup cost more than the scan itself. Inline text
+/// segments between escapes are short in practice (median ~17 bytes, >95%
+/// under 64 on prose corpora); long inputs (code block content) still go
+/// through memchr, which scans wider per iteration.
+const SHORT_SCAN_MAX: usize = 128;
 
 #[inline]
 fn first_text_escape(input: &[u8]) -> Option<usize> {
     if input.len() <= SHORT_SCAN_MAX {
-        return input.iter().position(|&b| TEXT_ESCAPE_TABLE[b as usize]);
+        return first_escape_short::<false>(input);
     }
     let a = memchr3(b'<', b'>', b'&', input);
     // A '"' is only relevant if it appears before the first <>& hit, so the
@@ -141,11 +142,156 @@ fn first_text_escape(input: &[u8]) -> Option<usize> {
 #[inline]
 fn first_attr_escape(input: &[u8]) -> Option<usize> {
     if input.len() <= SHORT_SCAN_MAX {
-        return input.iter().position(|&b| ATTR_ESCAPE_TABLE[b as usize]);
+        return first_escape_short::<true>(input);
     }
     let a = memchr3(b'<', b'>', b'&', input);
     let limit = a.unwrap_or(input.len());
     memchr2(b'"', b'\'', &input[..limit]).or(a)
+}
+
+/// Find the first escapable byte (`<>&"`, plus `'` when `ATTR`) in a short
+/// input, without memchr's per-call runtime dispatch: SSE2 is baseline on
+/// x86_64 and NEON on AArch64, so both compile to direct SIMD with no
+/// feature detection. Other architectures fall back to a table scan.
+#[inline]
+fn first_escape_short<const ATTR: bool>(input: &[u8]) -> Option<usize> {
+    #[cfg(target_arch = "x86_64")]
+    return first_escape_sse2::<ATTR>(input);
+    #[cfg(all(target_arch = "aarch64", target_feature = "neon"))]
+    return unsafe { first_escape_neon::<ATTR>(input) };
+    #[cfg(not(any(
+        target_arch = "x86_64",
+        all(target_arch = "aarch64", target_feature = "neon")
+    )))]
+    {
+        let table = if ATTR {
+            &ATTR_ESCAPE_TABLE
+        } else {
+            &TEXT_ESCAPE_TABLE
+        };
+        input.iter().position(|&b| table[b as usize])
+    }
+}
+
+/// Bitmask of lanes equal to any escapable byte in a 16-byte SSE2 vector.
+#[cfg(target_arch = "x86_64")]
+#[inline]
+fn escape_mask_sse2<const ATTR: bool>(v: std::arch::x86_64::__m128i) -> u32 {
+    use std::arch::x86_64::*;
+    // SAFETY: SSE2 is part of the x86_64 baseline.
+    unsafe {
+        let lt = _mm_cmpeq_epi8(v, _mm_set1_epi8(b'<' as i8));
+        let gt = _mm_cmpeq_epi8(v, _mm_set1_epi8(b'>' as i8));
+        let amp = _mm_cmpeq_epi8(v, _mm_set1_epi8(b'&' as i8));
+        let quot = _mm_cmpeq_epi8(v, _mm_set1_epi8(b'"' as i8));
+        let mut m = _mm_or_si128(_mm_or_si128(lt, gt), _mm_or_si128(amp, quot));
+        if ATTR {
+            m = _mm_or_si128(m, _mm_cmpeq_epi8(v, _mm_set1_epi8(b'\'' as i8)));
+        }
+        _mm_movemask_epi8(m) as u32
+    }
+}
+
+#[cfg(target_arch = "x86_64")]
+#[inline]
+fn first_escape_sse2<const ATTR: bool>(input: &[u8]) -> Option<usize> {
+    use std::arch::x86_64::*;
+    let len = input.len();
+    if len < 16 {
+        // Pad into a stack buffer; NUL is never an escape byte, so the
+        // padding cannot produce a hit.
+        let mut buf = [0u8; 16];
+        buf[..len].copy_from_slice(input);
+        // SAFETY: `buf` is 16 bytes; unaligned load is allowed.
+        let v = unsafe { _mm_loadu_si128(buf.as_ptr().cast()) };
+        let m = escape_mask_sse2::<ATTR>(v);
+        return (m != 0).then(|| m.trailing_zeros() as usize);
+    }
+    let mut pos = 0;
+    while pos + 16 <= len {
+        // SAFETY: `pos + 16 <= len` bounds the unaligned 16-byte load.
+        let v = unsafe { _mm_loadu_si128(input.as_ptr().add(pos).cast()) };
+        let m = escape_mask_sse2::<ATTR>(v);
+        if m != 0 {
+            return Some(pos + m.trailing_zeros() as usize);
+        }
+        pos += 16;
+    }
+    if pos < len {
+        // Overlapping final chunk; lanes before `pos` were already scanned
+        // clean, so any set bit belongs to the unscanned tail.
+        // SAFETY: `len >= 16` in this branch, so `len - 16` is in bounds.
+        let v = unsafe { _mm_loadu_si128(input.as_ptr().add(len - 16).cast()) };
+        let m = escape_mask_sse2::<ATTR>(v);
+        if m != 0 {
+            return Some(len - 16 + m.trailing_zeros() as usize);
+        }
+    }
+    None
+}
+
+#[cfg(all(target_arch = "aarch64", target_feature = "neon"))]
+#[inline]
+fn is_escape_byte<const ATTR: bool>(b: u8) -> bool {
+    matches!(b, b'<' | b'>' | b'&' | b'"') || (ATTR && b == b'\'')
+}
+
+#[cfg(all(target_arch = "aarch64", target_feature = "neon"))]
+#[target_feature(enable = "neon")]
+#[allow(unsafe_op_in_unsafe_fn)]
+unsafe fn first_escape_neon<const ATTR: bool>(input: &[u8]) -> Option<usize> {
+    use std::arch::aarch64::*;
+
+    #[inline]
+    #[target_feature(enable = "neon")]
+    unsafe fn chunk_hits<const ATTR: bool>(v: uint8x16_t) -> bool {
+        let lt = vceqq_u8(v, vdupq_n_u8(b'<'));
+        let gt = vceqq_u8(v, vdupq_n_u8(b'>'));
+        let amp = vceqq_u8(v, vdupq_n_u8(b'&'));
+        let quot = vceqq_u8(v, vdupq_n_u8(b'"'));
+        let mut m = vorrq_u8(vorrq_u8(lt, gt), vorrq_u8(amp, quot));
+        if ATTR {
+            m = vorrq_u8(m, vceqq_u8(v, vdupq_n_u8(b'\'')));
+        }
+        vmaxvq_u8(m) != 0
+    }
+
+    let len = input.len();
+    if len < 16 {
+        // Pad into a stack buffer; NUL is never an escape byte.
+        let mut buf = [0u8; 16];
+        buf[..len].copy_from_slice(input);
+        let v = vld1q_u8(buf.as_ptr());
+        if chunk_hits::<ATTR>(v) {
+            return input.iter().position(|&b| is_escape_byte::<ATTR>(b));
+        }
+        return None;
+    }
+    let mut pos = 0;
+    while pos + 16 <= len {
+        let v = vld1q_u8(input.as_ptr().add(pos));
+        if chunk_hits::<ATTR>(v) {
+            for (i, &b) in input[pos..pos + 16].iter().enumerate() {
+                if is_escape_byte::<ATTR>(b) {
+                    return Some(pos + i);
+                }
+            }
+        }
+        pos += 16;
+    }
+    if pos < len {
+        // Overlapping final chunk; lanes before `pos` were already scanned
+        // clean, so the first scalar hit is the overall first.
+        let v = vld1q_u8(input.as_ptr().add(len - 16));
+        if chunk_hits::<ATTR>(v) {
+            for (i, &b) in input[pos..].iter().enumerate() {
+                if is_escape_byte::<ATTR>(b) {
+                    return Some(pos + i);
+                }
+            }
+        }
+    }
+    None
 }
 
 /// Escape and return as a new Vec.
@@ -475,11 +621,23 @@ mod tests {
         v
     }
 
-    /// The scalar and memchr scanners must agree for every escape character
-    /// at every position across the length threshold.
+    /// The short-scan and memchr scanners must agree for every escape
+    /// character at every position across chunk and length thresholds.
     #[test]
     fn test_scanner_threshold_boundary() {
-        for len in [SHORT_SCAN_MAX - 1, SHORT_SCAN_MAX, SHORT_SCAN_MAX + 1] {
+        for len in [
+            1,
+            2,
+            15,
+            16,
+            17,
+            31,
+            32,
+            33,
+            SHORT_SCAN_MAX - 1,
+            SHORT_SCAN_MAX,
+            SHORT_SCAN_MAX + 1,
+        ] {
             for &c in b"<>&\"" {
                 for at in [0, len / 2, len - 1] {
                     let input = padded(len, at, &[c]);
@@ -497,6 +655,24 @@ mod tests {
             }
             assert_eq!(first_text_escape(&vec![b'x'; len]), None);
             assert_eq!(first_attr_escape(&vec![b'x'; len]), None);
+        }
+    }
+
+    /// Exhaustive position sweep around the SIMD chunk boundary, including
+    /// two escape bytes where the earlier one must win.
+    #[test]
+    fn test_scanner_every_position() {
+        for len in 1..=40usize {
+            for at in 0..len {
+                let input = padded(len, at, b"&");
+                assert_eq!(first_text_escape(&input), Some(at), "len={len} at={at}");
+                assert_eq!(first_attr_escape(&input), Some(at), "len={len} at={at}");
+                if at + 1 < len {
+                    let mut two = input.clone();
+                    two[len - 1] = b'<';
+                    assert_eq!(first_text_escape(&two), Some(at), "two: len={len} at={at}");
+                }
+            }
         }
     }
 


### PR DESCRIPTION
Fifth follow-up from the [2026-07-25 profiling pass](docs/reports/2026-07-25-profiling-hotspots.md) (#117, #119, #125, #126), from a fresh profile of the pure `commonmark`/`gfm` presets — the paths most relevant for the pulldown-cmark/md4c benchmark comparisons.

## Problem

After #126 removed the per-call memchr dispatch, its replacement became the new #2 hotspot: the scalar LUT loop in the short escape scan costs ~4.6 instructions per byte and accounts for ~9% of all instructions on `commonmark-50k` with the pure `commonmark` preset.

## Change

The short scan now uses compile-time SIMD instead of a scalar loop:

- **x86-64**: SSE2 is part of the architecture baseline, so a 16-byte-chunk `_mm_cmpeq_epi8`/`_mm_movemask_epi8` loop compiles to direct SIMD with zero runtime feature detection — exactly the dispatch overhead that made per-call memchr expensive at these segment lengths (median 17 bytes).
- **AArch64**: equivalent NEON path (`vceqq_u8`/`vmaxvq_u8`), mirroring the crate's existing `is_blank_line_simd` pattern.
- Sub-16-byte inputs are scanned via a NUL-padded stack buffer (NUL is never an escape byte, so padding cannot produce a hit); longer inputs finish with one overlapping final chunk.
- The threshold to the memchr path (long inputs, i.e. code-block content) rises from 64 to 128 bytes; the LUT loop remains as the portable fallback for other architectures.

## Results (x86-64 container)

Callgrind instructions vs `main`:

| Fixture / preset | Before | After | Δ |
|---|---:|---:|--:|
| commonmark-50k / commonmark | 33.02M | 31.30M | **−5.2%** |
| commonmark-50k / gfm | 37.56M | 35.97M | −4.2% |
| commonmark-5k / default | 19.53M | 18.84M | −3.5% |
| tables-5k / gfm | 36.19M | 36.17M | ±0% |

Criterion wall-clock (paired vs saved `main` baseline): `parsing/commonmark_50k` **−6.3%**, `parsing/commonmark_20k` **−4.9%** (both p < 0.05); smaller fixtures within container noise, no regressions detected.

## Verification

- Rendered HTML byte-identical to `main` across the full fixture × preset matrix.
- Full test suite + CommonMark conformance corpus pass; fmt and clippy clean.
- New tests: exhaustive escape-position sweep for lengths 1–40 (covers the sub-16 padded path, chunk boundaries, and the overlapping final chunk, including two-hit ordering), plus threshold-boundary cases extended to 15/16/17/31/32/33 and the new 128-byte limit.
- The NEON path is compiled and exercised by the macOS CI jobs; its wall-clock effect on Apple Silicon was not measured in this container (noted in the report).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XfE4muPHr1qcpVUQEhCSb3

---
_Generated by [Claude Code](https://claude.ai/code/session_01XfE4muPHr1qcpVUQEhCSb3)_