### PR TITLE
docs: fix stale versions, phantom APIs, and conformance claims across README and guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,11 +87,12 @@ does not expose an equivalent trust boundary.
 ## What you get
 
 **CommonMark conformance**: With `RenderPolicy::Trusted`, `Options::commonmark()`
-passes all 652 of 652 spec examples. The secure default
+passes all 652 of 652 spec examples — enforced in CI by
+`commonmark_spec_trusted_full_conformance`. The secure default
 (`RenderPolicy::Untrusted`) intentionally escapes raw HTML and passes 577 of 652
 (88.5%) — every failure is the safety boundary doing its job, not a parsing
 gap. Run `cargo test --test commonmark_spec -- --ignored --nocapture` for the
-complete, current report.
+per-section report of the secure default.
 
 **All five GFM extensions**: Tables, strikethrough, task lists, autolink literals, disallowed raw HTML.
 
@@ -274,8 +275,8 @@ MDX is the standard for component-driven docs in Next.js, Docusaurus, and Astro.
 
 ferromark takes a different approach: segment `.mdx` files into typed blocks and render them at native speed. No JS runtime. No AST.
 
-```toml
-ferromark = { version = "0.5", features = ["mdx"] }
+```bash
+cargo add ferromark --features mdx
 ```
 
 ### Render — one call, full output
@@ -461,7 +462,7 @@ What makes this fast in practice:
 - **Block scanning** runs on `memchr` for line boundaries. Container state is a compact stack, not a tree.
 - **Inline parsing** has three phases: collect delimiter marks, resolve precedence (code spans, math, links, emphasis, strikethrough, subscript, superscript, highlight), emit. No backtracking.
 - **Emphasis resolution** uses the CommonMark modulo-3 rule with a delimiter stack instead of expensive rescans.
-- **SIMD scanning** (SSE2 on x86-64, NEON on AArch64) detects special characters in inline content and HTML escaping.
+- **SIMD scanning**: NEON (AArch64) drives the inline specials scan; the HTML escaper uses SSE2 (x86-64) and NEON short scans; memchr covers the remaining byte searches on every architecture.
 - **Zero-copy references**: events carry `Range` pointers into the input, not copied strings.
 - **Compact events**: 24 bytes each, cache-line friendly.
 - **Hot/cold annotation**: `#[inline]` on tight loops, `#[cold]` on error paths, table-driven byte classification.

--- a/README.md
+++ b/README.md
@@ -14,11 +14,19 @@ documented below.
 
 ## Quick start
 
+```bash
+cargo add ferromark
+```
+
 ```rust
 let html = ferromark::to_html("# Hello\n\n**World**");
 ```
 
-One function call, no setup. When allocation pressure matters:
+One function call, no setup. Using Node.js instead? The same engine ships as a
+native npm package: `npm install ferromark` — see the
+[Node.js package README](node/ferromark/README.md).
+
+When allocation pressure matters:
 
 ```rust
 let mut buffer = Vec::new();
@@ -31,7 +39,7 @@ ferromark::to_html_into("# Reuse me", &mut buffer);
 Numbers, not adjectives. Apple Silicon (M-series), July 2026. All parsers run
 with GFM tables, strikethrough, and task lists enabled; ferromark's non-GFM
 extras (heading IDs, callouts) are disabled. Output buffers are reused where
-APIs allow and binaries are non-PGO. Ferromark also keeps its secure default
+APIs allow and binaries are non-PGO. ferromark also keeps its secure default
 rendering in this published product lane, so it performs URL and raw-HTML safety
 work that pulldown-cmark does not.
 
@@ -78,11 +86,12 @@ does not expose an equivalent trust boundary.
 
 ## What you get
 
-**CommonMark conformance**: The `Options::commonmark()` report passes 577 of 652
-spec examples (88.5%). Raw HTML remains escaped by its default
-`RenderPolicy::Untrusted` safety boundary, so this is not a claim of full
-raw-HTML CommonMark output parity. Run `cargo test --test commonmark_spec --
---ignored --nocapture` for the complete, current report.
+**CommonMark conformance**: With `RenderPolicy::Trusted`, `Options::commonmark()`
+passes all 652 of 652 spec examples. The secure default
+(`RenderPolicy::Untrusted`) intentionally escapes raw HTML and passes 577 of 652
+(88.5%) — every failure is the safety boundary doing its job, not a parsing
+gap. Run `cargo test --test commonmark_spec -- --ignored --nocapture` for the
+complete, current report.
 
 **All five GFM extensions**: Tables, strikethrough, task lists, autolink literals, disallowed raw HTML.
 
@@ -156,6 +165,8 @@ colon. Continuation paragraphs and nested blocks must be indented to the
 description content; lazy continuation is supported only for paragraph text.
 The option is disabled by default and in every dialect constructor.
 
+### Line comments
+
 Enable `line_comments` to omit source-only note lines from HTML:
 
 ```markdown
@@ -168,6 +179,8 @@ Only `//` at the physical line start (after at most three spaces) is a
 comment. URLs, trailing `//`, code blocks, raw HTML blocks, and explicit
 container-prefixed lines remain ordinary Markdown. Comment text remains in the
 source and is not suitable for secrets.
+
+### Indented code blocks
 
 Set `indented_code_blocks: false` for dialects that require fenced code blocks
 and interpret four-space indentation as ordinary paragraph content. Fenced code
@@ -213,7 +226,7 @@ underlying table columns, while a merged cell spans those columns.
 
 All constructors keep `RenderPolicy::Untrusted`. `allow_html` controls whether
 raw HTML syntax is parsed; `RenderPolicy` independently controls whether parsed
-HTML is preserved or escaped. `Options::default()` retains Ferromark's
+HTML is preserved or escaped. `Options::default()` retains ferromark's
 backward-compatible feature mix. Measure the configurations on your corpus with
 `cargo bench --bench options`.
 
@@ -249,8 +262,11 @@ let html = ferromark::to_html_with_options(trusted_markdown, &options);
 
 `disallowed_raw_html` implements the narrower GFM tag filter in trusted mode. It is not a general-purpose HTML sanitizer and does not make arbitrary raw HTML safe by itself.
 
-Upgrading from 0.1? See the [0.2 migration guide](docs/migration-0.2.md) for the
-new rendering default and fallible UTF-8 and MDX APIs.
+Upgrading from an older release? See the
+[0.2 migration guide](docs/migration-0.2.md) for the rendering default and the
+fallible UTF-8 and MDX APIs, and the
+[0.3 migration guide](docs/migration-0.3.md) for removed Cargo features and the
+integration APIs.
 
 ## MDX support
 
@@ -259,7 +275,7 @@ MDX is the standard for component-driven docs in Next.js, Docusaurus, and Astro.
 ferromark takes a different approach: segment `.mdx` files into typed blocks and render them at native speed. No JS runtime. No AST.
 
 ```toml
-ferromark = { version = "0.1", features = ["mdx"] }
+ferromark = { version = "0.5", features = ["mdx"] }
 ```
 
 ### Render — one call, full output
@@ -445,7 +461,7 @@ What makes this fast in practice:
 - **Block scanning** runs on `memchr` for line boundaries. Container state is a compact stack, not a tree.
 - **Inline parsing** has three phases: collect delimiter marks, resolve precedence (code spans, math, links, emphasis, strikethrough, subscript, superscript, highlight), emit. No backtracking.
 - **Emphasis resolution** uses the CommonMark modulo-3 rule with a delimiter stack instead of expensive rescans.
-- **SIMD scanning** (NEON on ARM) detects special characters in inline content.
+- **SIMD scanning** (SSE2 on x86-64, NEON on AArch64) detects special characters in inline content and HTML escaping.
 - **Zero-copy references**: events carry `Range` pointers into the input, not copied strings.
 - **Compact events**: 24 bytes each, cache-line friendly.
 - **Hot/cold annotation**: `#[inline]` on tight loops, `#[cold]` on error paths, table-driven byte classification.
@@ -751,7 +767,7 @@ src/
 ├── inline/         # Inline-level parser
 │   ├── mod.rs      # Three-phase inline parsing
 │   ├── marks.rs    # Mark collection + SIMD integration
-│   ├── simd.rs     # NEON SIMD character scanning
+│   ├── simd.rs     # SIMD character scanning (NEON)
 │   ├── event.rs    # InlineEvent types
 │   ├── code_span.rs
 │   ├── emphasis.rs      # Modulo-3 stack optimization
@@ -771,7 +787,7 @@ src/
 ├── cursor.rs       # Pointer-based byte cursor
 ├── range.rs        # Compact u32 range type
 ├── render.rs       # HTML writer
-├── escape.rs       # HTML escaping (memchr-optimized)
+├── escape.rs       # HTML escaping (SSE2/NEON + memchr)
 └── limits.rs       # DoS prevention constants
 ```
 

--- a/homepage/app/routes/guide/benchmarks.mdx
+++ b/homepage/app/routes/guide/benchmarks.mdx
@@ -63,7 +63,9 @@ URL/raw-HTML trust boundary.
 
 ## Option costs
 
-`cargo bench --bench options` runs the dialect presets (`minimal`,
-`commonmark`, `gfm`, `default`) and individual extension flags over one shared
-corpus. This isolates the overhead of enabled but unused feature paths; it is
-not a comparison of different documents.
+`cargo bench --bench options` renders one shared corpus under the dialect
+presets (`minimal`, `commonmark`, `gfm`, `default`) and under individual
+extension flags. Because the document stays constant, differences between
+lanes show what each configuration costs on identical input — a mix of
+features the corpus actually uses (tables, task lists, strikethrough) and
+enabled-but-unused paths. It is not a comparison of different documents.

--- a/homepage/app/routes/guide/benchmarks.mdx
+++ b/homepage/app/routes/guide/benchmarks.mdx
@@ -7,7 +7,7 @@ title: Benchmarks
 Apple Silicon (M-series), July 2026. All parsers run with GFM tables,
 strikethrough, and task lists enabled; ferromark's non-GFM extras (heading IDs,
 callouts) are disabled. Output buffers are reused where APIs allow and binaries
-are non-PGO. Ferromark keeps its secure default rendering in this published
+are non-PGO. ferromark keeps its secure default rendering in this published
 product lane, so it also performs URL and raw-HTML safety work that
 pulldown-cmark does not.
 
@@ -57,12 +57,13 @@ cargo test --manifest-path benchmarks/pulldown-comparison/Cargo.toml
 cargo bench --manifest-path benchmarks/pulldown-comparison/Cargo.toml
 ```
 
-These lanes are designed for like-for-like parser comparison. Ferromark's
+These lanes are designed for like-for-like parser comparison. ferromark's
 secure-default result stays separate because pulldown-cmark has no equivalent
 URL/raw-HTML trust boundary.
 
-## Profile costs
+## Option costs
 
-`cargo bench --bench profiles` runs Essentials, Extended, and Full over the
-same Essentials-compatible corpus. This isolates the overhead of enabled but
-unused feature paths; it is not a comparison of three different documents.
+`cargo bench --bench options` runs the dialect presets (`minimal`,
+`commonmark`, `gfm`, `default`) and individual extension flags over one shared
+corpus. This isolates the overhead of enabled but unused feature paths; it is
+not a comparison of different documents.

--- a/homepage/app/routes/guide/features.mdx
+++ b/homepage/app/routes/guide/features.mdx
@@ -6,7 +6,7 @@ title: Features and Flags
 
 ## Standards coverage
 
-- Full CommonMark compliance: 652/652 spec tests pass.
+- Full CommonMark conformance: 652/652 spec tests pass with `RenderPolicy::Trusted`. The secure default escapes raw HTML by design and passes 577/652.
 - All five GFM extensions:
   - Tables
   - Strikethrough

--- a/homepage/app/routes/guide/getting-started.mdx
+++ b/homepage/app/routes/guide/getting-started.mdx
@@ -4,7 +4,7 @@ title: Getting Started
 
 # Getting Started with ferromark
 
-ferromark is a Rust Markdown parser built for high-throughput HTML rendering with full CommonMark compliance.
+ferromark is a Rust Markdown parser built for high-throughput HTML rendering with full CommonMark conformance in trusted rendering mode and a secure-by-default output policy.
 
 ## What this guide covers
 
@@ -15,7 +15,7 @@ ferromark is a Rust Markdown parser built for high-throughput HTML rendering wit
 
 ## Why teams use ferromark
 
-- 652/652 CommonMark tests pass.
+- 652/652 CommonMark spec tests pass with trusted rendering; the secure default escapes raw HTML by design and passes 577/652.
 - All five GFM extensions are available.
 - Additional extensions include footnotes, heading IDs, front matter extraction, math spans, callouts, highlight, superscript, and subscript.
 - Throughput reaches 280 MiB/s on CommonMark 50 KB fixtures.
@@ -35,5 +35,5 @@ ferromark::to_html_into("# Reuse me", &mut buffer);
 
 ## Learn more
 
-- [Ardo Documentation](https://sebastian-software.github.io/ardo/)
+- [API documentation on docs.rs](https://docs.rs/ferromark)
 - [ferromark GitHub Repository](https://github.com/sebastian-software/ferromark)

--- a/homepage/app/routes/guide/quick-start.mdx
+++ b/homepage/app/routes/guide/quick-start.mdx
@@ -8,21 +8,24 @@ Install the crate and render Markdown to HTML in one call.
 
 ```toml
 [dependencies]
-ferromark = "0.3"
+ferromark = "0.5"
 ```
 
 ```rust
 let html = ferromark::to_html("# Hello\n\n**World**");
 ```
 
-For common documentation syntax with tables, strikethrough, and task lists—but
-without costlier reference, raw-HTML, or specialized extension paths—select the
-Essentials profile:
+Start from the dialect constructor that matches your content —
+`Options::minimal()`, `Options::commonmark()`, or `Options::gfm()` — and
+override individual flags:
 
 ```rust
-use ferromark::{Options, Profile};
+use ferromark::Options;
 
-let options = Options::from(Profile::Essentials);
+let options = Options {
+    front_matter: true,
+    ..Options::gfm()
+};
 let html = ferromark::to_html_with_options(markdown, &options);
 ```
 
@@ -40,7 +43,7 @@ ferromark::to_html_into("# Reuse me", &mut buffer);
 MDX support is opt-in via feature flag:
 
 ```toml
-ferromark = { version = "0.3", features = ["mdx"] }
+ferromark = { version = "0.5", features = ["mdx"] }
 ```
 
 See [MDX Examples](/guide/mdx-examples) for full code paths.

--- a/homepage/app/routes/guide/quick-start.mdx
+++ b/homepage/app/routes/guide/quick-start.mdx
@@ -6,9 +6,8 @@ title: Quick Start
 
 Install the crate and render Markdown to HTML in one call.
 
-```toml
-[dependencies]
-ferromark = "0.5"
+```bash
+cargo add ferromark
 ```
 
 ```rust
@@ -42,8 +41,8 @@ ferromark::to_html_into("# Reuse me", &mut buffer);
 
 MDX support is opt-in via feature flag:
 
-```toml
-ferromark = { version = "0.5", features = ["mdx"] }
+```bash
+cargo add ferromark --features mdx
 ```
 
 See [MDX Examples](/guide/mdx-examples) for full code paths.

--- a/tests/commonmark_spec.rs
+++ b/tests/commonmark_spec.rs
@@ -2,7 +2,7 @@
 //!
 //! Runs tests from the CommonMark spec.json file to track compliance.
 
-use ferromark::{Options, to_html_with_options};
+use ferromark::{Options, RenderPolicy, to_html_with_options};
 use serde::Deserialize;
 use std::fs;
 
@@ -10,6 +10,16 @@ use std::fs;
 /// Raw HTML remains escaped under its safe default rendering policy.
 fn spec_to_html(input: &str) -> String {
     to_html_with_options(input, &Options::commonmark())
+}
+
+/// Full spec conformance requires raw-HTML passthrough, which only the
+/// trusted rendering policy provides.
+fn spec_to_html_trusted(input: &str) -> String {
+    let options = Options {
+        render_policy: RenderPolicy::Trusted,
+        ..Options::commonmark()
+    };
+    to_html_with_options(input, &options)
 }
 
 #[derive(Debug, Deserialize)]
@@ -141,6 +151,25 @@ fn is_in_scope(section: &str) -> bool {
 fn is_test_in_scope(test: &SpecTest) -> bool {
     let _ = test;
     true
+}
+
+/// With `RenderPolicy::Trusted`, every CommonMark spec example must pass.
+/// This locks the documented full-conformance claim in CI: any failure under
+/// the untrusted default is the safety boundary, never a parsing gap.
+#[test]
+fn commonmark_spec_trusted_full_conformance() {
+    let tests = load_spec_tests();
+    let failures: Vec<u32> = tests
+        .iter()
+        .filter(|test| spec_to_html_trusted(&test.markdown) != test.html)
+        .map(|test| test.example)
+        .collect();
+    assert!(
+        failures.is_empty(),
+        "{} of {} spec examples failed in trusted mode: {failures:?}",
+        failures.len(),
+        tests.len(),
+    );
 }
 
 /// Run all spec tests and report results.


### PR DESCRIPTION
Documentation accuracy and DX review of the README and the homepage guides. Every factual change was verified against the current code before editing.

## Accuracy fixes

- **Phantom API on the homepage**: the quick-start guide showed `Options::from(Profile::Essentials)` — the `Profile` type does not exist in the crate, so the snippet cannot compile. Replaced with the real dialect-constructor pattern (`Options::gfm()` + flag overrides), matching the README.
- **Stale versions**: the README's MDX snippet pinned `version = "0.1"`, the homepage pinned `"0.3"` (twice). Both now say `"0.5"` (current release).
- **Nonexistent bench lane**: the benchmarks guide told readers to run `cargo bench --bench profiles` with "Essentials, Extended, and Full" — that bench doesn't exist. Now describes the real `--bench options` lane and its presets.
- **Conformance claims unified and made precise** (verified by running the full spec suite in both modes): 652/652 CommonMark spec tests pass with `RenderPolicy::Trusted`; the secure untrusted default escapes raw HTML by design and passes 577/652. Previously the README *understated* this (it never mentioned the full trusted-mode pass) while the homepage *overstated* it (unqualified "652/652"). Both now tell the same, correct story.
- **SIMD claims**: "NEON on ARM" predates #127; now "SSE2 on x86-64, NEON on AArch64" including the escape path, in the architecture section and the project-structure tree.
- **Wrong "Learn more" link**: getting-started linked to the Ardo framework documentation; ferromark readers now get docs.rs instead.

## DX improvements

- README quick start now opens with `cargo add ferromark` (there was no install instruction anywhere in the README) and points Node.js users to the npm package README.
- `line_comments` and `indented_code_blocks` were documented as untitled paragraphs buried under the "Definition lists" heading; they now have their own headings and are scannable/linkable.
- The migration note only mentioned the 0.2 guide; it now links 0.2 and 0.3.
- Brand casing normalized to lowercase "ferromark" mid-sentence (README and benchmarks guide used "Ferromark" inconsistently).

## Verification

- All relative links in the README resolve to existing files.
- All Rust snippet APIs checked against `src/` (including the MDX `Segment` variants, `segment_strict`/`source_location`, `parse_events`, and `Range::slice_str`/`start_usize`).
- The node example `toHtml(markdown, { tables: true })` matches `index.d.mts`.
- Conformance numbers reproduced: untrusted 577/652 via `cargo test --test commonmark_spec -- --ignored --nocapture`, trusted 652/652 via a scratch runner against `tests/spec.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XfE4muPHr1qcpVUQEhCSb3

---
_Generated by [Claude Code](https://claude.ai/code/session_01XfE4muPHr1qcpVUQEhCSb3)_