### PR TITLE
chore(deps): update ctor to 1.0.11

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -216,9 +216,9 @@ checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "ctor"
-version = "1.0.10"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2e30e509674ef0ec91e21a7735766db37d163d46151b6a361d8b83dd79116bd"
+checksum = "e9bb72bb94fdc1bd619f4c18cc91ecf6302aeb333d31b3c6ec0bb841cd920209"
 
 [[package]]
 name = "either"


### PR DESCRIPTION
## Summary

- updates the transitive `ctor` lockfile resolution from 1.0.10 to 1.0.11
- picks up the upstream Apple constructor-anchor alignment fix used through the N-API dependency chain
- leaves manifests and public APIs unchanged

## Impact

This is a lockfile-only maintenance update for the Node binding dependency graph. It keeps initialization support current without changing Ferromark behavior or its MSRV.

## Validation

- `cargo +1.88.0 test --workspace --all-features --locked --offline`
- `cargo +1.97.1 clippy --workspace --all-targets --all-features --locked --offline -- -D warnings`
- `cargo +1.97.1 fmt --all -- --check`
- Node build, tests, typecheck, lint, package validation, and smoke tests
- Cargo and pnpm security audits: 0 vulnerabilities