### PR TITLE
chore(deps)!: standardize on pnpm 11

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,7 +85,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: ["20", "22", "24"]
+        node: ["22", "24"]
     defaults:
       run:
         working-directory: node

--- a/homepage/app/routes/guide/quick-start.mdx
+++ b/homepage/app/routes/guide/quick-start.mdx
@@ -49,7 +49,7 @@ See [MDX Examples](/guide/mdx-examples) for full code paths.
 
 ## Use the Node.js package
 
-Install the native ESM package on Node.js 20 or newer:
+Install the native ESM package on Node.js 22 or newer:
 
 ```sh
 npm install ferromark

--- a/homepage/package.json
+++ b/homepage/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "private": true,
   "type": "module",
-  "packageManager": "pnpm@11.10.0",
+  "packageManager": "pnpm@11.17.0",
   "scripts": {
     "dev": "react-router dev",
     "build": "react-router build && node scripts/verify-build.mjs",

--- a/node/ferromark/README.md
+++ b/node/ferromark/README.md
@@ -55,4 +55,4 @@ toHtml('[guide](/guide)', { linkBasePath: '/docs' })
 
 Image sources and autolinks are not rewritten.
 
-The package supports Node.js 20 or newer on glibc Linux, macOS, and Windows for x64 and arm64. It does not include a WASM fallback.
+The package supports Node.js 22 or newer on glibc Linux, macOS, and Windows for x64 and arm64. It does not include a WASM fallback.

--- a/node/ferromark/package.json
+++ b/node/ferromark/package.json
@@ -41,7 +41,7 @@
     "README.md"
   ],
   "engines": {
-    "node": ">=20.0.0"
+    "node": ">=22.0.0"
   },
   "scripts": {
     "build": "node ./scripts/build-native.mjs && node ./scripts/verify-package.mjs",

--- a/node/package.json
+++ b/node/package.json
@@ -2,9 +2,9 @@
   "name": "ferromark-workspace",
   "private": true,
   "type": "module",
-  "packageManager": "pnpm@10.28.2",
+  "packageManager": "pnpm@11.17.0",
   "engines": {
-    "node": ">=20.0.0"
+    "node": ">=22.13.0"
   },
   "scripts": {
     "build": "pnpm --filter ferromark build",


### PR DESCRIPTION
## What changed

- standardize both JavaScript workspaces on pnpm 11.17.0
- raise the private Node tooling runtime to Node.js 22.13+
- raise the published `ferromark` npm package requirement to Node.js 22+
- test the Node package on Node.js 22 and 24 in CI
- update the README and quick-start guide accordingly

The pnpm 11 install accepts both existing lockfiles unchanged, so this update does not introduce lockfile churn.

## Why

The repository previously used pnpm 10.28.2 under `node/` and pnpm 11.10.0 under `homepage/`. Moving both islands to pnpm 11.17.0 keeps local tooling consistent and moves the Node workspace beyond all affected ranges found during the dependency audit.

Resolved advisories: GHSA-5wx6-mg75-v57r, GHSA-3qhv-2rgh-x77r, GHSA-gj8w-mvpf-x27x, GHSA-4gxm-v5v7-fqc4, GHSA-w466-c33r-3gjp, GHSA-fr4h-3cph-29xv, GHSA-72r4-9c5j-mj57, GHSA-qrv3-253h-g69c, GHSA-54hh-g5mx-jqcp, GHSA-p4xf-rf54-rj3x, GHSA-q6j5-fjx5-2mc3, GHSA-rxhj-4m44-96r4, GHSA-hwx4-2j3j-g496, GHSA-cjhr-43r9-cfmw, and GHSA-hg3w-7f8c-63hp.

Reference: [pnpm 11.17.0 release](https://github.com/pnpm/pnpm/releases/tag/v11.17.0) · [pnpm security advisories](https://github.com/pnpm/pnpm/security/advisories)

## Impact

This is a breaking support-policy change: consumers of the `ferromark` npm package now need Node.js 22 or newer. Node.js 20 is removed from the CI matrix; Node.js 22 and 24 remain covered.

## Validation

- pnpm 11.17.0 selected by Corepack in both workspaces
- frozen installs passed for `node/` and `homepage/`
- pnpm audits passed with no high-severity findings
- Node build, typecheck, lint, package check, clean smoke test, and all 8 tests passed
- homepage prerender build passed
- workflow pin check and `git diff --check` passed