### PR TITLE
chore(deps): refresh benchmark lockfiles for 0.7.0

### DIFF
--- a/benchmarks/md4c-comparison/Cargo.lock
+++ b/benchmarks/md4c-comparison/Cargo.lock
@@ -236,7 +236,7 @@ checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
 
 [[package]]
 name = "ferromark"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "html-escape",
  "memchr",

--- a/benchmarks/pulldown-comparison/Cargo.lock
+++ b/benchmarks/pulldown-comparison/Cargo.lock
@@ -198,7 +198,7 @@ checksum = "9e5e8f6c15a24b9a3ee5efec809ccd006d3b30e8b3bb63c39af737c7f87daa1d"
 
 [[package]]
 name = "ferromark"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "html-escape",
  "memchr",


### PR DESCRIPTION
## Summary

- refreshes the standalone `md4c-comparison` benchmark lockfile
- refreshes the standalone `pulldown-comparison` benchmark lockfile
- updates both local `ferromark` package resolutions from 0.6.0 to the current 0.7.0 workspace version

## Impact

The benchmark projects now resolve the released workspace version accurately. Production crates and runtime behavior are unchanged.

## Validation

- Rust 1.88 tests for both standalone benchmark projects
- current-toolchain all-target checks for both projects
- MD4C comparison validated with a temporary official MD4C checkout supplied through `MD4C_DIR`
- Cargo security audits for both lockfiles: 0 vulnerabilities