### PR TITLE
chore(deps): update homepage lucide

### DIFF
--- a/homepage/package.json
+++ b/homepage/package.json
@@ -14,7 +14,7 @@
     "@ferramenta/ardo-config": "git+https://github.com/sebastian-software/ferramenta.git#557b21484a2e58a33a61763a4871c5c8e1575cc0&path:packages/ardo-config",
     "ardo": "^4.2.0",
     "isbot": "*",
-    "lucide-react": "^1.26.0",
+    "lucide-react": "^1.27.0",
     "mermaid": "^11.16.0",
     "react": "^19.2.8",
     "react-dom": "^19.2.8",

--- a/homepage/pnpm-lock.yaml
+++ b/homepage/pnpm-lock.yaml
@@ -24,13 +24,13 @@ importers:
         version: https://codeload.github.com/sebastian-software/ferramenta/tar.gz/557b21484a2e58a33a61763a4871c5c8e1575cc0#path:packages/ardo-config(react@19.2.8)
       ardo:
         specifier: ^4.2.0
-        version: 4.2.0(@react-router/dev@8.3.0(react-router@8.3.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(typescript@5.9.3)(vite@8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(yaml@2.9.0)))(@types/node@26.1.1)(@types/react@19.2.17)(esbuild@0.28.1)(lightningcss@1.33.0)(lucide-react@1.26.0(react@19.2.8))(mermaid@11.16.0)(react-dom@19.2.8(react@19.2.8))(react-router@8.3.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)(rollup@4.59.0)(typescript@5.9.3)(vite@8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(yaml@2.9.0))
+        version: 4.2.0(@react-router/dev@8.3.0(react-router@8.3.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(typescript@5.9.3)(vite@8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(yaml@2.9.0)))(@types/node@26.1.1)(@types/react@19.2.17)(esbuild@0.28.1)(lightningcss@1.33.0)(lucide-react@1.27.0(react@19.2.8))(mermaid@11.16.0)(react-dom@19.2.8(react@19.2.8))(react-router@8.3.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)(rollup@4.59.0)(typescript@5.9.3)(vite@8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(yaml@2.9.0))
       isbot:
         specifier: '*'
         version: 5.2.1
       lucide-react:
-        specifier: ^1.26.0
-        version: 1.26.0(react@19.2.8)
+        specifier: ^1.27.0
+        version: 1.27.0(react@19.2.8)
       mermaid:
         specifier: ^11.16.0
         version: 11.16.0
@@ -1727,8 +1727,8 @@ packages:
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
 
-  lucide-react@1.26.0:
-    resolution: {integrity: sha512-raglYVR2+VkMfJL158krjVmE+rV5ST2lzA/KQm1FRSjMHT4MnWaegHxoVEpmc2So3nOEhp9oGejJwAPX8MoAjg==}
+  lucide-react@1.27.0:
+    resolution: {integrity: sha512-rJicGl/3Fly/E0rOH1YmPZ6e49JCnKknh1ox1vpHnkfjujAkKA6sqUZvH3MTAaXXjgexyUwgNwTJzTtYuAFYJw==}
     peerDependencies:
       react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
@@ -3433,7 +3433,7 @@ snapshots:
 
   acorn@8.17.0: {}
 
-  ardo@4.2.0(@react-router/dev@8.3.0(react-router@8.3.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(typescript@5.9.3)(vite@8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(yaml@2.9.0)))(@types/node@26.1.1)(@types/react@19.2.17)(esbuild@0.28.1)(lightningcss@1.33.0)(lucide-react@1.26.0(react@19.2.8))(mermaid@11.16.0)(react-dom@19.2.8(react@19.2.8))(react-router@8.3.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)(rollup@4.59.0)(typescript@5.9.3)(vite@8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(yaml@2.9.0)):
+  ardo@4.2.0(@react-router/dev@8.3.0(react-router@8.3.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(typescript@5.9.3)(vite@8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(yaml@2.9.0)))(@types/node@26.1.1)(@types/react@19.2.17)(esbuild@0.28.1)(lightningcss@1.33.0)(lucide-react@1.27.0(react@19.2.8))(mermaid@11.16.0)(react-dom@19.2.8(react@19.2.8))(react-router@8.3.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)(rollup@4.59.0)(typescript@5.9.3)(vite@8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(yaml@2.9.0)):
     dependencies:
       '@base-ui/react': 1.6.0(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@mdx-js/rollup': 3.1.1(rollup@4.59.0)
@@ -3446,7 +3446,7 @@ snapshots:
       '@vanilla-extract/vite-plugin': 5.2.5(@types/node@26.1.1)(esbuild@0.28.1)(lightningcss@1.33.0)(vite@8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(yaml@2.9.0))(yaml@2.9.0)
       '@vitejs/plugin-react': 6.0.4(vite@8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(yaml@2.9.0))
       gray-matter: 4.0.3
-      lucide-react: 1.26.0(react@19.2.8)
+      lucide-react: 1.27.0(react@19.2.8)
       minisearch: 7.2.0
       react: 19.2.8
       react-dom: 19.2.8(react@19.2.8)
@@ -4126,7 +4126,7 @@ snapshots:
     dependencies:
       yallist: 3.1.1
 
-  lucide-react@1.26.0(react@19.2.8):
+  lucide-react@1.27.0(react@19.2.8):
     dependencies:
       react: 19.2.8
 


### PR DESCRIPTION
## Dependency group

- Package: `lucide-react` 1.26.0 → 1.27.0
- Why separate: this is the homepage's Lucide/Ardo peer surface and has no coupling to the repository's other dependency updates.

## Upstream changes that matter here

[Lucide 1.27.0](https://github.com/lucide-icons/lucide/releases/tag/1.27.0) adds several icons and revises a small set of existing drawings, including `zap`, `zap-off`, `toolbox`, `feather`, `barrel`, and `trophy`. It does not require a React API or peer-range migration.

## Local impact

- The homepage has no direct Lucide imports; Lucide is supplied as an Ardo peer dependency.
- The lockfile update therefore only replaces the Lucide package and refreshes Ardo's peer snapshot.
- No application code or configuration changes are required.
- Remaining risk is limited to intentional visual changes if Ardo renders one of the revised icons.

## Validation

- `corepack pnpm --version`: 11.17.0
- `corepack pnpm install --frozen-lockfile`: passed; supply-chain policy check passed
- `corepack pnpm build`: passed; six prerendered pages verified
- `git diff --check origin/main...HEAD`: passed
- Production audit: delegated to the `homepage` CI job; merge will wait for it

## Risk

Low. This is an icon-data update with unchanged React compatibility, no direct local imports, and a clean production build.