### PR TITLE
chore(msrv)!: require Rust 1.88

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,8 +18,8 @@ jobs:
           - { os: macos-latest, rust: stable, features: default, args: "" }
           - { os: windows-latest, rust: stable, features: default, args: "" }
           - { os: ubuntu-latest, rust: stable, features: all, args: "--all-features" }
-          - { os: ubuntu-latest, rust: "1.85", features: default, args: "" }
-          - { os: ubuntu-latest, rust: "1.85", features: all, args: "--all-features" }
+          - { os: ubuntu-latest, rust: "1.88", features: default, args: "" }
+          - { os: ubuntu-latest, rust: "1.88", features: all, args: "--all-features" }
     runs-on: ${{ matrix.os }}
     name: test (${{ matrix.os }}, rust ${{ matrix.rust }}, ${{ matrix.features }})
     steps:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "ferromark"
 version = "0.6.0"
 edition = "2024"
-rust-version = "1.85"
+rust-version = "1.88"
 description = "Ultra-high-performance Markdown to HTML compiler"
 license = "MIT"
 repository = "https://github.com/sebastian-software/ferromark"

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![crates.io](https://img.shields.io/crates/v/ferromark.svg)](https://crates.io/crates/ferromark)
 [![docs.rs](https://docs.rs/ferromark/badge.svg)](https://docs.rs/ferromark)
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
-[![Rust 1.85+](https://img.shields.io/badge/rust-1.85%2B-orange.svg)](https://www.rust-lang.org)
+[![Rust 1.88+](https://img.shields.io/badge/rust-1.88%2B-orange.svg)](https://www.rust-lang.org)
 [![clippy](https://img.shields.io/badge/clippy--strict-passing-brightgreen.svg)](https://doc.rust-lang.org/clippy/)
 
 Markdown to HTML with a secure default and every GFM extension included. The

--- a/benchmarks/md4c-comparison/Cargo.toml
+++ b/benchmarks/md4c-comparison/Cargo.toml
@@ -2,7 +2,7 @@
 name = "ferromark-md4c-comparison"
 version = "0.0.0"
 edition = "2024"
-rust-version = "1.85"
+rust-version = "1.88"
 publish = false
 
 [dependencies]

--- a/benchmarks/pulldown-comparison/Cargo.toml
+++ b/benchmarks/pulldown-comparison/Cargo.toml
@@ -2,7 +2,7 @@
 name = "ferromark-pulldown-comparison"
 version = "0.0.0"
 edition = "2024"
-rust-version = "1.85"
+rust-version = "1.88"
 publish = false
 
 [dependencies]

--- a/node/native/Cargo.toml
+++ b/node/native/Cargo.toml
@@ -2,7 +2,7 @@
 name = "ferromark-node"
 version = "0.6.0"
 edition = "2024"
-rust-version = "1.85"
+rust-version = "1.88"
 license = "MIT"
 publish = false
 build = "build.rs"

--- a/node/native/src/lib.rs
+++ b/node/native/src/lib.rs
@@ -140,6 +140,7 @@ pub fn transform(markdown: String, options: Option<Options>) -> Result<Transform
     )))
 }
 
+#[allow(clippy::type_complexity)]
 struct CallbackRenderer<'scope> {
     callback: Function<'scope, FnArgs<(String, Option<String>, Option<String>)>, Option<String>>,
 }
@@ -159,6 +160,7 @@ impl FencedCodeRenderer for CallbackRenderer<'_> {
 }
 
 #[napi]
+#[allow(clippy::type_complexity)]
 pub fn to_html_with_renderer(
     markdown: String,
     options: Option<Options>,
@@ -179,6 +181,7 @@ pub fn to_html_with_renderer(
 /// fully escaped HTML — or null/undefined to fall back to the default
 /// escaped `<pre><code>` output.
 #[napi]
+#[allow(clippy::type_complexity)]
 pub fn transform_with_renderer(
     markdown: String,
     options: Option<Options>,

--- a/src/block/parser.rs
+++ b/src/block/parser.rs
@@ -575,33 +575,35 @@ impl<'a> BlockParser<'a> {
         // Check for setext heading underline (when in a paragraph)
         // Must check BEFORE thematic break since `---` can be either
         // Note: indent must be < 4 for a valid setext underline
-        if indent < 4 && self.in_paragraph
-            && let Some(level) = self.is_setext_underline_after_indent() {
-                // Strip link reference definitions before deciding on setext conversion.
-                let consumed = self.extract_link_ref_defs();
-                if consumed > 0 {
-                    let drain_count = consumed.min(self.paragraph_lines.len());
-                    self.paragraph_lines.drain(0..drain_count);
-                }
-                if self.paragraph_lines.is_empty() {
-                    // No paragraph content left after stripping definitions; not a setext heading.
-                    // Treat this line as normal paragraph content.
-                    let line_start = self.cursor.offset();
-                    self.parse_paragraph_line(line_start, events);
-                    return;
-                } else {
-                    // Skip to end of line
-                    while !self.cursor.is_eof() && !self.cursor.at(b'\n') {
-                        parser_cursor_bump!(self.cursor);
-                    }
-                    if !self.cursor.is_eof() {
-                        parser_cursor_bump!(self.cursor);
-                    }
-                    // Convert paragraph to heading
-                    self.close_paragraph_as_setext_heading(level, events);
-                    return;
-                }
+        if indent < 4
+            && self.in_paragraph
+            && let Some(level) = self.is_setext_underline_after_indent()
+        {
+            // Strip link reference definitions before deciding on setext conversion.
+            let consumed = self.extract_link_ref_defs();
+            if consumed > 0 {
+                let drain_count = consumed.min(self.paragraph_lines.len());
+                self.paragraph_lines.drain(0..drain_count);
             }
+            if self.paragraph_lines.is_empty() {
+                // No paragraph content left after stripping definitions; not a setext heading.
+                // Treat this line as normal paragraph content.
+                let line_start = self.cursor.offset();
+                self.parse_paragraph_line(line_start, events);
+                return;
+            } else {
+                // Skip to end of line
+                while !self.cursor.is_eof() && !self.cursor.at(b'\n') {
+                    parser_cursor_bump!(self.cursor);
+                }
+                if !self.cursor.is_eof() {
+                    parser_cursor_bump!(self.cursor);
+                }
+                // Convert paragraph to heading
+                self.close_paragraph_as_setext_heading(level, events);
+                return;
+            }
+        }
 
         // Check for GFM table delimiter row at top level (when in a paragraph)
         // Quick guard: delimiter rows start with |, -, or :
@@ -624,24 +626,25 @@ impl<'a> BlockParser<'a> {
             let line = &self.input[save_pos..line_end];
 
             if let Some(alignments) = Self::is_delimiter_row(line)
-                && !self.paragraph_lines.is_empty() {
-                    let last_para_line = self.paragraph_lines.last().unwrap();
-                    let header_line = last_para_line.slice(self.input);
-                    let header_cells = self.table_cells(header_line);
+                && !self.paragraph_lines.is_empty()
+            {
+                let last_para_line = self.paragraph_lines.last().unwrap();
+                let header_line = last_para_line.slice(self.input);
+                let header_cells = self.table_cells(header_line);
 
-                    if Self::table_width(&header_cells) == alignments.len() {
-                        let dash_counts = self
-                            .options
-                            .table_column_widths
-                            .then(|| Self::delimiter_dash_counts(line));
-                        self.cursor = Cursor::new_at(self.input, line_end);
-                        if !self.cursor.is_eof() && self.cursor.at(b'\n') {
-                            parser_cursor_bump!(self.cursor);
-                        }
-                        self.start_table(header_cells, alignments, dash_counts, events);
-                        return;
+                if Self::table_width(&header_cells) == alignments.len() {
+                    let dash_counts = self
+                        .options
+                        .table_column_widths
+                        .then(|| Self::delimiter_dash_counts(line));
+                    self.cursor = Cursor::new_at(self.input, line_end);
+                    if !self.cursor.is_eof() && self.cursor.at(b'\n') {
+                        parser_cursor_bump!(self.cursor);
                     }
+                    self.start_table(header_cells, alignments, dash_counts, events);
+                    return;
                 }
+            }
 
             self.cursor = Cursor::new_at(self.input, save_pos);
             self.partial_tab_cols = save_partial;
@@ -958,19 +961,21 @@ impl<'a> BlockParser<'a> {
 
             // Check for setext heading underline (when in a paragraph)
             // Must check BEFORE thematic break since `---` can be either
-            if self.in_paragraph && matches!(first, b'=' | b'-')
-                && let Some(level) = self.is_setext_underline_after_indent() {
-                    // Skip to end of line
-                    while !self.cursor.is_eof() && !self.cursor.at(b'\n') {
-                        parser_cursor_bump!(self.cursor);
-                    }
-                    if !self.cursor.is_eof() {
-                        parser_cursor_bump!(self.cursor);
-                    }
-                    // Convert paragraph to heading
-                    self.close_paragraph_as_setext_heading(level, events);
-                    return;
+            if self.in_paragraph
+                && matches!(first, b'=' | b'-')
+                && let Some(level) = self.is_setext_underline_after_indent()
+            {
+                // Skip to end of line
+                while !self.cursor.is_eof() && !self.cursor.at(b'\n') {
+                    parser_cursor_bump!(self.cursor);
                 }
+                if !self.cursor.is_eof() {
+                    parser_cursor_bump!(self.cursor);
+                }
+                // Convert paragraph to heading
+                self.close_paragraph_as_setext_heading(level, events);
+                return;
+            }
 
             if self.options.definition_lists
                 && first == b':'
@@ -1248,9 +1253,10 @@ impl<'a> BlockParser<'a> {
         // This ensures the blank only affects the innermost level that actually continues.
         if let Some(list_idx) = deepest_list_match {
             if let Some(open_list) = self.open_lists.get_mut(list_idx)
-                && open_list.blank_in_item {
-                    open_list.tight = false;
-                }
+                && open_list.blank_in_item
+            {
+                open_list.tight = false;
+            }
             // Clear blank_in_item for all outer lists - the blank was "consumed" by the deeper level
             for outer_list in self.open_lists[..list_idx].iter_mut() {
                 outer_list.blank_in_item = false;
@@ -1455,29 +1461,31 @@ impl<'a> BlockParser<'a> {
             let is_last_to_close = self.container_stack.len() == from + 1;
             let can_start_new_item = indent < 4;
 
-            if is_last_to_close && can_start_new_item
-                && let ContainerType::ListItem { kind, marker, .. } = top.typ {
-                    // Check if the current position has a same-type list marker
-                    let save_pos = self.cursor.offset();
-                    let save_partial = self.partial_tab_cols;
-                    let save_col = self.current_col;
-                    self.skip_indent();
-                    let is_same_list = self.peek_list_marker(kind, marker);
-                    self.cursor = Cursor::new_at(self.input, save_pos);
-                    self.partial_tab_cols = save_partial;
-                    self.current_col = save_col;
+            if is_last_to_close
+                && can_start_new_item
+                && let ContainerType::ListItem { kind, marker, .. } = top.typ
+            {
+                // Check if the current position has a same-type list marker
+                let save_pos = self.cursor.offset();
+                let save_partial = self.partial_tab_cols;
+                let save_col = self.current_col;
+                self.skip_indent();
+                let is_same_list = self.peek_list_marker(kind, marker);
+                self.cursor = Cursor::new_at(self.input, save_pos);
+                self.partial_tab_cols = save_partial;
+                self.current_col = save_col;
 
-                    if is_same_list {
-                        // Just close the item, not the list
-                        let enclosing_depth = self.container_stack.len() - 1;
-                        self.close_definition_lists_deeper_than(enclosing_depth, events);
-                        self.container_stack.pop();
-                        self.close_paragraph(events);
-                        events.push(BlockEvent::ListItemEnd);
-                        // Don't pop from open_lists
-                        continue;
-                    }
+                if is_same_list {
+                    // Just close the item, not the list
+                    let enclosing_depth = self.container_stack.len() - 1;
+                    self.close_definition_lists_deeper_than(enclosing_depth, events);
+                    self.container_stack.pop();
+                    self.close_paragraph(events);
+                    events.push(BlockEvent::ListItemEnd);
+                    // Don't pop from open_lists
+                    continue;
                 }
+            }
 
             self.close_top_container(events);
         }
@@ -1508,19 +1516,20 @@ impl<'a> BlockParser<'a> {
         // But keep the list open - only close the item.
         if let Some(container) = self.container_stack.last()
             && let ContainerType::ListItem { .. } = container.typ
-                && !container.has_content {
-                    // This is the second blank line (first was the blank item itself)
-                    // Close just the list item, not the list
-                    self.container_stack.pop();
-                    self.close_paragraph(events);
-                    events.push(BlockEvent::ListItemEnd);
-                    // Mark blank_in_item for the list - the blank line is between items,
-                    // which will make the list loose when the next item starts.
-                    if let Some(open_list) = self.open_lists.last_mut() {
-                        open_list.blank_in_item = true;
-                    }
-                    return; // Already handled blank marking for this case
-                }
+            && !container.has_content
+        {
+            // This is the second blank line (first was the blank item itself)
+            // Close just the list item, not the list
+            self.container_stack.pop();
+            self.close_paragraph(events);
+            events.push(BlockEvent::ListItemEnd);
+            // Mark blank_in_item for the list - the blank line is between items,
+            // which will make the list loose when the next item starts.
+            if let Some(open_list) = self.open_lists.last_mut() {
+                open_list.blank_in_item = true;
+            }
+            return; // Already handled blank marking for this case
+        }
 
         // Mark all lists with an active item as having seen a blank line.
         // We don't know yet which level the blank is at - that's determined
@@ -1531,10 +1540,11 @@ impl<'a> BlockParser<'a> {
         // not directly in the list item, so don't mark the list.
         if !close_blockquotes
             && let Some(container) = self.container_stack.last()
-                && container.typ == ContainerType::BlockQuote {
-                    // The blank is inside a blockquote, not between list item blocks
-                    return;
-                }
+            && container.typ == ContainerType::BlockQuote
+        {
+            // The blank is inside a blockquote, not between list item blocks
+            return;
+        }
 
         let active_list_count = self
             .container_stack
@@ -2540,18 +2550,21 @@ impl<'a> BlockParser<'a> {
 
         // Type 6: block tags
         if let Some((name, tag_end)) = self.parse_html_tag_name(line)
-            && self.is_block_tag(name) && self.tag_boundary(line, tag_end) {
-                return Some(HtmlBlockKind::Type6);
-            }
+            && self.is_block_tag(name)
+            && self.tag_boundary(line, tag_end)
+        {
+            return Some(HtmlBlockKind::Type6);
+        }
 
         // Type 7: any other HTML tag (cannot interrupt a paragraph)
         if in_paragraph {
             return None;
         }
         if let Some((_name, tag_end)) = self.parse_html_tag(line)
-            && line[tag_end..].iter().all(|&b| Self::is_html_whitespace(b)) {
-                return Some(HtmlBlockKind::Type7);
-            }
+            && line[tag_end..].iter().all(|&b| Self::is_html_whitespace(b))
+        {
+            return Some(HtmlBlockKind::Type7);
+        }
 
         None
     }
@@ -3754,19 +3767,19 @@ impl<'a> BlockParser<'a> {
             self.pending_definition_term = None;
         } else if let Some(pending) = self.pending_definition_term
             && pending.outer_depth == outer_depth
-                && matches!(
-                    events.get(pending.event_start),
-                    Some(BlockEvent::ParagraphStart)
-                )
-                && matches!(events.last(), Some(BlockEvent::ParagraphEnd))
-            {
-                for event in events.drain(pending.event_start..) {
-                    if let BlockEvent::Text(range) = event {
-                        terms.push(range);
-                    }
+            && matches!(
+                events.get(pending.event_start),
+                Some(BlockEvent::ParagraphStart)
+            )
+            && matches!(events.last(), Some(BlockEvent::ParagraphEnd))
+        {
+            for event in events.drain(pending.event_start..) {
+                if let BlockEvent::Text(range) = event {
+                    terms.push(range);
                 }
-                self.pending_definition_term = None;
             }
+            self.pending_definition_term = None;
+        }
 
         if terms.is_empty() && !waiting_list {
             return false;

--- a/src/block/parser.rs
+++ b/src/block/parser.rs
@@ -575,8 +575,8 @@ impl<'a> BlockParser<'a> {
         // Check for setext heading underline (when in a paragraph)
         // Must check BEFORE thematic break since `---` can be either
         // Note: indent must be < 4 for a valid setext underline
-        if indent < 4 && self.in_paragraph {
-            if let Some(level) = self.is_setext_underline_after_indent() {
+        if indent < 4 && self.in_paragraph
+            && let Some(level) = self.is_setext_underline_after_indent() {
                 // Strip link reference definitions before deciding on setext conversion.
                 let consumed = self.extract_link_ref_defs();
                 if consumed > 0 {
@@ -602,7 +602,6 @@ impl<'a> BlockParser<'a> {
                     return;
                 }
             }
-        }
 
         // Check for GFM table delimiter row at top level (when in a paragraph)
         // Quick guard: delimiter rows start with |, -, or :
@@ -624,8 +623,8 @@ impl<'a> BlockParser<'a> {
             };
             let line = &self.input[save_pos..line_end];
 
-            if let Some(alignments) = Self::is_delimiter_row(line) {
-                if !self.paragraph_lines.is_empty() {
+            if let Some(alignments) = Self::is_delimiter_row(line)
+                && !self.paragraph_lines.is_empty() {
                     let last_para_line = self.paragraph_lines.last().unwrap();
                     let header_line = last_para_line.slice(self.input);
                     let header_cells = self.table_cells(header_line);
@@ -643,7 +642,6 @@ impl<'a> BlockParser<'a> {
                         return;
                     }
                 }
-            }
 
             self.cursor = Cursor::new_at(self.input, save_pos);
             self.partial_tab_cols = save_partial;
@@ -960,8 +958,8 @@ impl<'a> BlockParser<'a> {
 
             // Check for setext heading underline (when in a paragraph)
             // Must check BEFORE thematic break since `---` can be either
-            if self.in_paragraph && matches!(first, b'=' | b'-') {
-                if let Some(level) = self.is_setext_underline_after_indent() {
+            if self.in_paragraph && matches!(first, b'=' | b'-')
+                && let Some(level) = self.is_setext_underline_after_indent() {
                     // Skip to end of line
                     while !self.cursor.is_eof() && !self.cursor.at(b'\n') {
                         parser_cursor_bump!(self.cursor);
@@ -973,7 +971,6 @@ impl<'a> BlockParser<'a> {
                     self.close_paragraph_as_setext_heading(level, events);
                     return;
                 }
-            }
 
             if self.options.definition_lists
                 && first == b':'
@@ -1094,7 +1091,7 @@ impl<'a> BlockParser<'a> {
 
     /// Try to match existing containers at line start.
     /// Returns number of matched containers.
-    fn match_containers(&mut self, _events: &mut Vec<BlockEvent>) -> usize {
+    fn match_containers(&mut self, _events: &mut [BlockEvent]) -> usize {
         if self.container_stack.is_empty() {
             return 0;
         }
@@ -1250,11 +1247,10 @@ impl<'a> BlockParser<'a> {
         // After matching, mark the deepest matched list as loose if it had a blank line.
         // This ensures the blank only affects the innermost level that actually continues.
         if let Some(list_idx) = deepest_list_match {
-            if let Some(open_list) = self.open_lists.get_mut(list_idx) {
-                if open_list.blank_in_item {
+            if let Some(open_list) = self.open_lists.get_mut(list_idx)
+                && open_list.blank_in_item {
                     open_list.tight = false;
                 }
-            }
             // Clear blank_in_item for all outer lists - the blank was "consumed" by the deeper level
             for outer_list in self.open_lists[..list_idx].iter_mut() {
                 outer_list.blank_in_item = false;
@@ -1459,8 +1455,8 @@ impl<'a> BlockParser<'a> {
             let is_last_to_close = self.container_stack.len() == from + 1;
             let can_start_new_item = indent < 4;
 
-            if is_last_to_close && can_start_new_item {
-                if let ContainerType::ListItem { kind, marker, .. } = top.typ {
+            if is_last_to_close && can_start_new_item
+                && let ContainerType::ListItem { kind, marker, .. } = top.typ {
                     // Check if the current position has a same-type list marker
                     let save_pos = self.cursor.offset();
                     let save_partial = self.partial_tab_cols;
@@ -1482,7 +1478,6 @@ impl<'a> BlockParser<'a> {
                         continue;
                     }
                 }
-            }
 
             self.close_top_container(events);
         }
@@ -1511,9 +1506,9 @@ impl<'a> BlockParser<'a> {
         // Two-blank-line rule: a list item can begin with at most one blank line.
         // If the innermost list item has no content and we see a blank line, close it.
         // But keep the list open - only close the item.
-        if let Some(container) = self.container_stack.last() {
-            if let ContainerType::ListItem { .. } = container.typ {
-                if !container.has_content {
+        if let Some(container) = self.container_stack.last()
+            && let ContainerType::ListItem { .. } = container.typ
+                && !container.has_content {
                     // This is the second blank line (first was the blank item itself)
                     // Close just the list item, not the list
                     self.container_stack.pop();
@@ -1526,8 +1521,6 @@ impl<'a> BlockParser<'a> {
                     }
                     return; // Already handled blank marking for this case
                 }
-            }
-        }
 
         // Mark all lists with an active item as having seen a blank line.
         // We don't know yet which level the blank is at - that's determined
@@ -1536,14 +1529,12 @@ impl<'a> BlockParser<'a> {
         // BUT: If close_blockquotes is false, the line had container markers (like `>`).
         // If there's a blockquote on the stack, the blank is inside the blockquote,
         // not directly in the list item, so don't mark the list.
-        if !close_blockquotes {
-            if let Some(container) = self.container_stack.last() {
-                if container.typ == ContainerType::BlockQuote {
+        if !close_blockquotes
+            && let Some(container) = self.container_stack.last()
+                && container.typ == ContainerType::BlockQuote {
                     // The blank is inside a blockquote, not between list item blocks
                     return;
                 }
-            }
-        }
 
         let active_list_count = self
             .container_stack
@@ -2548,21 +2539,19 @@ impl<'a> BlockParser<'a> {
         }
 
         // Type 6: block tags
-        if let Some((name, tag_end)) = self.parse_html_tag_name(line) {
-            if self.is_block_tag(name) && self.tag_boundary(line, tag_end) {
+        if let Some((name, tag_end)) = self.parse_html_tag_name(line)
+            && self.is_block_tag(name) && self.tag_boundary(line, tag_end) {
                 return Some(HtmlBlockKind::Type6);
             }
-        }
 
         // Type 7: any other HTML tag (cannot interrupt a paragraph)
         if in_paragraph {
             return None;
         }
-        if let Some((_name, tag_end)) = self.parse_html_tag(line) {
-            if line[tag_end..].iter().all(|&b| Self::is_html_whitespace(b)) {
+        if let Some((_name, tag_end)) = self.parse_html_tag(line)
+            && line[tag_end..].iter().all(|&b| Self::is_html_whitespace(b)) {
                 return Some(HtmlBlockKind::Type7);
             }
-        }
 
         None
     }
@@ -3763,8 +3752,8 @@ impl<'a> BlockParser<'a> {
             self.in_paragraph = false;
             terms.append(&mut self.paragraph_lines);
             self.pending_definition_term = None;
-        } else if let Some(pending) = self.pending_definition_term {
-            if pending.outer_depth == outer_depth
+        } else if let Some(pending) = self.pending_definition_term
+            && pending.outer_depth == outer_depth
                 && matches!(
                     events.get(pending.event_start),
                     Some(BlockEvent::ParagraphStart)
@@ -3778,7 +3767,6 @@ impl<'a> BlockParser<'a> {
                 }
                 self.pending_definition_term = None;
             }
-        }
 
         if terms.is_empty() && !waiting_list {
             return false;

--- a/src/inline/links.rs
+++ b/src/inline/links.rs
@@ -338,9 +338,10 @@ fn contains_ref_link_candidate(
 
         if let Some((ref_start, ref_end, _ref_close)) =
             parse_ref_label_immediate(text, close_pos as usize + 1)
-            && ref_start != ref_end {
-                label_bytes = &text[ref_start..ref_end];
-            }
+            && ref_start != ref_end
+        {
+            label_bytes = &text[ref_start..ref_end];
+        }
 
         normalize_label_into(label_bytes, label_buf);
         if label_buf.is_empty() {
@@ -697,24 +698,26 @@ fn is_uri_autolink(content: &[u8]) -> bool {
 fn is_email_autolink(content: &[u8]) -> bool {
     // Simple check: must contain @ with text before and after
     if let Some(at_pos) = content.iter().position(|&b| b == b'@')
-        && at_pos > 0 && at_pos < content.len() - 1 {
-            // Check for valid email characters
-            let local = &content[..at_pos];
-            let domain = &content[at_pos + 1..];
+        && at_pos > 0
+        && at_pos < content.len() - 1
+    {
+        // Check for valid email characters
+        let local = &content[..at_pos];
+        let domain = &content[at_pos + 1..];
 
-            // Local part: alphanumeric and some special chars
-            let local_valid = local.iter().all(|&b| {
-                b.is_ascii_alphanumeric() || b == b'.' || b == b'-' || b == b'_' || b == b'+'
-            });
+        // Local part: alphanumeric and some special chars
+        let local_valid = local.iter().all(|&b| {
+            b.is_ascii_alphanumeric() || b == b'.' || b == b'-' || b == b'_' || b == b'+'
+        });
 
-            // Domain: alphanumeric, dots, hyphens
-            let domain_valid = domain
-                .iter()
-                .all(|&b| b.is_ascii_alphanumeric() || b == b'.' || b == b'-')
-                && domain.contains(&b'.');
+        // Domain: alphanumeric, dots, hyphens
+        let domain_valid = domain
+            .iter()
+            .all(|&b| b.is_ascii_alphanumeric() || b == b'.' || b == b'-')
+            && domain.contains(&b'.');
 
-            return local_valid && domain_valid;
-        }
+        return local_valid && domain_valid;
+    }
     false
 }
 
@@ -769,15 +772,15 @@ pub fn find_autolink_literals_into(
                     && !in_any_range(at_pos as u32, autolink_ranges)
                     && !in_any_range(at_pos as u32, link_ranges)
                     && let Some(al) = try_email_autolink(text, at_pos)
-                        && !overlaps_any_range(al.start, al.end, code_spans)
-                            && !overlaps_any_range(al.start, al.end, html_ranges)
-                            && !overlaps_any_range(al.start, al.end, autolink_ranges)
-                            && !overlaps_any_range(al.start, al.end, link_ranges)
-                        {
-                            pos = al.end as usize;
-                            out.push(al);
-                            continue;
-                        }
+                    && !overlaps_any_range(al.start, al.end, code_spans)
+                    && !overlaps_any_range(al.start, al.end, html_ranges)
+                    && !overlaps_any_range(al.start, al.end, autolink_ranges)
+                    && !overlaps_any_range(al.start, al.end, link_ranges)
+                {
+                    pos = al.end as usize;
+                    out.push(al);
+                    continue;
+                }
                 pos = at_pos + 1;
             } else {
                 break;
@@ -801,20 +804,20 @@ pub fn find_autolink_literals_into(
                     let proto_start = find_protocol_start(text, colon);
                     if let Some(start) = proto_start
                         && !in_any_range(start as u32, code_spans)
-                            && !in_any_range(start as u32, html_ranges)
-                            && !in_any_range(start as u32, autolink_ranges)
-                            && !in_any_range(start as u32, link_ranges)
-                            && is_valid_autolink_preceding(text, start)
-                            && let Some(al) = try_url_autolink(text, start)
-                                && !overlaps_any_range(al.start, al.end, code_spans)
-                                    && !overlaps_any_range(al.start, al.end, html_ranges)
-                                    && !overlaps_any_range(al.start, al.end, autolink_ranges)
-                                    && !overlaps_any_range(al.start, al.end, link_ranges)
-                                {
-                                    pos = al.end as usize;
-                                    out.push(al);
-                                    continue;
-                                }
+                        && !in_any_range(start as u32, html_ranges)
+                        && !in_any_range(start as u32, autolink_ranges)
+                        && !in_any_range(start as u32, link_ranges)
+                        && is_valid_autolink_preceding(text, start)
+                        && let Some(al) = try_url_autolink(text, start)
+                        && !overlaps_any_range(al.start, al.end, code_spans)
+                        && !overlaps_any_range(al.start, al.end, html_ranges)
+                        && !overlaps_any_range(al.start, al.end, autolink_ranges)
+                        && !overlaps_any_range(al.start, al.end, link_ranges)
+                    {
+                        pos = al.end as usize;
+                        out.push(al);
+                        continue;
+                    }
                 }
                 pos = colon + 1;
             } else {
@@ -841,15 +844,15 @@ pub fn find_autolink_literals_into(
                         && !in_any_range(start as u32, autolink_ranges)
                         && !in_any_range(start as u32, link_ranges)
                         && let Some(al) = try_www_autolink(text, start)
-                            && !overlaps_any_range(al.start, al.end, code_spans)
-                                && !overlaps_any_range(al.start, al.end, html_ranges)
-                                && !overlaps_any_range(al.start, al.end, autolink_ranges)
-                                && !overlaps_any_range(al.start, al.end, link_ranges)
-                            {
-                                pos = al.end as usize;
-                                out.push(al);
-                                continue;
-                            }
+                        && !overlaps_any_range(al.start, al.end, code_spans)
+                        && !overlaps_any_range(al.start, al.end, html_ranges)
+                        && !overlaps_any_range(al.start, al.end, autolink_ranges)
+                        && !overlaps_any_range(al.start, al.end, link_ranges)
+                    {
+                        pos = al.end as usize;
+                        out.push(al);
+                        continue;
+                    }
                 }
                 pos = dot + 1;
             } else {
@@ -1123,10 +1126,11 @@ fn trim_autolink_trailing(text: &[u8], start: usize, mut end: usize) -> usize {
 
         // Rule 3: Entity check - if ends with `;` preceded by `&<alphanum>+`
         if last == b';'
-            && let Some(new_end) = trim_trailing_entity(text, start, end) {
-                end = new_end;
-                continue;
-            }
+            && let Some(new_end) = trim_trailing_entity(text, start, end)
+        {
+            end = new_end;
+            continue;
+        }
 
         break;
     }

--- a/src/inline/links.rs
+++ b/src/inline/links.rs
@@ -338,11 +338,9 @@ fn contains_ref_link_candidate(
 
         if let Some((ref_start, ref_end, _ref_close)) =
             parse_ref_label_immediate(text, close_pos as usize + 1)
-        {
-            if ref_start != ref_end {
+            && ref_start != ref_end {
                 label_bytes = &text[ref_start..ref_end];
             }
-        }
 
         normalize_label_into(label_bytes, label_buf);
         if label_buf.is_empty() {
@@ -698,8 +696,8 @@ fn is_uri_autolink(content: &[u8]) -> bool {
 /// Check if content is a valid email autolink.
 fn is_email_autolink(content: &[u8]) -> bool {
     // Simple check: must contain @ with text before and after
-    if let Some(at_pos) = content.iter().position(|&b| b == b'@') {
-        if at_pos > 0 && at_pos < content.len() - 1 {
+    if let Some(at_pos) = content.iter().position(|&b| b == b'@')
+        && at_pos > 0 && at_pos < content.len() - 1 {
             // Check for valid email characters
             let local = &content[..at_pos];
             let domain = &content[at_pos + 1..];
@@ -717,7 +715,6 @@ fn is_email_autolink(content: &[u8]) -> bool {
 
             return local_valid && domain_valid;
         }
-    }
     false
 }
 
@@ -771,9 +768,8 @@ pub fn find_autolink_literals_into(
                     && !in_any_range(at_pos as u32, html_ranges)
                     && !in_any_range(at_pos as u32, autolink_ranges)
                     && !in_any_range(at_pos as u32, link_ranges)
-                {
-                    if let Some(al) = try_email_autolink(text, at_pos) {
-                        if !overlaps_any_range(al.start, al.end, code_spans)
+                    && let Some(al) = try_email_autolink(text, at_pos)
+                        && !overlaps_any_range(al.start, al.end, code_spans)
                             && !overlaps_any_range(al.start, al.end, html_ranges)
                             && !overlaps_any_range(al.start, al.end, autolink_ranges)
                             && !overlaps_any_range(al.start, al.end, link_ranges)
@@ -782,8 +778,6 @@ pub fn find_autolink_literals_into(
                             out.push(al);
                             continue;
                         }
-                    }
-                }
                 pos = at_pos + 1;
             } else {
                 break;
@@ -805,15 +799,14 @@ pub fn find_autolink_literals_into(
                 {
                     // Walk backwards to find protocol start (http, https, ftp)
                     let proto_start = find_protocol_start(text, colon);
-                    if let Some(start) = proto_start {
-                        if !in_any_range(start as u32, code_spans)
+                    if let Some(start) = proto_start
+                        && !in_any_range(start as u32, code_spans)
                             && !in_any_range(start as u32, html_ranges)
                             && !in_any_range(start as u32, autolink_ranges)
                             && !in_any_range(start as u32, link_ranges)
                             && is_valid_autolink_preceding(text, start)
-                        {
-                            if let Some(al) = try_url_autolink(text, start) {
-                                if !overlaps_any_range(al.start, al.end, code_spans)
+                            && let Some(al) = try_url_autolink(text, start)
+                                && !overlaps_any_range(al.start, al.end, code_spans)
                                     && !overlaps_any_range(al.start, al.end, html_ranges)
                                     && !overlaps_any_range(al.start, al.end, autolink_ranges)
                                     && !overlaps_any_range(al.start, al.end, link_ranges)
@@ -822,9 +815,6 @@ pub fn find_autolink_literals_into(
                                     out.push(al);
                                     continue;
                                 }
-                            }
-                        }
-                    }
                 }
                 pos = colon + 1;
             } else {
@@ -850,9 +840,8 @@ pub fn find_autolink_literals_into(
                         && !in_any_range(start as u32, html_ranges)
                         && !in_any_range(start as u32, autolink_ranges)
                         && !in_any_range(start as u32, link_ranges)
-                    {
-                        if let Some(al) = try_www_autolink(text, start) {
-                            if !overlaps_any_range(al.start, al.end, code_spans)
+                        && let Some(al) = try_www_autolink(text, start)
+                            && !overlaps_any_range(al.start, al.end, code_spans)
                                 && !overlaps_any_range(al.start, al.end, html_ranges)
                                 && !overlaps_any_range(al.start, al.end, autolink_ranges)
                                 && !overlaps_any_range(al.start, al.end, link_ranges)
@@ -861,8 +850,6 @@ pub fn find_autolink_literals_into(
                                 out.push(al);
                                 continue;
                             }
-                        }
-                    }
                 }
                 pos = dot + 1;
             } else {
@@ -1135,12 +1122,11 @@ fn trim_autolink_trailing(text: &[u8], start: usize, mut end: usize) -> usize {
         }
 
         // Rule 3: Entity check - if ends with `;` preceded by `&<alphanum>+`
-        if last == b';' {
-            if let Some(new_end) = trim_trailing_entity(text, start, end) {
+        if last == b';'
+            && let Some(new_end) = trim_trailing_entity(text, start, end) {
                 end = new_end;
                 continue;
             }
-        }
 
         break;
     }

--- a/src/inline/marks.rs
+++ b/src/inline/marks.rs
@@ -499,16 +499,14 @@ fn next_special<const HIGHLIGHT: bool, const SUPERSCRIPT: bool>(
     if let Some(i) = memchr::memchr(b'$', slice) {
         best = Some(best.map_or(i, |b| b.min(i)));
     }
-    if SUPERSCRIPT {
-        if let Some(i) = memchr::memchr(b'^', slice) {
+    if SUPERSCRIPT
+        && let Some(i) = memchr::memchr(b'^', slice) {
             best = Some(best.map_or(i, |b| b.min(i)));
         }
-    }
-    if HIGHLIGHT {
-        if let Some(i) = memchr::memchr(b'=', slice) {
+    if HIGHLIGHT
+        && let Some(i) = memchr::memchr(b'=', slice) {
             best = Some(best.map_or(i, |b| b.min(i)));
         }
-    }
 
     best.map(|i| pos + i)
 }

--- a/src/inline/marks.rs
+++ b/src/inline/marks.rs
@@ -499,14 +499,12 @@ fn next_special<const HIGHLIGHT: bool, const SUPERSCRIPT: bool>(
     if let Some(i) = memchr::memchr(b'$', slice) {
         best = Some(best.map_or(i, |b| b.min(i)));
     }
-    if SUPERSCRIPT
-        && let Some(i) = memchr::memchr(b'^', slice) {
-            best = Some(best.map_or(i, |b| b.min(i)));
-        }
-    if HIGHLIGHT
-        && let Some(i) = memchr::memchr(b'=', slice) {
-            best = Some(best.map_or(i, |b| b.min(i)));
-        }
+    if SUPERSCRIPT && let Some(i) = memchr::memchr(b'^', slice) {
+        best = Some(best.map_or(i, |b| b.min(i)));
+    }
+    if HIGHLIGHT && let Some(i) = memchr::memchr(b'=', slice) {
+        best = Some(best.map_or(i, |b| b.min(i)));
+    }
 
     best.map(|i| pos + i)
 }

--- a/src/inline/mod.rs
+++ b/src/inline/mod.rs
@@ -675,10 +675,12 @@ impl InlineParser {
                 code_span_index += 1;
             }
             if let Some(span) = code_spans.get(code_span_index)
-                && pos as u32 >= span.opener_pos && (pos as u32) < span.closer_end {
-                    pos = span.closer_end as usize;
-                    continue;
-                }
+                && pos as u32 >= span.opener_pos
+                && (pos as u32) < span.closer_end
+            {
+                pos = span.closer_end as usize;
+                continue;
+            }
 
             let bracket_mark = matches!(text[pos], b'[' | b']')
                 .then(|| {
@@ -2254,15 +2256,16 @@ mod tests {
         let mut found = false;
         for event in events {
             if let InlineEvent::Html(range) = event
-                && range.start == 0 {
-                    let slice = range.slice(input.as_bytes());
-                    assert!(
-                        slice.starts_with(b"<a "),
-                        "Expected HTML span to start at <a>"
-                    );
-                    found = true;
-                    break;
-                }
+                && range.start == 0
+            {
+                let slice = range.slice(input.as_bytes());
+                assert!(
+                    slice.starts_with(b"<a "),
+                    "Expected HTML span to start at <a>"
+                );
+                found = true;
+                break;
+            }
         }
         assert!(found, "Expected raw HTML tag to be parsed at start");
     }

--- a/src/inline/mod.rs
+++ b/src/inline/mod.rs
@@ -674,12 +674,11 @@ impl InlineParser {
             {
                 code_span_index += 1;
             }
-            if let Some(span) = code_spans.get(code_span_index) {
-                if pos as u32 >= span.opener_pos && (pos as u32) < span.closer_end {
+            if let Some(span) = code_spans.get(code_span_index)
+                && pos as u32 >= span.opener_pos && (pos as u32) < span.closer_end {
                     pos = span.closer_end as usize;
                     continue;
                 }
-            }
 
             let bracket_mark = matches!(text[pos], b'[' | b']')
                 .then(|| {
@@ -2254,8 +2253,8 @@ mod tests {
         let events = parse_inline(input);
         let mut found = false;
         for event in events {
-            if let InlineEvent::Html(range) = event {
-                if range.start == 0 {
+            if let InlineEvent::Html(range) = event
+                && range.start == 0 {
                     let slice = range.slice(input.as_bytes());
                     assert!(
                         slice.starts_with(b"<a "),
@@ -2264,7 +2263,6 @@ mod tests {
                     found = true;
                     break;
                 }
-            }
         }
         assert!(found, "Expected raw HTML tag to be parsed at start");
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1922,18 +1922,17 @@ fn render_inline_event(
             }
         }
         InlineEvent::LinkStartRef { def_index } => {
-            if !in_image
-                && let Some(def) = link_refs.get(*def_index as usize) {
-                    writer.write_str("<a href=\"");
-                    writer.write_link_url_with_policy_and_base(&def.url, render_policy, link_base);
+            if !in_image && let Some(def) = link_refs.get(*def_index as usize) {
+                writer.write_str("<a href=\"");
+                writer.write_link_url_with_policy_and_base(&def.url, render_policy, link_base);
+                writer.write_str("\"");
+                if let Some(title) = &def.title {
+                    writer.write_str(" title=\"");
+                    writer.write_link_title(title);
                     writer.write_str("\"");
-                    if let Some(title) = &def.title {
-                        writer.write_str(" title=\"");
-                        writer.write_link_title(title);
-                        writer.write_str("\"");
-                    }
-                    writer.write_str(">");
                 }
+                writer.write_str(">");
+            }
         }
         InlineEvent::LinkEnd => {
             if !in_image {
@@ -2073,23 +2072,22 @@ fn render_inline_event(
             }
         }
         InlineEvent::FootnoteRef { def_index } => {
-            if !in_image
-                && let Some(fn_store) = footnote_store {
-                    let def_idx = *def_index as usize;
-                    if let (Some(number), Some(def)) = (
-                        footnote_numbers.number_reference(def_idx),
-                        fn_store.get(def_idx),
-                    ) {
-                        writer.write_str("<sup><a href=\"#user-content-fn-");
-                        writer.write_string(&def.label);
-                        writer.write_str("\" id=\"user-content-fnref-");
-                        writer.write_string(&def.label);
-                        writer.write_str("\" data-footnote-ref>");
-                        let num_str = number.to_string();
-                        writer.write_string(&num_str);
-                        writer.write_str("</a></sup>");
-                    }
+            if !in_image && let Some(fn_store) = footnote_store {
+                let def_idx = *def_index as usize;
+                if let (Some(number), Some(def)) = (
+                    footnote_numbers.number_reference(def_idx),
+                    fn_store.get(def_idx),
+                ) {
+                    writer.write_str("<sup><a href=\"#user-content-fn-");
+                    writer.write_string(&def.label);
+                    writer.write_str("\" id=\"user-content-fnref-");
+                    writer.write_string(&def.label);
+                    writer.write_str("\" data-footnote-ref>");
+                    let num_str = number.to_string();
+                    writer.write_string(&num_str);
+                    writer.write_str("</a></sup>");
                 }
+            }
         }
         InlineEvent::InlineFootnote(range) => {
             if !in_image {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1922,8 +1922,8 @@ fn render_inline_event(
             }
         }
         InlineEvent::LinkStartRef { def_index } => {
-            if !in_image {
-                if let Some(def) = link_refs.get(*def_index as usize) {
+            if !in_image
+                && let Some(def) = link_refs.get(*def_index as usize) {
                     writer.write_str("<a href=\"");
                     writer.write_link_url_with_policy_and_base(&def.url, render_policy, link_base);
                     writer.write_str("\"");
@@ -1934,7 +1934,6 @@ fn render_inline_event(
                     }
                     writer.write_str(">");
                 }
-            }
         }
         InlineEvent::LinkEnd => {
             if !in_image {
@@ -2074,8 +2073,8 @@ fn render_inline_event(
             }
         }
         InlineEvent::FootnoteRef { def_index } => {
-            if !in_image {
-                if let Some(fn_store) = footnote_store {
+            if !in_image
+                && let Some(fn_store) = footnote_store {
                     let def_idx = *def_index as usize;
                     if let (Some(number), Some(def)) = (
                         footnote_numbers.number_reference(def_idx),
@@ -2091,7 +2090,6 @@ fn render_inline_event(
                         writer.write_str("</a></sup>");
                     }
                 }
-            }
         }
         InlineEvent::InlineFootnote(range) => {
             if !in_image {

--- a/src/mdx/splitter.rs
+++ b/src/mdx/splitter.rs
@@ -42,9 +42,9 @@ pub fn split(input: &str) -> Vec<Segment<'_>> {
         }
 
         // 1. Closing tag: `</`
-        if first == b'<' && first_non_ws + 1 < len && bytes[first_non_ws + 1] == b'/' {
-            if let Some(tag_info) = parse_jsx_tag(&bytes[first_non_ws..]) {
-                if tag_info.is_closing {
+        if first == b'<' && first_non_ws + 1 < len && bytes[first_non_ws + 1] == b'/'
+            && let Some(tag_info) = parse_jsx_tag(&bytes[first_non_ws..])
+                && tag_info.is_closing {
                     let end = first_non_ws + tag_info.end_offset;
                     // Flow JSX requires no trailing non-whitespace content on the line
                     if has_trailing_content(bytes, end) {
@@ -53,36 +53,32 @@ pub fn split(input: &str) -> Vec<Segment<'_>> {
                         flush_markdown(input, &mut md_start, line_start, &mut segments);
                         let seg_end = consume_trailing_newline(bytes, end);
                         segments.push(Segment::JsxBlockClose(&input[line_start..seg_end]));
-                        if !tag_info.name.is_empty() {
-                            if let Some(top_pos) =
+                        if !tag_info.name.is_empty()
+                            && let Some(top_pos) =
                                 tag_stack.iter().rposition(|n| n == tag_info.name)
                             {
                                 tag_stack.remove(top_pos);
                             }
-                        }
                         pos = seg_end;
                         in_paragraph = false;
                         continue;
                     }
                 }
-            }
             // Fall through to markdown
-        }
 
         // 2. ESM: `import ` or `export ` at column 0, not interrupting a paragraph
-        if pos == first_non_ws && !in_paragraph {
-            if let Some(esm_end) = try_esm(bytes, pos) {
+        if pos == first_non_ws && !in_paragraph
+            && let Some(esm_end) = try_esm(bytes, pos) {
                 flush_markdown(input, &mut md_start, line_start, &mut segments);
                 segments.push(Segment::Esm(&input[pos..esm_end]));
                 pos = esm_end;
                 in_paragraph = false;
                 continue;
             }
-        }
 
         // 3. Expression: `{` as first non-whitespace
-        if first == b'{' {
-            if let Some(expr_len) = find_expression_end(&bytes[first_non_ws..]) {
+        if first == b'{'
+            && let Some(expr_len) = find_expression_end(&bytes[first_non_ws..]) {
                 let end = first_non_ws + expr_len;
                 // Flow expression requires no trailing non-whitespace content
                 if !has_trailing_content(bytes, end) {
@@ -96,14 +92,12 @@ pub fn split(input: &str) -> Vec<Segment<'_>> {
                 // Trailing content → treat as markdown
             }
             // Unterminated expression → treat as markdown
-        }
 
         // 4. JSX opening/self-closing tag: `<` followed by letter or `>`
         if first == b'<'
             && first_non_ws + 1 < len
             && (bytes[first_non_ws + 1].is_ascii_alphabetic() || bytes[first_non_ws + 1] == b'>')
-        {
-            if let Some(tag_info) = parse_jsx_tag(&bytes[first_non_ws..]) {
+            && let Some(tag_info) = parse_jsx_tag(&bytes[first_non_ws..]) {
                 let end = first_non_ws + tag_info.end_offset;
                 // Flow JSX requires no trailing non-whitespace content on the line
                 if !has_trailing_content(bytes, end) {
@@ -125,7 +119,6 @@ pub fn split(input: &str) -> Vec<Segment<'_>> {
                 // Trailing content → treat as markdown
             }
             // Invalid JSX → fall through to markdown
-        }
 
         // 5. Otherwise → Markdown
         extend_markdown(&mut md_start, line_start);
@@ -134,11 +127,10 @@ pub fn split(input: &str) -> Vec<Segment<'_>> {
     }
 
     // Flush any remaining markdown
-    if let Some(start) = md_start {
-        if start < len {
+    if let Some(start) = md_start
+        && start < len {
             segments.push(Segment::Markdown(&input[start..len]));
         }
-    }
 
     segments
 }
@@ -158,11 +150,10 @@ fn flush_markdown<'a>(
     current_pos: usize,
     segments: &mut Vec<Segment<'a>>,
 ) {
-    if let Some(start) = md_start.take() {
-        if start < current_pos {
+    if let Some(start) = md_start.take()
+        && start < current_pos {
             segments.push(Segment::Markdown(&input[start..current_pos]));
         }
-    }
 }
 
 /// Advance past the current line (past `\n` or to EOF).

--- a/src/mdx/splitter.rs
+++ b/src/mdx/splitter.rs
@@ -42,83 +42,89 @@ pub fn split(input: &str) -> Vec<Segment<'_>> {
         }
 
         // 1. Closing tag: `</`
-        if first == b'<' && first_non_ws + 1 < len && bytes[first_non_ws + 1] == b'/'
+        if first == b'<'
+            && first_non_ws + 1 < len
+            && bytes[first_non_ws + 1] == b'/'
             && let Some(tag_info) = parse_jsx_tag(&bytes[first_non_ws..])
-                && tag_info.is_closing {
-                    let end = first_non_ws + tag_info.end_offset;
-                    // Flow JSX requires no trailing non-whitespace content on the line
-                    if has_trailing_content(bytes, end) {
-                        // Fall through to markdown
-                    } else {
-                        flush_markdown(input, &mut md_start, line_start, &mut segments);
-                        let seg_end = consume_trailing_newline(bytes, end);
-                        segments.push(Segment::JsxBlockClose(&input[line_start..seg_end]));
-                        if !tag_info.name.is_empty()
-                            && let Some(top_pos) =
-                                tag_stack.iter().rposition(|n| n == tag_info.name)
-                            {
-                                tag_stack.remove(top_pos);
-                            }
-                        pos = seg_end;
-                        in_paragraph = false;
-                        continue;
-                    }
-                }
-            // Fall through to markdown
-
-        // 2. ESM: `import ` or `export ` at column 0, not interrupting a paragraph
-        if pos == first_non_ws && !in_paragraph
-            && let Some(esm_end) = try_esm(bytes, pos) {
+            && tag_info.is_closing
+        {
+            let end = first_non_ws + tag_info.end_offset;
+            // Flow JSX requires no trailing non-whitespace content on the line
+            if has_trailing_content(bytes, end) {
+                // Fall through to markdown
+            } else {
                 flush_markdown(input, &mut md_start, line_start, &mut segments);
-                segments.push(Segment::Esm(&input[pos..esm_end]));
-                pos = esm_end;
+                let seg_end = consume_trailing_newline(bytes, end);
+                segments.push(Segment::JsxBlockClose(&input[line_start..seg_end]));
+                if !tag_info.name.is_empty()
+                    && let Some(top_pos) = tag_stack.iter().rposition(|n| n == tag_info.name)
+                {
+                    tag_stack.remove(top_pos);
+                }
+                pos = seg_end;
                 in_paragraph = false;
                 continue;
             }
+        }
+        // Fall through to markdown
+
+        // 2. ESM: `import ` or `export ` at column 0, not interrupting a paragraph
+        if pos == first_non_ws
+            && !in_paragraph
+            && let Some(esm_end) = try_esm(bytes, pos)
+        {
+            flush_markdown(input, &mut md_start, line_start, &mut segments);
+            segments.push(Segment::Esm(&input[pos..esm_end]));
+            pos = esm_end;
+            in_paragraph = false;
+            continue;
+        }
 
         // 3. Expression: `{` as first non-whitespace
         if first == b'{'
-            && let Some(expr_len) = find_expression_end(&bytes[first_non_ws..]) {
-                let end = first_non_ws + expr_len;
-                // Flow expression requires no trailing non-whitespace content
-                if !has_trailing_content(bytes, end) {
-                    flush_markdown(input, &mut md_start, line_start, &mut segments);
-                    let seg_end = consume_trailing_newline(bytes, end);
-                    segments.push(Segment::Expression(&input[line_start..seg_end]));
-                    pos = seg_end;
-                    in_paragraph = false;
-                    continue;
-                }
-                // Trailing content → treat as markdown
+            && let Some(expr_len) = find_expression_end(&bytes[first_non_ws..])
+        {
+            let end = first_non_ws + expr_len;
+            // Flow expression requires no trailing non-whitespace content
+            if !has_trailing_content(bytes, end) {
+                flush_markdown(input, &mut md_start, line_start, &mut segments);
+                let seg_end = consume_trailing_newline(bytes, end);
+                segments.push(Segment::Expression(&input[line_start..seg_end]));
+                pos = seg_end;
+                in_paragraph = false;
+                continue;
             }
-            // Unterminated expression → treat as markdown
+            // Trailing content → treat as markdown
+        }
+        // Unterminated expression → treat as markdown
 
         // 4. JSX opening/self-closing tag: `<` followed by letter or `>`
         if first == b'<'
             && first_non_ws + 1 < len
             && (bytes[first_non_ws + 1].is_ascii_alphabetic() || bytes[first_non_ws + 1] == b'>')
-            && let Some(tag_info) = parse_jsx_tag(&bytes[first_non_ws..]) {
-                let end = first_non_ws + tag_info.end_offset;
-                // Flow JSX requires no trailing non-whitespace content on the line
-                if !has_trailing_content(bytes, end) {
-                    flush_markdown(input, &mut md_start, line_start, &mut segments);
-                    let seg_end = consume_trailing_newline(bytes, end);
-                    let slice = &input[line_start..seg_end];
-                    if tag_info.is_self_closing {
-                        segments.push(Segment::JsxBlockSelfClose(slice));
-                    } else {
-                        if !tag_info.name.is_empty() {
-                            tag_stack.push(tag_info.name.to_string());
-                        }
-                        segments.push(Segment::JsxBlockOpen(slice));
+            && let Some(tag_info) = parse_jsx_tag(&bytes[first_non_ws..])
+        {
+            let end = first_non_ws + tag_info.end_offset;
+            // Flow JSX requires no trailing non-whitespace content on the line
+            if !has_trailing_content(bytes, end) {
+                flush_markdown(input, &mut md_start, line_start, &mut segments);
+                let seg_end = consume_trailing_newline(bytes, end);
+                let slice = &input[line_start..seg_end];
+                if tag_info.is_self_closing {
+                    segments.push(Segment::JsxBlockSelfClose(slice));
+                } else {
+                    if !tag_info.name.is_empty() {
+                        tag_stack.push(tag_info.name.to_string());
                     }
-                    pos = seg_end;
-                    in_paragraph = false;
-                    continue;
+                    segments.push(Segment::JsxBlockOpen(slice));
                 }
-                // Trailing content → treat as markdown
+                pos = seg_end;
+                in_paragraph = false;
+                continue;
             }
-            // Invalid JSX → fall through to markdown
+            // Trailing content → treat as markdown
+        }
+        // Invalid JSX → fall through to markdown
 
         // 5. Otherwise → Markdown
         extend_markdown(&mut md_start, line_start);
@@ -128,9 +134,10 @@ pub fn split(input: &str) -> Vec<Segment<'_>> {
 
     // Flush any remaining markdown
     if let Some(start) = md_start
-        && start < len {
-            segments.push(Segment::Markdown(&input[start..len]));
-        }
+        && start < len
+    {
+        segments.push(Segment::Markdown(&input[start..len]));
+    }
 
     segments
 }
@@ -151,9 +158,10 @@ fn flush_markdown<'a>(
     segments: &mut Vec<Segment<'a>>,
 ) {
     if let Some(start) = md_start.take()
-        && start < current_pos {
-            segments.push(Segment::Markdown(&input[start..current_pos]));
-        }
+        && start < current_pos
+    {
+        segments.push(Segment::Markdown(&input[start..current_pos]));
+    }
 }
 
 /// Advance past the current line (past `\n` or to EOF).

--- a/src/mdx/strict.rs
+++ b/src/mdx/strict.rs
@@ -52,13 +52,12 @@ fn validate(input: &str) -> Vec<MdxDiagnostic> {
             continue;
         }
 
-        if first_non_ws == pos && !in_paragraph {
-            if let Some(esm_end) = try_esm(bytes, pos) {
+        if first_non_ws == pos && !in_paragraph
+            && let Some(esm_end) = try_esm(bytes, pos) {
                 in_paragraph = false;
                 pos = esm_end;
                 continue;
             }
-        }
 
         if is_esm_start(&bytes[first_non_ws..]) {
             diagnostics.push(diagnostic(

--- a/src/mdx/strict.rs
+++ b/src/mdx/strict.rs
@@ -52,12 +52,14 @@ fn validate(input: &str) -> Vec<MdxDiagnostic> {
             continue;
         }
 
-        if first_non_ws == pos && !in_paragraph
-            && let Some(esm_end) = try_esm(bytes, pos) {
-                in_paragraph = false;
-                pos = esm_end;
-                continue;
-            }
+        if first_non_ws == pos
+            && !in_paragraph
+            && let Some(esm_end) = try_esm(bytes, pos)
+        {
+            in_paragraph = false;
+            pos = esm_end;
+            continue;
+        }
 
         if is_esm_start(&bytes[first_non_ws..]) {
             diagnostics.push(diagnostic(

--- a/src/render.rs
+++ b/src/render.rs
@@ -333,8 +333,8 @@ impl HtmlWriter {
         policy: RenderPolicy,
         base: Option<&str>,
     ) {
-        if let Some(base) = base {
-            if url.first() == Some(&b'/')
+        if let Some(base) = base
+            && url.first() == Some(&b'/')
                 && url.get(1) != Some(&b'/')
                 && !Self::has_base_prefix(url, base.as_bytes())
             {
@@ -342,7 +342,6 @@ impl HtmlWriter {
                 // still lands inside an attribute value: escape it.
                 escape::escape_full_into(&mut self.out, base.as_bytes());
             }
-        }
         self.write_link_url_with_policy(url, policy);
     }
 
@@ -768,7 +767,7 @@ impl HtmlWriter {
         if fraction != 0 {
             self.write_byte(b'.');
             self.write_byte(b'0' + (fraction / 10) as u8);
-            if fraction % 10 != 0 {
+            if !fraction.is_multiple_of(10) {
                 self.write_byte(b'0' + (fraction % 10) as u8);
             }
         }

--- a/src/render.rs
+++ b/src/render.rs
@@ -335,13 +335,13 @@ impl HtmlWriter {
     ) {
         if let Some(base) = base
             && url.first() == Some(&b'/')
-                && url.get(1) != Some(&b'/')
-                && !Self::has_base_prefix(url, base.as_bytes())
-            {
-                // The base is configuration, not authored URL text, but it
-                // still lands inside an attribute value: escape it.
-                escape::escape_full_into(&mut self.out, base.as_bytes());
-            }
+            && url.get(1) != Some(&b'/')
+            && !Self::has_base_prefix(url, base.as_bytes())
+        {
+            // The base is configuration, not authored URL text, but it
+            // still lands inside an attribute value: escape it.
+            escape::escape_full_into(&mut self.out, base.as_bytes());
+        }
         self.write_link_url_with_policy(url, policy);
     }
 

--- a/tests/commonmark_spec.rs
+++ b/tests/commonmark_spec.rs
@@ -64,14 +64,15 @@ fn uses_reference_links(markdown: &str) -> bool {
     for line in markdown.lines() {
         let trimmed = line.trim_start();
         if let Some(stripped) = trimmed.strip_prefix('[')
-            && let Some(bracket_end) = stripped.find("]:") {
-                // Found a potential reference definition
-                let label = &stripped[..bracket_end];
-                // Label should not be empty and should not contain unescaped brackets
-                if !label.is_empty() && !has_unescaped_bracket(label) {
-                    return true;
-                }
+            && let Some(bracket_end) = stripped.find("]:")
+        {
+            // Found a potential reference definition
+            let label = &stripped[..bracket_end];
+            // Label should not be empty and should not contain unescaped brackets
+            if !label.is_empty() && !has_unescaped_bracket(label) {
+                return true;
             }
+        }
         // Also check for continuation lines that contain ]: followed by URL/space
         // This catches multi-line reference labels like "[Foo\n  bar]: /url"
         if (trimmed.contains("]: ") || trimmed.contains("]:/") || trimmed.contains("]: <"))

--- a/tests/commonmark_spec.rs
+++ b/tests/commonmark_spec.rs
@@ -63,8 +63,8 @@ fn uses_reference_links(markdown: &str) -> bool {
     // Reference definition pattern: starts with optional spaces, [label]:
     for line in markdown.lines() {
         let trimmed = line.trim_start();
-        if let Some(stripped) = trimmed.strip_prefix('[') {
-            if let Some(bracket_end) = stripped.find("]:") {
+        if let Some(stripped) = trimmed.strip_prefix('[')
+            && let Some(bracket_end) = stripped.find("]:") {
                 // Found a potential reference definition
                 let label = &stripped[..bracket_end];
                 // Label should not be empty and should not contain unescaped brackets
@@ -72,7 +72,6 @@ fn uses_reference_links(markdown: &str) -> bool {
                     return true;
                 }
             }
-        }
         // Also check for continuation lines that contain ]: followed by URL/space
         // This catches multi-line reference labels like "[Foo\n  bar]: /url"
         if (trimmed.contains("]: ") || trimmed.contains("]:/") || trimmed.contains("]: <"))


### PR DESCRIPTION
## What changed

- raise the Rust MSRV from 1.85 to 1.88 across the workspace and standalone benchmark manifests
- update the CI MSRV matrix to Rust 1.88
- update the README MSRV badge
- apply the mechanical Clippy cleanups unlocked by the Rust 1.88 MSRV

## Why

Rust 1.88 has been available since June 2025 and is now required by the current N-API-RS dependency line. Using one shared MSRV removes the compatibility pins that held the native bindings back.

Raising `rust-version` also makes Rust 1.88 language and library features eligible for current Clippy suggestions. Because CI treats warnings as errors, the affected nested conditionals and divisibility check are updated in the same compatibility change.

## Impact

This is a breaking toolchain requirement: building ferromark now requires Rust 1.88 or newer. The Clippy-driven source changes preserve behavior.

## Validation

- `cargo +1.88.0 test --workspace --all-features --locked --offline`
- `cargo +1.88.0 check --workspace --all-targets --all-features --locked --offline`
- `cargo +1.97.1 clippy --workspace --all-targets --all-features --locked --offline -- -D warnings`
- `cargo +1.88.0 fmt --all -- --check`
- `cargo +1.97.1 fmt --all -- --check`
- `git diff --check`