### PR TITLE
fix(node): unwind panics in native addon

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,6 +78,13 @@ panic = "abort"
 opt-level = 3
 strip = true
 
+# N-API catches Rust panics and turns them into JavaScript exceptions. Cargo only
+# reads workspace profiles from this manifest, so the Node addon must opt into
+# this profile explicitly rather than defining it in node/native/Cargo.toml.
+[profile.release-node]
+inherits = "release"
+panic = "unwind"
+
 [profile.release-debug]
 inherits = "release"
 debug = true

--- a/node/ferromark/README.md
+++ b/node/ferromark/README.md
@@ -56,3 +56,10 @@ toHtml('[guide](/guide)', { linkBasePath: '/docs' })
 Image sources and autolinks are not rewritten.
 
 The package supports Node.js 22 or newer on glibc Linux, macOS, and Windows for x64 and arm64. It does not include a WASM fallback.
+
+## Native build profile
+
+The native addon is built with Cargo's workspace-level `release-node` profile. It
+keeps the optimized release settings while enabling panic unwinding, allowing
+N-API to translate a Rust panic into a JavaScript exception instead of aborting
+the Node.js process.

--- a/node/ferromark/package.json
+++ b/node/ferromark/package.json
@@ -46,8 +46,8 @@
   "scripts": {
     "build": "node ./scripts/build-native.mjs && node ./scripts/verify-package.mjs",
     "build:native": "node ./scripts/build-native.mjs",
-    "lint": "node --check index.mjs && node --check scripts/build-native.mjs && node --check scripts/verify-package.mjs",
-    "test": "node --test test/*.test.mjs"
+    "lint": "node --check index.mjs && node --check scripts/build-native.mjs && node --check scripts/verify-package.mjs && node --check scripts/verify-panic-unwind.mjs",
+    "test": "node --test test/*.test.mjs && node ./scripts/verify-panic-unwind.mjs"
   },
   "publishConfig": {
     "access": "public",

--- a/node/ferromark/scripts/build-native.mjs
+++ b/node/ferromark/scripts/build-native.mjs
@@ -2,23 +2,29 @@ import { spawnSync } from 'node:child_process'
 import process from 'node:process'
 
 const pnpm = process.platform === 'win32' ? 'pnpm.cmd' : 'pnpm'
+const outputDir = process.env.FERROMARK_NATIVE_OUTPUT_DIR ?? '.'
 const args = [
   'exec',
   'napi',
   'build',
   '--platform',
-  '--release',
+  '--profile',
+  'release-node',
   '--manifest-path',
   '../native/Cargo.toml',
   '--dts',
   'native.d.ts',
   '--no-js',
   '--output-dir',
-  '.',
+  outputDir,
 ]
 
 if (process.env.FERROMARK_RUST_TARGET) {
   args.push('--target', process.env.FERROMARK_RUST_TARGET)
+}
+
+if (process.env.FERROMARK_NAPI_FEATURES) {
+  args.push('--features', process.env.FERROMARK_NAPI_FEATURES)
 }
 
 args.push('--', '--locked')

--- a/node/ferromark/scripts/verify-panic-unwind.mjs
+++ b/node/ferromark/scripts/verify-panic-unwind.mjs
@@ -1,0 +1,98 @@
+import assert from 'node:assert/strict'
+import { spawnSync } from 'node:child_process'
+import { mkdtemp, readFile, readdir, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const root = new URL('../../../', import.meta.url)
+const buildScriptUrl = new URL('./build-native.mjs', import.meta.url)
+const [cargoToml, buildScript] = await Promise.all([
+  readFile(new URL('Cargo.toml', root), 'utf8'),
+  readFile(buildScriptUrl, 'utf8'),
+])
+
+const profile = cargoToml.match(
+  /^\[profile\.release-node\]$([\s\S]*?)(?=^\[|(?![\s\S]))/m,
+)
+
+assert.ok(profile, 'Cargo.toml must define the release-node profile at the workspace root')
+assert.match(profile[1], /^inherits = "release"$/m)
+assert.match(profile[1], /^panic = "unwind"$/m)
+assert.match(
+  buildScript,
+  /['"]--profile['"],\s*['"]release-node['"],/,
+  'the native package builder must select Cargo\'s release-node profile',
+)
+
+const cargo = spawnSync(
+  'cargo',
+  [
+    'rustc',
+    '--locked',
+    '--package',
+    'ferromark-node',
+    '--profile',
+    'release-node',
+    '--lib',
+    '--',
+    '--print',
+    'cfg',
+  ],
+  { cwd: root, encoding: 'utf8' },
+)
+
+assert.ifError(cargo.error)
+assert.equal(
+  cargo.status,
+  0,
+  `Could not inspect the Node cdylib panic strategy:\n${cargo.stderr}`,
+)
+assert.match(
+  cargo.stdout,
+  /^panic="unwind"$/m,
+  'the release-node cdylib must compile with panic=unwind',
+)
+
+const outputDir = await mkdtemp(join(tmpdir(), 'ferromark-panic-unwind-'))
+
+try {
+  const build = spawnSync(process.execPath, [fileURLToPath(buildScriptUrl)], {
+    cwd: fileURLToPath(new URL('./', buildScriptUrl)),
+    encoding: 'utf8',
+    env: {
+      ...process.env,
+      FERROMARK_NAPI_FEATURES: 'panic-test',
+      FERROMARK_NATIVE_OUTPUT_DIR: outputDir,
+    },
+  })
+
+  assert.ifError(build.error)
+  assert.equal(
+    build.status,
+    0,
+    `Could not build the panic-unwind verification addon:\n${build.stderr}`,
+  )
+
+  const nativeBinding = (await readdir(outputDir)).find(file => file.endsWith('.node'))
+  assert.ok(nativeBinding, 'the panic-unwind verification build did not produce a .node addon')
+
+  const panicCheck = spawnSync(
+    process.execPath,
+    [
+      '--input-type=module',
+      '--eval',
+      `import { createRequire } from 'node:module';\nconst addon = createRequire(import.meta.url)(${JSON.stringify(join(outputDir, nativeBinding))});\ntry { addon.testPanicUnwind(); } catch (error) { if (error instanceof Error && error.message.includes('ferromark N-API panic-unwind verification')) process.exit(0); }\nprocess.exit(1);`,
+    ],
+    { encoding: 'utf8' },
+  )
+
+  assert.ifError(panicCheck.error)
+  assert.equal(
+    panicCheck.status,
+    0,
+    `a panic in the Node cdylib was not translated to a JavaScript Error:\n${panicCheck.stderr}`,
+  )
+} finally {
+  await rm(outputDir, { force: true, recursive: true })
+}

--- a/node/native/Cargo.toml
+++ b/node/native/Cargo.toml
@@ -12,6 +12,9 @@ crate-type = ["cdylib"]
 doctest = false
 test = false
 
+[features]
+panic-test = []
+
 [dependencies]
 ferromark = { path = "../.." }
 napi = { version = "=3.11.0", default-features = false, features = ["dyn-symbols", "napi8"] }

--- a/node/native/src/lib.rs
+++ b/node/native/src/lib.rs
@@ -4,6 +4,12 @@ use ferromark::{
 use napi::bindgen_prelude::{Error, FnArgs, Function, Result, Status};
 use napi_derive::napi;
 
+#[cfg(feature = "panic-test")]
+#[napi(catch_unwind)]
+pub fn __test_panic_unwind() {
+    panic!("ferromark N-API panic-unwind verification");
+}
+
 #[napi(object)]
 pub struct Options {
     pub render_policy: Option<String>,
@@ -85,7 +91,7 @@ fn core_options(options: Option<Options>) -> Result<CoreOptions> {
     options.map_or_else(|| Ok(CoreOptions::default()), Options::into_core)
 }
 
-#[napi]
+#[napi(catch_unwind)]
 pub fn to_html(markdown: String, options: Option<Options>) -> Result<String> {
     Ok(ferromark::to_html_with_options(
         &markdown,
@@ -132,7 +138,7 @@ fn transform_result(result: ferromark::ParseResult<'_>) -> TransformResult {
 }
 
 /// Render Markdown and return HTML together with headings and front matter.
-#[napi]
+#[napi(catch_unwind)]
 pub fn transform(markdown: String, options: Option<Options>) -> Result<TransformResult> {
     let options = core_options(options)?;
     Ok(transform_result(ferromark::parse_with_options(
@@ -159,7 +165,7 @@ impl FencedCodeRenderer for CallbackRenderer<'_> {
     }
 }
 
-#[napi]
+#[napi(catch_unwind)]
 #[allow(clippy::type_complexity)]
 pub fn to_html_with_renderer(
     markdown: String,
@@ -180,7 +186,7 @@ pub fn to_html_with_renderer(
 /// The callback receives `(code, language, meta)` and must return trusted,
 /// fully escaped HTML — or null/undefined to fall back to the default
 /// escaped `<pre><code>` output.
-#[napi]
+#[napi(catch_unwind)]
 #[allow(clippy::type_complexity)]
 pub fn transform_with_renderer(
     markdown: String,


### PR DESCRIPTION
## Summary

- build the Node native addon with a dedicated `release-node` Cargo profile using panic unwinding
- opt the exported parser functions into napi-rs panic catching
- add an end-to-end guard that verifies a Rust panic becomes a catchable JavaScript error
- document and wire the Node-specific native build profile

## Validation

- Rust test suite and clippy checks
- Node package build and tests
- panic-unwind verification script

Fixes #140

🔧 Emily Carter · Implementation Agent
