### PR TITLE
fix: bound reference-link resolution work

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,6 +252,13 @@ These aren't planned. They'd compromise the streaming architecture that makes fe
 
 The default `RenderPolicy::Untrusted` is the browser-facing safety boundary. It escapes all raw HTML and allows relative URLs plus a small set of non-script schemes (`http`, `https`, `mailto`, `tel`, and similar). URL schemes are checked after entity and control-character normalization, so spellings such as `javas&#99;ript:` are blocked too.
 
+Reference-link resolution also has a document-wide work budget. If a document
+uses up that budget while inspecting reference labels, later reference links
+are emitted as literal text instead of being resolved. This conservative
+fallback applies to the default untrusted renderer (and trusted rendering as
+well), so repeated adversarial paragraphs cannot accumulate unbounded parser
+work.
+
 ```rust
 let html = ferromark::to_html(user_supplied_markdown);
 ```
@@ -478,7 +485,7 @@ What makes this fast in practice:
 
 - **Linear time.** No regex, no backtracking, no quadratic blowup on adversarial input.
 - **Low allocation pressure.** Compact events, range references, reusable output buffers.
-- **Operational safety.** Enforced limits cap block nesting (32), inline marks (4,096), code-span backtick runs (32), link-destination parenthesis depth (32), ordered-list marker digits (9), and table columns (128). Footnote numbering has no arbitrary count cap; its definition-index lookup stays O(1) per reference.
+- **Operational safety.** Enforced limits cap block nesting (32), inline marks (4,096), document-wide reference-link resolution work, code-span backtick runs (32), link-destination parenthesis depth (32), ordered-list marker digits (9), and table columns (128). Footnote numbering has no arbitrary count cap; its definition-index lookup stays O(1) per reference.
 - **Small dependency surface.** Minimal crates, straightforward integration.
 
 <details>

--- a/README.md
+++ b/README.md
@@ -254,10 +254,11 @@ The default `RenderPolicy::Untrusted` is the browser-facing safety boundary. It 
 
 Reference-link resolution also has a document-wide work budget. If a document
 uses up that budget while inspecting reference labels, later reference links
-are emitted as literal text instead of being resolved. This conservative
-fallback applies to the default untrusted renderer (and trusted rendering as
-well), so repeated adversarial paragraphs cannot accumulate unbounded parser
-work.
+are emitted as literal text instead of being resolved. The budget resets for
+each new render or public inline-parser call, while remaining shared across
+paragraphs of that document. This conservative fallback applies to the default
+untrusted renderer (and trusted rendering as well), so repeated adversarial
+paragraphs cannot accumulate unbounded parser work.
 
 ```rust
 let html = ferromark::to_html(user_supplied_markdown);

--- a/src/inline/links.rs
+++ b/src/inline/links.rs
@@ -67,12 +67,14 @@ pub struct RefLink {
 #[derive(Debug)]
 pub(crate) struct ReferenceResolutionBudget {
     remaining: usize,
+    exhausted: bool,
 }
 
 impl ReferenceResolutionBudget {
     pub(crate) const fn new() -> Self {
         Self {
             remaining: limits::MAX_REFERENCE_RESOLUTION_WORK,
+            exhausted: false,
         }
     }
 
@@ -80,6 +82,7 @@ impl ReferenceResolutionBudget {
     fn consume(&mut self, work: usize) -> bool {
         let Some(remaining) = self.remaining.checked_sub(work) else {
             self.remaining = 0;
+            self.exhausted = true;
             return false;
         };
         self.remaining = remaining;
@@ -281,7 +284,12 @@ pub fn resolve_reference_links_into(
     candidate_prefix.clear();
     candidate_prefix.reserve(open_brackets.len() + 1);
     candidate_prefix.push(0);
+    let mut candidate_limit = open_brackets.len();
     for (open_idx, &(open_pos, is_image)) in open_brackets.iter().enumerate() {
+        if work_budget.remaining == 0 {
+            candidate_limit = open_idx;
+            break;
+        }
         let candidate = (!formed_opens[open_idx])
             .then(|| {
                 matching_closes[open_idx].and_then(|close_idx| {
@@ -298,17 +306,21 @@ pub fn resolve_reference_links_into(
                 })
             })
             .flatten();
+        if work_budget.exhausted {
+            candidate_limit = open_idx;
+            break;
+        }
         candidates[open_idx] = candidate;
         let count = candidate_prefix[open_idx] + usize::from(!is_image && candidate.is_some());
         candidate_prefix.push(count);
         if work_budget.remaining == 0 {
-            out_links.clear();
-            return;
+            candidate_limit = open_idx + 1;
+            break;
         }
     }
 
     // Process open brackets from left to right.
-    for open_idx in 0..open_brackets.len() {
+    for open_idx in 0..candidate_limit {
         if formed_opens[open_idx] {
             continue;
         }
@@ -327,6 +339,9 @@ pub fn resolve_reference_links_into(
 
         // Links cannot contain links (but can contain images)
         let end_open_idx = open_brackets.partition_point(|&(pos, _)| pos < close_pos);
+        if end_open_idx > candidate_limit {
+            continue;
+        }
         let has_nested_candidate = candidate_prefix[end_open_idx] > candidate_prefix[open_idx + 1];
         if contains_link(occupied, open_pos, close_pos) || has_nested_candidate {
             continue;

--- a/src/inline/links.rs
+++ b/src/inline/links.rs
@@ -60,6 +60,40 @@ pub struct RefLink {
     pub def_index: usize,
 }
 
+/// Shared work allowance for reference-link resolution in one document.
+///
+/// Exhaustion is a safe fallback: callers leave unresolved reference syntax as
+/// literal text rather than attempting more label scans.
+#[derive(Debug)]
+pub(crate) struct ReferenceResolutionBudget {
+    remaining: usize,
+}
+
+impl ReferenceResolutionBudget {
+    pub(crate) const fn new() -> Self {
+        Self {
+            remaining: limits::MAX_REFERENCE_RESOLUTION_WORK,
+        }
+    }
+
+    #[inline]
+    fn consume(&mut self, work: usize) -> bool {
+        let Some(remaining) = self.remaining.checked_sub(work) else {
+            self.remaining = 0;
+            return false;
+        };
+        self.remaining = remaining;
+        true
+    }
+}
+
+#[derive(Clone, Copy)]
+pub(super) struct RefCandidate {
+    def_index: usize,
+    end: u32,
+    suffix_brackets: Option<(usize, usize)>,
+}
+
 /// Parse links from text, given bracket positions.
 /// Returns list of resolved links.
 #[allow(dead_code)]
@@ -191,6 +225,11 @@ pub fn resolve_reference_links_into(
     formed_opens: &mut Vec<bool>,
     used_closes: &mut Vec<bool>,
     occupied: &mut Vec<(u32, u32)>,
+    matching_closes: &mut Vec<Option<usize>>,
+    matching_stack: &mut Vec<usize>,
+    candidates: &mut Vec<Option<RefCandidate>>,
+    candidate_prefix: &mut Vec<usize>,
+    work_budget: &mut ReferenceResolutionBudget,
 ) {
     out_links.clear();
     label_buf.clear();
@@ -221,137 +260,180 @@ pub fn resolve_reference_links_into(
         }
     }
 
-    // Process open brackets from left to right
-    let mut nested_label_buf = String::new();
+    // Build the bracket structure once. The old resolver rebuilt this nesting
+    // walk for every opener, which made nested input super-linear.
+    if !work_budget.consume(open_brackets.len() + close_brackets.len()) {
+        return;
+    }
+    precompute_matching_closes(
+        open_brackets,
+        close_brackets,
+        formed_opens,
+        used_closes,
+        matching_closes,
+        matching_stack,
+    );
+
+    // Determine each resolvable candidate once, then answer the "does this
+    // link contain another link?" question with a prefix-count range query.
+    candidates.clear();
+    candidates.resize(open_brackets.len(), None);
+    candidate_prefix.clear();
+    candidate_prefix.reserve(open_brackets.len() + 1);
+    candidate_prefix.push(0);
+    for (open_idx, &(open_pos, is_image)) in open_brackets.iter().enumerate() {
+        let candidate = (!formed_opens[open_idx])
+            .then(|| {
+                matching_closes[open_idx].and_then(|close_idx| {
+                    build_ref_candidate(
+                        text,
+                        open_pos,
+                        close_idx,
+                        open_brackets,
+                        close_brackets,
+                        defs,
+                        label_buf,
+                        work_budget,
+                    )
+                })
+            })
+            .flatten();
+        candidates[open_idx] = candidate;
+        let count = candidate_prefix[open_idx] + usize::from(!is_image && candidate.is_some());
+        candidate_prefix.push(count);
+        if work_budget.remaining == 0 {
+            out_links.clear();
+            return;
+        }
+    }
+
+    // Process open brackets from left to right.
     for open_idx in 0..open_brackets.len() {
         if formed_opens[open_idx] {
             continue;
         }
         let (open_pos, is_image) = open_brackets[open_idx];
 
-        let close_idx = find_matching_close(
-            open_pos,
-            open_brackets,
-            close_brackets,
-            formed_opens,
-            used_closes,
-        );
-
-        let Some(close_idx) = close_idx else { continue };
-        let close_pos = close_brackets[close_idx];
-
-        // Determine reference label
-        let mut end = close_pos + 1;
-        let label_start = (open_pos + 1) as usize;
-        let label_end = close_pos as usize;
-        let mut label_bytes = &text[label_start..label_end];
-
-        let mut ref_label: Option<(usize, usize, usize)> = None;
-        if let Some((ref_start, ref_end, ref_close_pos)) =
-            parse_ref_label_immediate(text, close_pos as usize + 1)
-        {
-            // Full or collapsed reference: [label][ref] or [label][]
-            if ref_start == ref_end {
-                // Collapsed: use link text as label
-            } else {
-                label_bytes = &text[ref_start..ref_end];
-            }
-            end = (ref_close_pos + 1) as u32;
-            ref_label = Some((ref_start, ref_end, ref_close_pos));
-        }
-
-        normalize_label_into(label_bytes, label_buf);
-        if label_buf.is_empty() {
+        let Some(close_idx) = matching_closes[open_idx] else {
+            continue;
+        };
+        if used_closes[close_idx] {
             continue;
         }
-        let Some(def_index) = defs.get_index(label_buf) else {
+        let close_pos = close_brackets[close_idx];
+        let Some(candidate) = candidates[open_idx] else {
             continue;
         };
 
         // Links cannot contain links (but can contain images)
-        if contains_link(occupied, open_pos, close_pos)
-            || contains_ref_link_candidate(
-                text,
-                open_brackets,
-                close_brackets,
-                defs,
-                open_pos,
-                close_pos,
-                &mut nested_label_buf,
-            )
-        {
+        let end_open_idx = open_brackets.partition_point(|&(pos, _)| pos < close_pos);
+        let has_nested_candidate = candidate_prefix[end_open_idx] > candidate_prefix[open_idx + 1];
+        if contains_link(occupied, open_pos, close_pos) || has_nested_candidate {
             continue;
         }
 
         formed_opens[open_idx] = true;
         used_closes[close_idx] = true;
 
-        if let Some((ref_start, _ref_end, ref_close_pos)) = ref_label {
-            if let Some(idx) = find_open_idx(open_brackets, (ref_start - 1) as u32) {
-                formed_opens[idx] = true;
-            }
-            if let Some(idx) = find_close_idx(close_brackets, ref_close_pos as u32) {
-                used_closes[idx] = true;
-            }
+        if let Some((ref_open_idx, ref_close_idx)) = candidate.suffix_brackets {
+            formed_opens[ref_open_idx] = true;
+            used_closes[ref_close_idx] = true;
         }
 
         out_links.push(RefLink {
             start: if is_image { open_pos - 1 } else { open_pos },
             text_end: close_pos,
-            end,
+            end: candidate.end,
             is_image,
-            def_index,
+            def_index: candidate.def_index,
         });
-
-        occupied.push((open_pos, end));
     }
 
     out_links.sort_by_key(|l| l.start);
 }
 
-fn contains_ref_link_candidate(
+fn precompute_matching_closes(
+    open_brackets: &[(u32, bool)],
+    close_brackets: &[u32],
+    formed_opens: &[bool],
+    used_closes: &[bool],
+    matching_closes: &mut Vec<Option<usize>>,
+    stack: &mut Vec<usize>,
+) {
+    matching_closes.clear();
+    matching_closes.resize(open_brackets.len(), None);
+    stack.clear();
+
+    let mut open_idx = 0;
+    let mut close_idx = 0;
+    while open_idx < open_brackets.len() || close_idx < close_brackets.len() {
+        while open_idx < open_brackets.len() && formed_opens[open_idx] {
+            open_idx += 1;
+        }
+        while close_idx < close_brackets.len() && used_closes[close_idx] {
+            close_idx += 1;
+        }
+        if open_idx == open_brackets.len() && close_idx == close_brackets.len() {
+            break;
+        }
+
+        let next_open = open_brackets
+            .get(open_idx)
+            .map_or(u32::MAX, |&(pos, _)| pos);
+        let next_close = close_brackets.get(close_idx).copied().unwrap_or(u32::MAX);
+        if next_open <= next_close {
+            stack.push(open_idx);
+            open_idx += 1;
+        } else {
+            if let Some(open_idx) = stack.pop() {
+                matching_closes[open_idx] = Some(close_idx);
+            }
+            close_idx += 1;
+        }
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn build_ref_candidate(
     text: &[u8],
+    open_pos: u32,
+    close_idx: usize,
     open_brackets: &[(u32, bool)],
     close_brackets: &[u32],
     defs: &LinkRefStore,
-    start: u32,
-    end: u32,
     label_buf: &mut String,
-) -> bool {
-    label_buf.clear();
-    for &(open_pos, is_image) in open_brackets {
-        if open_pos <= start || open_pos >= end || is_image {
-            continue;
-        }
-        let close_pos = close_brackets
-            .iter()
-            .copied()
-            .find(|&c| c > open_pos && c < end);
-        let Some(close_pos) = close_pos else { continue };
+    work_budget: &mut ReferenceResolutionBudget,
+) -> Option<RefCandidate> {
+    let close_pos = close_brackets[close_idx];
+    let label_start = (open_pos + 1) as usize;
+    let label_end = close_pos as usize;
+    let mut label_bytes = text.get(label_start..label_end)?;
+    let mut end = close_pos + 1;
+    let mut suffix_brackets = None;
 
-        let label_start = (open_pos + 1) as usize;
-        let label_end = close_pos as usize;
-        if label_start >= label_end || label_end > text.len() {
-            continue;
-        }
-        let mut label_bytes = &text[label_start..label_end];
-
-        if let Some((ref_start, ref_end, _ref_close)) =
-            parse_ref_label_immediate(text, close_pos as usize + 1)
-            && ref_start != ref_end
-        {
+    if let Some((ref_start, ref_end, ref_close_pos)) =
+        parse_ref_label_immediate(text, close_pos as usize + 1, work_budget)
+    {
+        if ref_start != ref_end {
             label_bytes = &text[ref_start..ref_end];
         }
-
-        normalize_label_into(label_bytes, label_buf);
-        if label_buf.is_empty() {
-            continue;
-        }
-        if defs.get_index(label_buf).is_some() {
-            return true;
-        }
+        end = (ref_close_pos + 1) as u32;
+        suffix_brackets = Some((
+            find_open_idx(open_brackets, (ref_start - 1) as u32)?,
+            find_close_idx(close_brackets, ref_close_pos as u32)?,
+        ));
     }
-    false
+
+    if !work_budget.consume(label_bytes.len()) {
+        return None;
+    }
+    normalize_label_into(label_bytes, label_buf);
+    let def_index = defs.get_index(label_buf)?;
+    Some(RefCandidate {
+        def_index,
+        end,
+        suffix_brackets,
+    })
 }
 
 #[inline]
@@ -365,7 +447,8 @@ fn find_close_idx(close_brackets: &[u32], pos: u32) -> Option<usize> {
 }
 
 fn contains_link(links: &[(u32, u32)], start: u32, end: u32) -> bool {
-    links.iter().any(|&(s, e)| s >= start && e <= end)
+    let idx = links.partition_point(|&(link_start, _)| link_start < start);
+    links.get(idx).is_some_and(|&(_, link_end)| link_end <= end)
 }
 
 /// Find the matching close bracket for an open bracket, accounting for nesting.
@@ -438,7 +521,11 @@ fn find_matching_close(
     None
 }
 
-fn parse_ref_label_immediate(text: &[u8], mut pos: usize) -> Option<(usize, usize, usize)> {
+fn parse_ref_label_immediate(
+    text: &[u8],
+    mut pos: usize,
+    work_budget: &mut ReferenceResolutionBudget,
+) -> Option<(usize, usize, usize)> {
     let len = text.len();
 
     if pos >= len || text[pos] != b'[' {
@@ -448,6 +535,9 @@ fn parse_ref_label_immediate(text: &[u8], mut pos: usize) -> Option<(usize, usiz
     pos += 1;
 
     while pos < len {
+        if !work_budget.consume(1) {
+            return None;
+        }
         match text[pos] {
             b'\\' => {
                 if pos + 1 < len {

--- a/src/inline/links.rs
+++ b/src/inline/links.rs
@@ -79,6 +79,12 @@ impl ReferenceResolutionBudget {
     }
 
     #[inline]
+    pub(crate) fn reset(&mut self) {
+        self.remaining = limits::MAX_REFERENCE_RESOLUTION_WORK;
+        self.exhausted = false;
+    }
+
+    #[inline]
     fn consume(&mut self, work: usize) -> bool {
         let Some(remaining) = self.remaining.checked_sub(work) else {
             self.remaining = 0;

--- a/src/inline/links.rs
+++ b/src/inline/links.rs
@@ -345,10 +345,13 @@ pub fn resolve_reference_links_into(
 
         // Links cannot contain links (but can contain images)
         let end_open_idx = open_brackets.partition_point(|&(pos, _)| pos < close_pos);
-        if end_open_idx > candidate_limit {
-            continue;
-        }
-        let has_nested_candidate = candidate_prefix[end_open_idx] > candidate_prefix[open_idx + 1];
+        // Once the budget boundary is reached, later openers are deliberately
+        // literal. They cannot invalidate a completed outer candidate; only
+        // candidates that were fully inspected before that boundary can form
+        // nested links.
+        let inspected_end_open_idx = end_open_idx.min(candidate_limit);
+        let has_nested_candidate =
+            candidate_prefix[inspected_end_open_idx] > candidate_prefix[open_idx + 1];
         if contains_link(occupied, open_pos, close_pos) || has_nested_candidate {
             continue;
         }

--- a/src/inline/mod.rs
+++ b/src/inline/mod.rs
@@ -143,7 +143,8 @@ impl InlineParser {
         allow_html: bool,
         events: &mut Vec<InlineEvent>,
     ) {
-        self.parse_with_options(
+        self.begin_document();
+        self.parse_with_options_in_document(
             text, link_refs, allow_html, true, false, false, false, true, false, false, None,
             events,
         );
@@ -165,8 +166,30 @@ impl InlineParser {
         link_refs: Option<&LinkRefStore>,
         events: &mut Vec<InlineEvent>,
     ) {
+        self.begin_document();
+        self.parse_mdx_in_document(text, link_refs, events);
+    }
+
+    /// Begin a document-level inline parsing session.
+    ///
+    /// Public parsing methods call this automatically. Renderers that parse
+    /// multiple paragraphs with one reusable parser call it once per document
+    /// so reference-resolution work remains bounded for the whole document.
+    pub(crate) fn begin_document(&mut self) {
+        self.ref_work_budget.reset();
+    }
+
+    /// Parse inline Markdown with opt-in MDX expressions as part of an active
+    /// document-level parsing session.
+    #[cfg(feature = "mdx")]
+    pub(crate) fn parse_mdx_in_document(
+        &mut self,
+        text: &[u8],
+        link_refs: Option<&LinkRefStore>,
+        events: &mut Vec<InlineEvent>,
+    ) {
         let new_events_start = events.len();
-        self.parse_with_options(
+        self.parse_with_options_in_document(
             text, link_refs, false, true, false, false, false, true, false, false, None, events,
         );
         split_mdx_text_events(text, events, new_events_start);
@@ -175,6 +198,40 @@ impl InlineParser {
     /// Parse inline content with configurable inline extensions.
     #[allow(clippy::too_many_arguments)]
     pub fn parse_with_options(
+        &mut self,
+        text: &[u8],
+        link_refs: Option<&LinkRefStore>,
+        allow_html: bool,
+        strikethrough: bool,
+        highlight: bool,
+        superscript: bool,
+        subscript: bool,
+        autolink_literals: bool,
+        math: bool,
+        inline_footnotes: bool,
+        footnote_store: Option<&FootnoteStore>,
+        events: &mut Vec<InlineEvent>,
+    ) {
+        self.begin_document();
+        self.parse_with_options_in_document(
+            text,
+            link_refs,
+            allow_html,
+            strikethrough,
+            highlight,
+            superscript,
+            subscript,
+            autolink_literals,
+            math,
+            inline_footnotes,
+            footnote_store,
+            events,
+        );
+    }
+
+    /// Parse inline content as part of an active document-level parsing session.
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn parse_with_options_in_document(
         &mut self,
         text: &[u8],
         link_refs: Option<&LinkRefStore>,

--- a/src/inline/mod.rs
+++ b/src/inline/mod.rs
@@ -27,8 +27,9 @@ use code_span::{CodeSpan, extract_code_spans, resolve_code_spans};
 use emphasis::{EmphasisMatch, EmphasisStacks, resolve_emphasis_with_stacks_into};
 use highlight::{HighlightMatch, resolve_highlight_into};
 use links::{
-    Autolink, AutolinkLiteral, Link, RefLink, find_autolink_literals_into, find_autolinks_into,
-    resolve_links_into, resolve_reference_links_into,
+    Autolink, AutolinkLiteral, Link, RefLink, ReferenceResolutionBudget,
+    find_autolink_literals_into, find_autolinks_into, resolve_links_into,
+    resolve_reference_links_into,
 };
 use marks::{
     Mark, MarkBuffer, MarkSummary, collect_marks, collect_marks_highlight,
@@ -62,6 +63,11 @@ pub struct InlineParser {
     ref_formed_opens: Vec<bool>,
     ref_used_closes: Vec<bool>,
     ref_occupied: Vec<(u32, u32)>,
+    ref_matching_closes: Vec<Option<usize>>,
+    ref_matching_stack: Vec<usize>,
+    ref_candidates: Vec<Option<links::RefCandidate>>,
+    ref_candidate_prefix: Vec<usize>,
+    ref_work_budget: ReferenceResolutionBudget,
     autolink_literals: Vec<AutolinkLiteral>,
     emphasis_stacks: EmphasisStacks,
     emphasis_matches: Vec<EmphasisMatch>,
@@ -104,6 +110,11 @@ impl InlineParser {
             ref_formed_opens: Vec::with_capacity(32),
             ref_used_closes: Vec::with_capacity(32),
             ref_occupied: Vec::with_capacity(8),
+            ref_matching_closes: Vec::with_capacity(32),
+            ref_matching_stack: Vec::with_capacity(32),
+            ref_candidates: Vec::with_capacity(32),
+            ref_candidate_prefix: Vec::with_capacity(33),
+            ref_work_budget: ReferenceResolutionBudget::new(),
             autolink_literals: Vec::new(),
             emphasis_stacks: EmphasisStacks::default(),
             emphasis_matches: Vec::with_capacity(16),
@@ -346,6 +357,11 @@ impl InlineParser {
                     &mut self.ref_formed_opens,
                     &mut self.ref_used_closes,
                     &mut self.ref_occupied,
+                    &mut self.ref_matching_closes,
+                    &mut self.ref_matching_stack,
+                    &mut self.ref_candidates,
+                    &mut self.ref_candidate_prefix,
+                    &mut self.ref_work_budget,
                 );
             } else {
                 self.ref_links.clear();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1012,9 +1012,11 @@ impl<'a, 'r, R: FencedCodeRenderer + ?Sized> RenderContext<'a, 'r, R> {
         fenced_code_renderer: Option<&'r mut R>,
         headings: Option<&'a mut Vec<Heading>>,
     ) -> Self {
+        let mut inline_parser = InlineParser::new();
+        inline_parser.begin_document();
         Self {
             writer,
-            inline_parser: InlineParser::new(),
+            inline_parser,
             inline_events: Vec::with_capacity(64),
             para_state: ParagraphState::new(),
             heading_state: HeadingState::new(),
@@ -1685,7 +1687,7 @@ fn render_inline_content(
     inline_events.clear();
     inline_events.reserve((text.len() / 8).max(8));
     let refs = options.allow_link_refs.then_some(link_refs);
-    inline_parser.parse_with_options(
+    inline_parser.parse_with_options_in_document(
         text,
         refs,
         options.allow_html,

--- a/src/limits.rs
+++ b/src/limits.rs
@@ -9,6 +9,14 @@ pub const MAX_BLOCK_NESTING: usize = 32;
 /// Maximum number of marks collected during inline parsing
 pub const MAX_INLINE_MARKS: usize = 4096;
 
+/// Maximum reference-link resolution work per rendered document.
+///
+/// This counts bracket records and label bytes inspected while resolving
+/// reference-style links. Once exhausted, remaining reference links are left
+/// as literal text. The limit is shared by all paragraphs so independently
+/// bounded pathological paragraphs cannot multiply expensive work.
+pub const MAX_REFERENCE_RESOLUTION_WORK: usize = MAX_INLINE_MARKS * 8;
+
 /// Maximum backtick run length for code spans (prevents O(n^2) matching)
 /// Longer runs are treated as literal text
 pub const MAX_CODE_SPAN_BACKTICKS: usize = 32;

--- a/src/mdx/events.rs
+++ b/src/mdx/events.rs
@@ -188,6 +188,8 @@ fn build_event_stream(
     let (link_refs, markdown_block_events) = parse_markdown_segments(&segments);
     link_refs.append_definitions_to(&mut stream.link_references);
     let mut markdown_block_events = markdown_block_events.into_iter();
+    let mut inline_parser = InlineParser::new();
+    inline_parser.begin_document();
 
     for spanned in segments {
         let segment_start = content_start + spanned.range.start_usize();
@@ -204,6 +206,7 @@ fn build_event_stream(
                     segment_start,
                     &link_refs,
                     block_events,
+                    &mut inline_parser,
                     &mut stream.events,
                 );
             }
@@ -367,10 +370,9 @@ fn emit_markdown_events(
     source_offset: usize,
     link_refs: &LinkRefStore,
     block_events: Vec<BlockEvent>,
+    inline_parser: &mut InlineParser,
     events: &mut Vec<MdxEvent>,
 ) {
-    let mut inline_parser = InlineParser::new();
-    inline_parser.begin_document();
     let mut inline_events = Vec::new();
     let mut inline_group = Vec::new();
     for block_event in block_events {
@@ -386,7 +388,7 @@ fn emit_markdown_events(
                     markdown,
                     source_offset,
                     link_refs,
-                    &mut inline_parser,
+                    inline_parser,
                     &mut inline_events,
                     &mut inline_group,
                     events,
@@ -399,7 +401,7 @@ fn emit_markdown_events(
         markdown,
         source_offset,
         link_refs,
-        &mut inline_parser,
+        inline_parser,
         &mut inline_events,
         &mut inline_group,
         events,

--- a/src/mdx/events.rs
+++ b/src/mdx/events.rs
@@ -370,6 +370,7 @@ fn emit_markdown_events(
     events: &mut Vec<MdxEvent>,
 ) {
     let mut inline_parser = InlineParser::new();
+    inline_parser.begin_document();
     let mut inline_events = Vec::new();
     let mut inline_group = Vec::new();
     for block_event in block_events {
@@ -499,7 +500,7 @@ fn emit_inline_range(
     events: &mut Vec<MdxEvent>,
 ) {
     inline_events.clear();
-    inline_parser.parse_mdx(range.slice(markdown), Some(link_refs), inline_events);
+    inline_parser.parse_mdx_in_document(range.slice(markdown), Some(link_refs), inline_events);
     let inline_offset = source_offset + range.start_usize();
 
     for event in inline_events.drain(..) {

--- a/tests/resource_limits_tests.rs
+++ b/tests/resource_limits_tests.rs
@@ -1,4 +1,7 @@
-use ferromark::{Options, limits, to_html, to_html_with_options};
+use ferromark::{
+    InlineEvent, InlineParser, LinkRefDef, LinkRefStore, Options, limits, to_html,
+    to_html_with_options,
+};
 
 #[test]
 fn block_container_nesting_is_bounded() {
@@ -31,6 +34,40 @@ fn reference_link_resolution_budget_is_shared_across_paragraphs() {
     // is exhausted, proving that the allowance does not reset per paragraph.
     assert_eq!(html.matches("<a href=\"/safe\">").count(), paragraphs - 2);
     assert!(html.ends_with("<p>[x]</p>\n"));
+}
+
+#[test]
+fn reusable_inline_parser_resets_reference_budget_per_document() {
+    let mut refs = LinkRefStore::new();
+    refs.insert(
+        "x".to_owned(),
+        LinkRefDef {
+            url: b"/safe".to_vec(),
+            title: None,
+        },
+    );
+    let mut parser = InlineParser::new();
+    let mut events = Vec::new();
+
+    // One document depletes its allowance. Reusing the public parser for a
+    // separate document must start a fresh document budget.
+    let exhausting_document = "[x] ".repeat(limits::MAX_REFERENCE_RESOLUTION_WORK / 3 + 1);
+    parser.parse(
+        exhausting_document.as_bytes(),
+        Some(&refs),
+        true,
+        &mut events,
+    );
+
+    events.clear();
+    parser.parse(b"[x]", Some(&refs), true, &mut events);
+    assert!(
+        matches!(
+            events.first(),
+            Some(InlineEvent::LinkStartRef { def_index: 0 })
+        ),
+        "a reusable parser must not retain the prior document's exhausted budget: {events:?}"
+    );
 }
 
 #[test]

--- a/tests/resource_limits_tests.rs
+++ b/tests/resource_limits_tests.rs
@@ -36,6 +36,34 @@ fn reference_link_resolution_budget_is_shared_across_paragraphs() {
     assert!(html.ends_with("<p>[x]</p>\n"));
 }
 
+#[cfg(feature = "mdx")]
+#[test]
+fn mdx_reference_budget_is_shared_across_markdown_segments() {
+    use ferromark::mdx::{MdxEvent, parse_events};
+
+    let references_per_segment = limits::MAX_REFERENCE_RESOLUTION_WORK / 3;
+    let segment = "[x]\n\n".repeat(references_per_segment);
+    let input = format!("[x]: /safe\n\n{segment}<Component />\n\n{segment}");
+    let stream = parse_events(&input);
+
+    // A flow JSX separator creates two independent Markdown segments, but
+    // they are still one MDX document and therefore share one work allowance.
+    assert_eq!(
+        stream
+            .events
+            .iter()
+            .filter(|event| matches!(event, MdxEvent::Inline(InlineEvent::LinkStartRef { .. })))
+            .count(),
+        references_per_segment
+    );
+    assert!(
+        stream
+            .events
+            .iter()
+            .any(|event| matches!(event, MdxEvent::FlowJsxSelfClose(_)))
+    );
+}
+
 #[test]
 fn reusable_inline_parser_resets_reference_budget_per_document() {
     let mut refs = LinkRefStore::new();

--- a/tests/resource_limits_tests.rs
+++ b/tests/resource_limits_tests.rs
@@ -34,6 +34,25 @@ fn reference_link_resolution_budget_is_shared_across_paragraphs() {
 }
 
 #[test]
+fn exhausted_reference_budget_keeps_completed_candidates_in_the_current_paragraph() {
+    let completed_paragraphs = limits::MAX_REFERENCE_RESOLUTION_WORK / 3 - 3;
+    let markdown = format!(
+        "[x]: /safe\n\n{}[x] [x] [x] [x]",
+        "[x]\n\n".repeat(completed_paragraphs)
+    );
+    let html = to_html(&markdown);
+
+    // The final paragraph has budget for its bracket structure and exactly
+    // three labels. Its completed candidates still resolve; only the final
+    // candidate falls back to literal text.
+    assert_eq!(
+        html.matches("<a href=\"/safe\">").count(),
+        completed_paragraphs + 3
+    );
+    assert!(html.ends_with("<a href=\"/safe\">x</a> [x]</p>\n"));
+}
+
+#[test]
 fn nested_reference_brackets_remain_bounded_and_literal_after_exhaustion() {
     let depth = limits::MAX_INLINE_MARKS / 2 - 1;
     let nested = format!("{}x{}", "[".repeat(depth), "]".repeat(depth));

--- a/tests/resource_limits_tests.rs
+++ b/tests/resource_limits_tests.rs
@@ -90,6 +90,29 @@ fn exhausted_reference_budget_keeps_completed_candidates_in_the_current_paragrap
 }
 
 #[test]
+fn exhausted_reference_budget_keeps_completed_outer_full_reference_links() {
+    // Leave enough work for the final paragraph's bracket structure and its
+    // outer full-reference candidate, but not its unresolved inner openers.
+    let completed_paragraphs = (limits::MAX_REFERENCE_RESOLUTION_WORK - 24) / 3;
+    let markdown = format!(
+        "[x]: /safe\n[label]: /target\n\n{}[x [a [b] ] ][label]",
+        "[x]\n\n".repeat(completed_paragraphs)
+    );
+    let html = to_html(&markdown);
+
+    // The uninspected `[a ...]` and `[b]` syntax degrades to literal text,
+    // but it must not discard the already completed outer full reference.
+    assert_eq!(
+        html.matches("<a href=\"/safe\">").count(),
+        completed_paragraphs
+    );
+    assert!(
+        html.ends_with("<p><a href=\"/target\">x [a [b] ] </a></p>\n"),
+        "{html}"
+    );
+}
+
+#[test]
 fn nested_reference_brackets_remain_bounded_and_literal_after_exhaustion() {
     let depth = limits::MAX_INLINE_MARKS / 2 - 1;
     let nested = format!("{}x{}", "[".repeat(depth), "]".repeat(depth));

--- a/tests/resource_limits_tests.rs
+++ b/tests/resource_limits_tests.rs
@@ -21,6 +21,32 @@ fn inline_mark_collection_is_bounded() {
 }
 
 #[test]
+fn reference_link_resolution_budget_is_shared_across_paragraphs() {
+    let paragraphs = limits::MAX_REFERENCE_RESOLUTION_WORK / 3 + 2;
+    let markdown = format!("[x]: /safe\n\n{}", "[x]\n\n".repeat(paragraphs));
+    let html = to_html(&markdown);
+
+    // A `[x]` reference spends two bracket records plus one label byte. The
+    // final paragraphs are deliberately left literal once the document budget
+    // is exhausted, proving that the allowance does not reset per paragraph.
+    assert_eq!(html.matches("<a href=\"/safe\">").count(), paragraphs - 2);
+    assert!(html.ends_with("<p>[x]</p>\n"));
+}
+
+#[test]
+fn nested_reference_brackets_remain_bounded_and_literal_after_exhaustion() {
+    let depth = limits::MAX_INLINE_MARKS / 2 - 1;
+    let nested = format!("{}x{}", "[".repeat(depth), "]".repeat(depth));
+    let markdown = format!("[x]: /safe\n\n{nested}\n\n{nested}");
+    let html = to_html(&markdown);
+
+    // The first deeply nested paragraph consumes the shared label-inspection
+    // allowance. The second cannot re-run quadratic nesting work.
+    assert_eq!(html.matches("<a href=\"/safe\">").count(), 0);
+    assert!(html.contains(&nested));
+}
+
+#[test]
 fn oversized_backtick_runs_stay_literal() {
     let fence = "`".repeat(limits::MAX_CODE_SPAN_BACKTICKS + 1);
     let html = to_html(&format!("{fence}code{fence}"));


### PR DESCRIPTION
## Summary

- bound reference-link resolution work across adversarial documents
- replace repeated close-bracket scans with indexed structural lookup
- preserve ordinary CommonMark reference-link behavior while safely degrading pathological input
- add correctness and deterministic resource-limit regression coverage

## Validation

- focused reference-link and resource-limit tests
- full Rust test suite
- clippy and formatting checks

Fixes #142

🔧 Emily Carter · Implementation Agent
