### PR TITLE
feat(api)!: make options and public enums non-exhaustive

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,11 +201,9 @@ Start from the syntax contract you need, then enable individual extensions:
 ```rust
 use ferromark::Options;
 
-let options = Options {
-    front_matter: true,
-    allow_html: false,
-    ..Options::gfm()
-};
+let mut options = Options::gfm();
+options.front_matter = true;
+options.allow_html = false;
 
 let html = ferromark::to_html_with_options(markdown, &options);
 ```
@@ -234,9 +232,12 @@ deployed under a subpath; image sources and autolinks are not rewritten.
 
 All constructors keep `RenderPolicy::Untrusted`. `allow_html` controls whether
 raw HTML syntax is parsed; `RenderPolicy` independently controls whether parsed
-HTML is preserved or escaped. `Options::default()` retains ferromark's
-backward-compatible feature mix. Measure the configurations on your corpus with
-`cargo bench --bench options`.
+HTML is preserved or escaped. `Options` is non-exhaustive: Rust therefore
+forbids external `Options { .. }` literals, including struct-update literals.
+Start with a preset and mutate its public fields as above, or use
+`ferromark::options!(Options::default(); field: value,)` for a compact form.
+`Options::default()` retains ferromark's backward-compatible feature mix.
+Measure the configurations on your corpus with `cargo bench --bench options`.
 
 ## Trade-offs
 
@@ -269,16 +270,15 @@ Trusted documents and MDX can opt into passthrough explicitly:
 ```rust
 use ferromark::{Options, RenderPolicy};
 
-let options = Options {
-    render_policy: RenderPolicy::Trusted,
-    ..Options::default()
-};
+let mut options = Options::default();
+options.render_policy = RenderPolicy::Trusted;
 let html = ferromark::to_html_with_options(trusted_markdown, &options);
 ```
 
 `disallowed_raw_html` implements the narrower GFM tag filter in trusted mode. It is not a general-purpose HTML sanitizer and does not make arbitrary raw HTML safe by itself.
 
-Upgrading from an older release? See the
+Upgrading from an older release? See the [0.8 migration guide](docs/migration-0.8.md)
+for the `Options` and event-match migration, the
 [0.2 migration guide](docs/migration-0.2.md) for the rendering default and the
 fallible UTF-8 and MDX APIs, and the
 [0.3 migration guide](docs/migration-0.3.md) for removed Cargo features and the

--- a/benches/footnotes.rs
+++ b/benches/footnotes.rs
@@ -24,10 +24,8 @@ fn document_with_distinct_footnotes(count: usize) -> String {
 }
 
 fn benchmark_footnote_scaling(c: &mut Criterion) {
-    let options = Options {
-        footnotes: true,
-        ..Options::default()
-    };
+    let options = ferromark::options!(Options::default();
+        footnotes: true,);
     let mut group = c.benchmark_group("footnotes/distinct_references");
     group.sample_size(10);
 

--- a/benches/options.rs
+++ b/benches/options.rs
@@ -25,7 +25,7 @@ fn throughput(bytes: usize, seconds: f64) -> f64 { bytes as f64 / seconds }
 "#;
 
 fn all_extensions() -> Options {
-    Options {
+    ferromark::options!(Options::default();
         render_policy: RenderPolicy::Untrusted,
         allow_html: true,
         allow_link_refs: true,
@@ -48,27 +48,20 @@ fn all_extensions() -> Options {
         definition_lists: true,
         line_comments: true,
         indented_code_blocks: true,
-        link_base_path: None,
-    }
+        link_base_path: None,)
 }
 
 fn options_cost_benches(c: &mut Criterion) {
     let input = SHARED_SECTION.repeat(96);
     let mut group = c.benchmark_group("options/shared_corpus");
     group.throughput(Throughput::Bytes(input.len() as u64));
-    let table_column_widths = Options {
-        table_column_widths: true,
-        ..Options::default()
-    };
+    let table_column_widths = ferromark::options!(Options::default();
+        table_column_widths: true,);
 
-    let merged_table_cells = Options {
-        merged_table_cells: true,
-        ..Options::default()
-    };
-    let inline_footnotes = Options {
-        inline_footnotes: true,
-        ..Options::default()
-    };
+    let merged_table_cells = ferromark::options!(Options::default();
+        merged_table_cells: true,);
+    let inline_footnotes = ferromark::options!(Options::default();
+        inline_footnotes: true,);
 
     for (name, options) in [
         ("minimal", Options::minimal()),
@@ -80,24 +73,18 @@ fn options_cost_benches(c: &mut Criterion) {
         ("default_inline_footnotes", inline_footnotes),
         (
             "default_definition_lists",
-            Options {
-                definition_lists: true,
-                ..Options::default()
-            },
+            ferromark::options!(Options::default();
+                definition_lists: true,),
         ),
         (
             "default_line_comments",
-            Options {
-                line_comments: true,
-                ..Options::default()
-            },
+            ferromark::options!(Options::default();
+                line_comments: true,),
         ),
         (
             "default_no_indented_code",
-            Options {
-                indented_code_blocks: false,
-                ..Options::default()
-            },
+            ferromark::options!(Options::default();
+                indented_code_blocks: false,),
         ),
         ("all_extensions", all_extensions()),
     ] {

--- a/benches/parsing.rs
+++ b/benches/parsing.rs
@@ -187,10 +187,8 @@ fn bench_extensions(c: &mut Criterion) {
 
     let mut group = c.benchmark_group("extensions");
 
-    let deflist_options = Options {
-        definition_lists: true,
-        ..Options::gfm()
-    };
+    let deflist_options = ferromark::options!(Options::gfm();
+        definition_lists: true,);
     group.throughput(Throughput::Bytes(samples::DEFLISTS_5K.len() as u64));
     group.bench_function("deflists_5k", |b| {
         b.iter(|| {
@@ -198,11 +196,9 @@ fn bench_extensions(c: &mut Criterion) {
         })
     });
 
-    let merged_options = Options {
+    let merged_options = ferromark::options!(Options::gfm();
         merged_table_cells: true,
-        table_column_widths: true,
-        ..Options::gfm()
-    };
+        table_column_widths: true,);
     group.throughput(Throughput::Bytes(samples::TABLES_MERGED_5K.len() as u64));
     group.bench_function("tables_merged_5k", |b| {
         b.iter(|| {
@@ -210,7 +206,7 @@ fn bench_extensions(c: &mut Criterion) {
         })
     });
 
-    let all_options = Options {
+    let all_options = ferromark::options!(Options::default();
         render_policy: RenderPolicy::Untrusted,
         allow_html: true,
         allow_link_refs: true,
@@ -233,8 +229,7 @@ fn bench_extensions(c: &mut Criterion) {
         definition_lists: true,
         line_comments: true,
         indented_code_blocks: true,
-        link_base_path: None,
-    };
+        link_base_path: None,);
     group.throughput(Throughput::Bytes(samples::MIXED_EXTENDED_5K.len() as u64));
     group.bench_function("mixed_extended_5k", |b| {
         b.iter(|| {

--- a/benchmarks/md4c-comparison/benches/comparison.rs
+++ b/benchmarks/md4c-comparison/benches/comparison.rs
@@ -206,11 +206,9 @@ to handle longer documents efficiently.
 /// extras (heading IDs, callouts) off so every parser performs the same work.
 /// pulldown-cmark, md4c, and comrak generate no heading IDs in this setup.
 fn ferromark_comparison_options() -> ferromark::Options {
-    ferromark::Options {
+    ferromark::options!(ferromark::Options::default();
         heading_ids: false,
-        callouts: false,
-        ..Default::default()
-    }
+        callouts: false,)
 }
 
 /// Parse with ferromark

--- a/benchmarks/pulldown-comparison/src/lib.rs
+++ b/benchmarks/pulldown-comparison/src/lib.rs
@@ -31,7 +31,7 @@ pub fn ferromark_options(config: ParityConfig) -> FerromarkOptions {
         ParityConfig::ExtendedOverlap => (true, true, true, true, true, true, true),
     };
 
-    FerromarkOptions {
+    ferromark::options!(FerromarkOptions::default();
         render_policy: RenderPolicy::Trusted,
         allow_html: true,
         allow_link_refs: true,
@@ -55,7 +55,7 @@ pub fn ferromark_options(config: ParityConfig) -> FerromarkOptions {
         line_comments: false,
         indented_code_blocks: true,
         link_base_path: None,
-    }
+    )
 }
 
 /// Return the explicit pulldown-cmark options for a parity configuration.

--- a/benchmarks/pulldown-comparison/src/model.rs
+++ b/benchmarks/pulldown-comparison/src/model.rs
@@ -128,10 +128,8 @@ impl RunConfig {
             Self::MinimalSecure => Options::minimal(),
             Self::MinimalTrusted => trusted(Options::minimal()),
             Self::DefaultSecure => Options::default(),
-            Self::DefaultSecureNoHeadingIds => Options {
-                heading_ids: false,
-                ..Options::default()
-            },
+            Self::DefaultSecureNoHeadingIds => ferromark::options!(Options::default();
+                heading_ids: false,),
             Self::DefaultTrusted => trusted(Options::default()),
             Self::AllExtensionsSecure => all_extensions(),
             Self::AllExtensionsTrusted => trusted(all_extensions()),
@@ -168,14 +166,12 @@ impl FromStr for RunConfig {
 }
 
 fn trusted(options: Options) -> Options {
-    Options {
-        render_policy: RenderPolicy::Trusted,
-        ..options
-    }
+    ferromark::options!(options;
+        render_policy: RenderPolicy::Trusted,)
 }
 
 fn all_extensions() -> Options {
-    Options {
+    ferromark::options!(Options::default();
         render_policy: RenderPolicy::Untrusted,
         allow_html: true,
         allow_link_refs: true,
@@ -198,8 +194,7 @@ fn all_extensions() -> Options {
         definition_lists: true,
         line_comments: true,
         indented_code_blocks: true,
-        link_base_path: None,
-    }
+        link_base_path: None,)
 }
 
 #[cfg(test)]
@@ -235,10 +230,8 @@ mod tests {
         assert!(enabled.heading_ids);
         assert!(!disabled.heading_ids);
         assert_eq!(
-            Options {
-                heading_ids: false,
-                ..enabled
-            },
+            ferromark::options!(enabled;
+                heading_ids: false,),
             disabled
         );
     }

--- a/docs/migration-0.2.md
+++ b/docs/migration-0.2.md
@@ -21,10 +21,8 @@ Content you fully control can opt into raw HTML passthrough:
 ```rust
 use ferromark::{Options, RenderPolicy};
 
-let options = Options {
-    render_policy: RenderPolicy::Trusted,
-    ..Options::default()
-};
+let options = ferromark::options!(Options::default();
+    render_policy: RenderPolicy::Trusted,);
 let html = ferromark::to_html_with_options(trusted_markdown, &options);
 ```
 

--- a/docs/migration-0.8.md
+++ b/docs/migration-0.8.md
@@ -1,0 +1,53 @@
+# Migrating to ferromark 0.8
+
+Version 0.8 makes ferromark's public `Options` and event/type enums
+forward-compatible before 1.0. This is an intentional pre-1.0 breaking API
+change: update option construction and exhaustive enum matches as below.
+
+## Configure non-exhaustive options from a preset
+
+`Options` is now `#[non_exhaustive]`. Rust consequently rejects all external
+struct literals, including the former update form:
+
+```rust,ignore
+let options = Options {
+    heading_ids: false,
+    ..Options::default()
+};
+```
+
+Start from a preset and mutate its public fields instead:
+
+```rust
+use ferromark::Options;
+
+let mut options = Options::default();
+options.heading_ids = false;
+```
+
+For several updates, `ferromark::options!` is a compact equivalent:
+
+```rust
+use ferromark::Options;
+
+let options = ferromark::options!(Options::gfm();
+    front_matter: true,
+    allow_html: false,
+);
+```
+
+## Add fallback arms to public enum matches
+
+Public parser, rendering, autolink, and MDX enums are also
+`#[non_exhaustive]`. Add a wildcard arm so future variants can be handled
+without another source-breaking release:
+
+```rust
+use ferromark::RenderPolicy;
+
+let label = match RenderPolicy::Untrusted {
+    RenderPolicy::Untrusted => "untrusted",
+    _ => "future policy",
+};
+assert_eq!(label, "untrusted");
+```

--- a/examples/mdx_segment.rs
+++ b/examples/mdx_segment.rs
@@ -57,6 +57,9 @@ cargo add ferromark
                 println!("[{i}] Expression");
                 println!("    {}", s.trim());
             }
+            _ => {
+                println!("[{i}] Unsupported segment");
+            }
         }
         println!();
     }

--- a/examples/profile_harness.rs
+++ b/examples/profile_harness.rs
@@ -18,7 +18,7 @@ use std::hint::black_box;
 use ferromark::{Options, RenderPolicy};
 
 fn all_extensions() -> Options {
-    Options {
+    ferromark::options!(Options::default();
         render_policy: RenderPolicy::Untrusted,
         allow_html: true,
         allow_link_refs: true,
@@ -41,8 +41,7 @@ fn all_extensions() -> Options {
         definition_lists: true,
         line_comments: true,
         indented_code_blocks: true,
-        link_base_path: None,
-    }
+        link_base_path: None,)
 }
 
 fn preset(name: &str) -> Options {
@@ -52,64 +51,36 @@ fn preset(name: &str) -> Options {
         "gfm" => Options::gfm(),
         "default" => Options::default(),
         "all" => all_extensions(),
-        "gfm-deflists" => Options {
-            definition_lists: true,
-            ..Options::gfm()
-        },
-        "gfm-merged" => Options {
-            merged_table_cells: true,
-            ..Options::gfm()
-        },
-        "gfm-widths" => Options {
-            table_column_widths: true,
-            ..Options::gfm()
-        },
-        "gfm-footnotes" => Options {
+        "gfm-deflists" => ferromark::options!(Options::gfm();
+            definition_lists: true,),
+        "gfm-merged" => ferromark::options!(Options::gfm();
+            merged_table_cells: true,),
+        "gfm-widths" => ferromark::options!(Options::gfm();
+            table_column_widths: true,),
+        "gfm-footnotes" => ferromark::options!(Options::gfm();
             footnotes: true,
-            inline_footnotes: true,
-            ..Options::gfm()
-        },
-        "cm+tables" => Options {
-            tables: true,
-            ..Options::commonmark()
-        },
-        "cm+autolink" => Options {
-            autolink_literals: true,
-            ..Options::commonmark()
-        },
-        "cm+strike" => Options {
-            strikethrough: true,
-            ..Options::commonmark()
-        },
-        "cm+tasklists" => Options {
-            task_lists: true,
-            ..Options::commonmark()
-        },
-        "cm+disallowed" => Options {
-            disallowed_raw_html: true,
-            ..Options::commonmark()
-        },
-        "cm+headingids" => Options {
-            heading_ids: true,
-            ..Options::commonmark()
-        },
-        "cm+math" => Options {
-            math: true,
-            ..Options::commonmark()
-        },
-        "cm+highlight" => Options {
-            highlight: true,
-            ..Options::commonmark()
-        },
-        "cm+supsub" => Options {
+            inline_footnotes: true,),
+        "cm+tables" => ferromark::options!(Options::commonmark();
+            tables: true,),
+        "cm+autolink" => ferromark::options!(Options::commonmark();
+            autolink_literals: true,),
+        "cm+strike" => ferromark::options!(Options::commonmark();
+            strikethrough: true,),
+        "cm+tasklists" => ferromark::options!(Options::commonmark();
+            task_lists: true,),
+        "cm+disallowed" => ferromark::options!(Options::commonmark();
+            disallowed_raw_html: true,),
+        "cm+headingids" => ferromark::options!(Options::commonmark();
+            heading_ids: true,),
+        "cm+math" => ferromark::options!(Options::commonmark();
+            math: true,),
+        "cm+highlight" => ferromark::options!(Options::commonmark();
+            highlight: true,),
+        "cm+supsub" => ferromark::options!(Options::commonmark();
             superscript: true,
-            subscript: true,
-            ..Options::commonmark()
-        },
-        "cm+callouts" => Options {
-            callouts: true,
-            ..Options::commonmark()
-        },
+            subscript: true,),
+        "cm+callouts" => ferromark::options!(Options::commonmark();
+            callouts: true,),
         other => {
             eprintln!("unknown preset: {other}");
             std::process::exit(2);

--- a/src/block/event.rs
+++ b/src/block/event.rs
@@ -3,7 +3,10 @@
 use crate::Range;
 
 /// GitHub-style callout/admonition type.
+///
+/// Future releases may add callout types. Downstream matches must include a wildcard arm.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum CalloutType {
     /// Informational note.
     Note,
@@ -42,7 +45,10 @@ impl CalloutType {
 }
 
 /// Column alignment for table cells.
+///
+/// Future releases may add alignment modes. Downstream matches must include a wildcard arm.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[non_exhaustive]
 pub enum Alignment {
     /// No alignment specified.
     #[default]
@@ -56,7 +62,10 @@ pub enum Alignment {
 }
 
 /// The source form of a code block.
+///
+/// Future releases may add code-block forms. Downstream matches must include a wildcard arm.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum CodeBlockKind {
     /// A backtick- or tilde-fenced code block.
     Fenced {
@@ -68,7 +77,10 @@ pub enum CodeBlockKind {
 }
 
 /// Events emitted by the block parser.
+///
+/// Future releases may add events. Downstream matches must include a wildcard arm.
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum BlockEvent {
     /// Start of a paragraph.
     ParagraphStart,
@@ -209,7 +221,10 @@ pub enum BlockEvent {
 }
 
 /// Type of list.
+///
+/// Future releases may add list forms. Downstream matches must include a wildcard arm.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum ListKind {
     /// Unordered list (bullet points).
     Unordered,
@@ -223,7 +238,10 @@ pub enum ListKind {
 }
 
 /// Task list item state.
+///
+/// Future releases may add task states. Downstream matches must include a wildcard arm.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[non_exhaustive]
 pub enum TaskState {
     /// Not a task item.
     #[default]

--- a/src/inline/event.rs
+++ b/src/inline/event.rs
@@ -3,7 +3,10 @@
 use crate::Range;
 
 /// Events emitted by the inline parser.
+///
+/// Future releases may add events. Downstream matches must include a wildcard arm.
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum InlineEvent {
     /// Plain text content.
     Text(Range),

--- a/src/inline/links.rs
+++ b/src/inline/links.rs
@@ -838,7 +838,10 @@ fn is_email_autolink(content: &[u8]) -> bool {
 // ─── Autolink Literals (GFM extension) ───────────────────────────────────────
 
 /// Kind of autolink literal.
+///
+/// Future releases may add literal kinds. Downstream matches must include a wildcard arm.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum AutolinkLiteralKind {
     /// `http://` or `https://` or `ftp://` URL.
     Url,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -93,7 +93,10 @@ pub trait FencedCodeRenderer {
 }
 
 /// Trust boundary applied while rendering links, images, and raw HTML.
+///
+/// Future releases may add policies. Downstream matches must include a wildcard arm.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[non_exhaustive]
 pub enum RenderPolicy {
     /// Escape all raw HTML and allow only browser-safe URL schemes.
     #[default]
@@ -103,7 +106,22 @@ pub enum RenderPolicy {
 }
 
 /// Parsing/rendering options.
+///
+/// This struct is non-exhaustive so new options can be added without a breaking
+/// release. Outside ferromark, Rust rejects both complete and struct-update
+/// literals for non-exhaustive structs. Start with a preset and mutate the
+/// public fields instead:
+///
+/// ```
+/// use ferromark::Options;
+///
+/// let mut options = Options::default();
+/// options.heading_ids = false;
+/// ```
+///
+/// [`options!`] is a compact equivalent when several fields need changing.
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
 pub struct Options {
     /// Select the output trust boundary. Defaults to [`RenderPolicy::Untrusted`].
     pub render_policy: RenderPolicy,
@@ -302,6 +320,39 @@ impl Default for Options {
             link_base_path: None,
         }
     }
+}
+
+/// Create [`Options`] by applying public-field updates to a preset.
+///
+/// This is useful outside ferromark because [`Options`] is non-exhaustive and
+/// therefore cannot be constructed with a struct literal. It is equivalent to
+/// creating the preset, mutating each named public field, and returning it.
+///
+/// ```
+/// use ferromark::Options;
+///
+/// let options = ferromark::options!(Options::gfm();
+///     front_matter: true,
+///     allow_html: false,
+/// );
+/// assert!(options.front_matter);
+/// assert!(!options.allow_html);
+/// ```
+#[macro_export]
+macro_rules! options {
+    ($base:expr; $($field:ident $( : $value:expr )?),* $(,)?) => {{
+        let mut __ferromark_options = $base;
+        $(
+            $crate::options!(@set __ferromark_options, $field $(, $value)?);
+        )*
+        __ferromark_options
+    }};
+    (@set $options:ident, $field:ident, $value:expr) => {
+        $options.$field = $value
+    };
+    (@set $options:ident, $field:ident) => {
+        $options.$field = $field
+    };
 }
 
 /// Result of parsing Markdown with front matter extraction.

--- a/src/mdx/events.rs
+++ b/src/mdx/events.rs
@@ -29,7 +29,9 @@ pub const MDX_EVENT_STREAM_VERSION: u16 = 2;
 ///
 /// Ranges embedded in any event are absolute byte ranges into the original
 /// input passed to [`parse_events`](super::parse_events).
+/// Future releases may add events. Downstream matches must include a wildcard arm.
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum MdxEvent {
     /// Front matter including its opening and closing delimiter lines.
     FrontMatter {

--- a/src/mdx/mod.rs
+++ b/src/mdx/mod.rs
@@ -128,7 +128,9 @@ pub use events::{
 /// A typed segment of an MDX document.
 ///
 /// All variants are zero-copy `&str` slices into the original input.
+/// Future releases may add segment types. Downstream matches must include a wildcard arm.
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum Segment<'a> {
     /// ESM statement (`import` / `export`) — pass through unchanged.
     Esm(&'a str),
@@ -161,7 +163,10 @@ pub struct SpannedSegment<'a> {
 }
 
 /// A stable category for a structural MDX diagnostic.
+///
+/// Future releases may add diagnostic categories. Downstream matches must include a wildcard arm.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum MdxDiagnosticCode {
     /// A flow expression has no closing `}`.
     UnterminatedExpression,

--- a/src/mdx/render.rs
+++ b/src/mdx/render.rs
@@ -5,7 +5,10 @@ use crate::{Options, RenderPolicy};
 use super::{Segment, segment};
 
 /// Error returned when a component name cannot be used as a JavaScript binding.
+///
+/// Future releases may add validation failures. Downstream matches must include a wildcard arm.
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum ComponentNameError {
     /// The name is empty.
     Empty,

--- a/tests/callout_tests.rs
+++ b/tests/callout_tests.rs
@@ -5,10 +5,8 @@ fn html(input: &str) -> String {
 }
 
 fn html_no_callouts(input: &str) -> String {
-    let opts = Options {
-        callouts: false,
-        ..Options::default()
-    };
+    let opts = ferromark::options!(Options::default();
+        callouts: false,);
     to_html_with_options(input, &opts)
 }
 

--- a/tests/commonmark_spec.rs
+++ b/tests/commonmark_spec.rs
@@ -15,10 +15,8 @@ fn spec_to_html(input: &str) -> String {
 /// Full spec conformance requires raw-HTML passthrough, which only the
 /// trusted rendering policy provides.
 fn spec_to_html_trusted(input: &str) -> String {
-    let options = Options {
-        render_policy: RenderPolicy::Trusted,
-        ..Options::commonmark()
-    };
+    let options = ferromark::options!(Options::commonmark();
+        render_policy: RenderPolicy::Trusted,);
     to_html_with_options(input, &options)
 }
 

--- a/tests/definition_list_tests.rs
+++ b/tests/definition_list_tests.rs
@@ -1,10 +1,8 @@
 use ferromark::{BlockEvent, BlockParser, Options, to_html_with_options};
 
 fn options() -> Options {
-    Options {
-        definition_lists: true,
-        ..Options::default()
-    }
+    ferromark::options!(Options::default();
+        definition_lists: true,)
 }
 
 fn render(input: &str) -> String {

--- a/tests/document_api_tests.rs
+++ b/tests/document_api_tests.rs
@@ -63,10 +63,8 @@ fn parse_setext_headings_are_collected() {
 }
 
 fn base_options(base: &str) -> Options {
-    Options {
-        link_base_path: Some(base.into()),
-        ..Options::default()
-    }
+    ferromark::options!(Options::default();
+        link_base_path: Some(base.into()),)
 }
 
 #[test]
@@ -142,10 +140,8 @@ fn link_base_path_is_attribute_escaped() {
 #[test]
 fn parse_heading_text_survives_trusted_raw_html_with_quoted_gt() {
     use ferromark::RenderPolicy;
-    let options = Options {
-        render_policy: RenderPolicy::Trusted,
-        ..Options::default()
-    };
+    let options = ferromark::options!(Options::default();
+        render_policy: RenderPolicy::Trusted,);
     let result = ferromark::parse_with_options("# <span title=\"a>b\">Text</span>\n", &options);
 
     assert_eq!(result.headings[0].text, "Text");

--- a/tests/footnote_tests.rs
+++ b/tests/footnote_tests.rs
@@ -1,10 +1,8 @@
 use ferromark::{Options, to_html_with_options};
 
 fn opts() -> Options {
-    Options {
-        footnotes: true,
-        ..Options::default()
-    }
+    ferromark::options!(Options::default();
+        footnotes: true,)
 }
 
 fn render(input: &str) -> String {
@@ -132,10 +130,8 @@ fn duplicate_definition_first_wins() {
 
 #[test]
 fn footnotes_disabled_literal() {
-    let opts = Options {
-        footnotes: false,
-        ..Options::default()
-    };
+    let opts = ferromark::options!(Options::default();
+        footnotes: false,);
     let result = to_html_with_options("Text[^1].\n\n[^1]: Content.", &opts);
     assert!(
         !result.contains("<sup>"),

--- a/tests/front_matter_tests.rs
+++ b/tests/front_matter_tests.rs
@@ -85,10 +85,8 @@ fn crlf_line_endings() {
 
 #[test]
 fn to_html_with_front_matter_strips() {
-    let options = Options {
-        front_matter: true,
-        ..Options::default()
-    };
+    let options = ferromark::options!(Options::default();
+        front_matter: true,);
     let html = to_html_with_options("---\ntitle: Hello\n---\n# Content", &options);
     assert!(html.contains("Content</h1>"));
     assert!(!html.contains("title"));

--- a/tests/gfm_autolink_tests.rs
+++ b/tests/gfm_autolink_tests.rs
@@ -1,10 +1,8 @@
 use ferromark::{Options, to_html_with_options};
 
 fn autolink_html(input: &str) -> String {
-    let options = Options {
-        autolink_literals: true,
-        ..Options::default()
-    };
+    let options = ferromark::options!(Options::default();
+        autolink_literals: true,);
     to_html_with_options(input, &options)
 }
 
@@ -107,10 +105,8 @@ fn no_autolink_for_at_only() {
 #[test]
 fn autolink_disabled() {
     let input = "http://google.com";
-    let options = Options {
-        autolink_literals: false,
-        ..Options::default()
-    };
+    let options = ferromark::options!(Options::default();
+        autolink_literals: false,);
     let result = to_html_with_options(input, &options);
     assert!(
         !result.contains("<a"),

--- a/tests/gfm_disallowed_html_tests.rs
+++ b/tests/gfm_disallowed_html_tests.rs
@@ -3,10 +3,8 @@ use ferromark::{Options, RenderPolicy, to_html_with_options};
 fn to_html(input: &str) -> String {
     to_html_with_options(
         input,
-        &Options {
-            render_policy: RenderPolicy::Trusted,
-            ..Options::default()
-        },
+        &ferromark::options!(Options::default();
+            render_policy: RenderPolicy::Trusted,),
     )
 }
 
@@ -129,11 +127,9 @@ fn self_closing_disallowed_tag() {
 fn disallowed_html_disabled() {
     let result = to_html_with_options(
         "foo <script>alert('xss')</script> bar",
-        &Options {
+        &ferromark::options!(Options::default();
             render_policy: RenderPolicy::Trusted,
-            disallowed_raw_html: false,
-            ..Options::default()
-        },
+            disallowed_raw_html: false,),
     );
     assert_eq!(result, "<p>foo <script>alert('xss')</script> bar</p>\n");
 }

--- a/tests/gfm_strikethrough_tests.rs
+++ b/tests/gfm_strikethrough_tests.rs
@@ -86,10 +86,8 @@ fn double_tilde_strikethrough() {
 fn strikethrough_disabled() {
     let result = to_html_with_options(
         "~~test~~",
-        &Options {
-            strikethrough: false,
-            ..Options::default()
-        },
+        &ferromark::options!(Options::default();
+            strikethrough: false,),
     );
     assert_eq!(result, "<p>~~test~~</p>\n");
 }

--- a/tests/gfm_table_tests.rs
+++ b/tests/gfm_table_tests.rs
@@ -153,10 +153,8 @@ fn table_terminated_by_thematic_break() {
 #[test]
 fn table_disabled_via_options() {
     let input = "| a | b |\n| - | - |\n| c | d |\n";
-    let options = Options {
-        tables: false,
-        ..Options::default()
-    };
+    let options = ferromark::options!(Options::default();
+        tables: false,);
     let result = to_html_with_options(input, &options);
     // Without tables, this should be a paragraph (with thematic break from ---)
     assert!(
@@ -212,10 +210,8 @@ fn delimiter_left_alignment() {
 // === Opt-in relative column-width hints ===
 
 fn table_width_options() -> Options {
-    Options {
-        table_column_widths: true,
-        ..Options::default()
-    }
+    ferromark::options!(Options::default();
+        table_column_widths: true,)
 }
 
 #[test]
@@ -282,11 +278,9 @@ fn rounded_column_widths_still_total_one_hundred_percent() {
 #[test]
 fn column_width_option_does_not_enable_tables() {
     let input = "| A | B |\n| -- | ---- |\n";
-    let options = Options {
+    let options = ferromark::options!(Options::default();
         tables: false,
-        table_column_widths: true,
-        ..Options::default()
-    };
+        table_column_widths: true,);
     let result = to_html_with_options(input, &options);
 
     assert!(!result.contains("<table>"));
@@ -432,10 +426,8 @@ fn cmark_ext_embedded_html_in_cells() {
     assert_eq!(
         to_html_with_options(
             input,
-            &Options {
-                render_policy: RenderPolicy::Trusted,
-                ..Options::default()
-            }
+            &ferromark::options!(Options::default();
+                render_policy: RenderPolicy::Trusted,)
         ),
         expected
     );

--- a/tests/gfm_task_list_tests.rs
+++ b/tests/gfm_task_list_tests.rs
@@ -49,9 +49,7 @@ fn task_list_disabled() {
 
     let input = "- [ ] foo\n- [x] bar";
     let expected = "<ul>\n<li>[ ] foo</li>\n<li>[x] bar</li>\n</ul>\n";
-    let options = Options {
-        task_lists: false,
-        ..Options::default()
-    };
+    let options = ferromark::options!(Options::default();
+        task_lists: false,);
     assert_eq!(to_html_with_options(input, &options), expected);
 }

--- a/tests/heading_id_tests.rs
+++ b/tests/heading_id_tests.rs
@@ -1,18 +1,14 @@
 use ferromark::{Options, to_html, to_html_with_options};
 
 fn html_with_ids(input: &str) -> String {
-    let options = Options {
-        heading_ids: true,
-        ..Options::default()
-    };
+    let options = ferromark::options!(Options::default();
+        heading_ids: true,);
     to_html_with_options(input, &options)
 }
 
 fn html_without_ids(input: &str) -> String {
-    let options = Options {
-        heading_ids: false,
-        ..Options::default()
-    };
+    let options = ferromark::options!(Options::default();
+        heading_ids: false,);
     to_html_with_options(input, &options)
 }
 

--- a/tests/highlight_tests.rs
+++ b/tests/highlight_tests.rs
@@ -3,22 +3,18 @@ use ferromark::{Options, to_html_with_options};
 fn highlight_html(input: &str) -> String {
     to_html_with_options(
         input,
-        &Options {
+        &ferromark::options!(Options::default();
             highlight: true,
-            heading_ids: false,
-            ..Options::default()
-        },
+            heading_ids: false,),
     )
 }
 
 fn no_highlight_html(input: &str) -> String {
     to_html_with_options(
         input,
-        &Options {
+        &ferromark::options!(Options::default();
             highlight: false,
-            heading_ids: false,
-            ..Options::default()
-        },
+            heading_ids: false,),
     )
 }
 

--- a/tests/indented_code_options_tests.rs
+++ b/tests/indented_code_options_tests.rs
@@ -3,10 +3,8 @@ use ferromark::{Options, to_html, to_html_with_options};
 fn without_indented_code(input: &str) -> String {
     to_html_with_options(
         input,
-        &Options {
-            indented_code_blocks: false,
-            ..Options::default()
-        },
+        &ferromark::options!(Options::default();
+            indented_code_blocks: false,),
     )
 }
 
@@ -62,11 +60,9 @@ fn blockquote_indented_code_falls_back_to_paragraph_when_disabled() {
 fn footnote_indented_code_falls_back_to_paragraph_when_disabled() {
     let result = to_html_with_options(
         "[^1]: note\n\n        nested\n\nText[^1].\n",
-        &Options {
+        &ferromark::options!(Options::default();
             footnotes: true,
-            indented_code_blocks: false,
-            ..Options::default()
-        },
+            indented_code_blocks: false,),
     );
 
     assert!(result.contains("<p>note</p>"), "{result}");

--- a/tests/inline_footnote_tests.rs
+++ b/tests/inline_footnote_tests.rs
@@ -1,10 +1,8 @@
 use ferromark::{InlineEvent, InlineParser, Options, to_html_with_options};
 
 fn options() -> Options {
-    Options {
-        inline_footnotes: true,
-        ..Options::default()
-    }
+    ferromark::options!(Options::default();
+        inline_footnotes: true,)
 }
 
 fn render(input: &str) -> String {
@@ -49,11 +47,9 @@ Reference.[^ref]
 [^ref]: Second.";
     let html = to_html_with_options(
         input,
-        &Options {
+        &ferromark::options!(Options::default();
             footnotes: true,
-            inline_footnotes: true,
-            ..Options::default()
-        },
+            inline_footnotes: true,),
     );
 
     assert!(html.contains("data-footnote-ref>1</a></sup>"), "{html}");
@@ -67,11 +63,9 @@ Reference.[^ref]
 fn inline_notes_take_precedence_over_superscript() {
     let html = to_html_with_options(
         "2^10^ and a note.^[Content.]",
-        &Options {
+        &ferromark::options!(Options::default();
             superscript: true,
-            inline_footnotes: true,
-            ..Options::default()
-        },
+            inline_footnotes: true,),
     );
 
     assert!(html.contains("2<sup>10</sup>"), "{html}");
@@ -82,11 +76,9 @@ fn inline_notes_take_precedence_over_superscript() {
 fn whitespace_only_notes_do_not_capture_later_superscript_delimiters() {
     let html = to_html_with_options(
         "some text^[  ]^word^",
-        &Options {
+        &ferromark::options!(Options::default();
             superscript: true,
-            inline_footnotes: true,
-            ..Options::default()
-        },
+            inline_footnotes: true,),
     );
 
     assert_eq!(html, "<p>some text^[  ]<sup>word</sup></p>\n");

--- a/tests/line_comment_tests.rs
+++ b/tests/line_comment_tests.rs
@@ -3,10 +3,8 @@ use ferromark::{BlockEvent, BlockParser, Options, Range, RenderPolicy, to_html_w
 fn with_line_comments(input: &str) -> String {
     to_html_with_options(
         input,
-        &Options {
-            line_comments: true,
-            ..Options::default()
-        },
+        &ferromark::options!(Options::default();
+            line_comments: true,),
     )
 }
 
@@ -64,11 +62,9 @@ fn fenced_code_and_raw_html_blocks_remain_opaque() {
 
     let html = to_html_with_options(
         "<div>\n// html content\n</div>\n",
-        &Options {
+        &ferromark::options!(Options::default();
             line_comments: true,
-            render_policy: RenderPolicy::Trusted,
-            ..Options::default()
-        },
+            render_policy: RenderPolicy::Trusted,),
     );
     assert_eq!(html, "<div>\n// html content\n</div>\n");
 }
@@ -110,10 +106,8 @@ fn semantic_comment_events_keep_exact_source_order_and_range() {
     let input = "first\n// private\nsecond\n";
     let mut parser = BlockParser::new_with_options(
         input.as_bytes(),
-        Options {
-            line_comments: true,
-            ..Options::default()
-        },
+        ferromark::options!(Options::default();
+            line_comments: true,),
     );
     let mut events = Vec::new();
     parser.parse(&mut events);
@@ -140,10 +134,8 @@ fn crlf_comment_ranges_exclude_the_line_ending() {
     let input = "// private\r\nvisible\r\n";
     let mut parser = BlockParser::new_with_options(
         input.as_bytes(),
-        Options {
-            line_comments: true,
-            ..Options::default()
-        },
+        ferromark::options!(Options::default();
+            line_comments: true,),
     );
     let mut events = Vec::new();
     parser.parse(&mut events);
@@ -157,10 +149,8 @@ fn comments_before_link_reference_definitions_do_not_leak() {
     let input = "// private\n[target]: /url\n\nvisible\n";
     let mut parser = BlockParser::new_with_options(
         input.as_bytes(),
-        Options {
-            line_comments: true,
-            ..Options::default()
-        },
+        ferromark::options!(Options::default();
+            line_comments: true,),
     );
     let mut events = Vec::new();
     parser.parse(&mut events);

--- a/tests/math_tests.rs
+++ b/tests/math_tests.rs
@@ -1,20 +1,16 @@
 use ferromark::{Options, to_html_with_options};
 
 fn math_html(input: &str) -> String {
-    let options = Options {
+    let options = ferromark::options!(Options::default();
         math: true,
-        heading_ids: false,
-        ..Options::default()
-    };
+        heading_ids: false,);
     to_html_with_options(input, &options)
 }
 
 fn no_math_html(input: &str) -> String {
-    let options = Options {
+    let options = ferromark::options!(Options::default();
         math: false,
-        heading_ids: false,
-        ..Options::default()
-    };
+        heading_ids: false,);
     to_html_with_options(input, &options)
 }
 

--- a/tests/mdx_segment_tests.rs
+++ b/tests/mdx_segment_tests.rs
@@ -1296,13 +1296,11 @@ yarn add ferromark
 #[test]
 fn render_with_custom_options() {
     let input = "# Heading\n\n~~struck~~\n";
-    let opts = Options {
+    let opts = ferromark::options!(Options::default();
         strikethrough: true,
         heading_ids: false,
         allow_html: true,
-        disallowed_raw_html: false,
-        ..Options::default()
-    };
+        disallowed_raw_html: false,);
     let out = render_with_options(input, &opts);
     assert!(out.body.contains("<del>struck</del>"));
     assert!(!out.body.contains("id="));

--- a/tests/merged_table_cell_tests.rs
+++ b/tests/merged_table_cell_tests.rs
@@ -1,11 +1,9 @@
 use ferromark::{BlockEvent, BlockParser, Options, to_html_with_options};
 
 fn options() -> Options {
-    Options {
+    ferromark::options!(Options::default();
         tables: true,
-        merged_table_cells: true,
-        ..Options::default()
-    }
+        merged_table_cells: true,)
 }
 
 fn render(input: &str) -> String {
@@ -82,12 +80,10 @@ fn merged_header_cells_participate_in_table_recognition() {
 
 #[test]
 fn merged_cells_compose_with_underlying_column_width_hints() {
-    let options = Options {
+    let options = ferromark::options!(Options::default();
         tables: true,
         merged_table_cells: true,
-        table_column_widths: true,
-        ..Options::default()
-    };
+        table_column_widths: true,);
     let html = to_html_with_options(
         "\
 | Group ||

--- a/tests/non_exhaustive_api_tests.rs
+++ b/tests/non_exhaustive_api_tests.rs
@@ -1,0 +1,148 @@
+//! Public API compatibility checks compiled as an external crate.
+
+use ferromark::block::{ListKind, TaskState};
+use ferromark::inline::AutolinkLiteralKind;
+use ferromark::{
+    Alignment, BlockEvent, CalloutType, CodeBlockKind, InlineEvent, Options, RenderPolicy,
+};
+
+#[test]
+fn downstream_can_customize_non_exhaustive_options_by_mutating_a_preset() {
+    let mut options = Options::default();
+    options.heading_ids = false;
+
+    assert!(!options.heading_ids);
+}
+
+#[test]
+fn downstream_can_customize_non_exhaustive_options_with_the_options_macro() {
+    let options = ferromark::options!(Options::default();
+        heading_ids: false,
+    );
+
+    assert!(!options.heading_ids);
+}
+
+#[test]
+fn downstream_event_matches_include_forward_compatible_fallbacks() {
+    assert_eq!(render_policy_label(RenderPolicy::Untrusted), "untrusted");
+    assert_eq!(callout_label(CalloutType::Note), "note");
+    assert_eq!(alignment_label(Alignment::Left), "left");
+    assert_eq!(code_block_label(CodeBlockKind::Indented), "indented");
+    assert_eq!(block_event_label(BlockEvent::ParagraphStart), "paragraph");
+    assert_eq!(list_label(ListKind::Unordered), "unordered");
+    assert_eq!(task_label(TaskState::Checked), "checked");
+    assert_eq!(inline_event_label(InlineEvent::SoftBreak), "soft-break");
+    assert_eq!(autolink_label(AutolinkLiteralKind::Url), "url");
+}
+
+fn render_policy_label(policy: RenderPolicy) -> &'static str {
+    match policy {
+        RenderPolicy::Untrusted => "untrusted",
+        _ => "other",
+    }
+}
+
+fn callout_label(callout: CalloutType) -> &'static str {
+    match callout {
+        CalloutType::Note => "note",
+        _ => "other",
+    }
+}
+
+fn alignment_label(alignment: Alignment) -> &'static str {
+    match alignment {
+        Alignment::Left => "left",
+        _ => "other",
+    }
+}
+
+fn code_block_label(kind: CodeBlockKind) -> &'static str {
+    match kind {
+        CodeBlockKind::Indented => "indented",
+        _ => "other",
+    }
+}
+
+fn block_event_label(event: BlockEvent) -> &'static str {
+    match event {
+        BlockEvent::ParagraphStart => "paragraph",
+        _ => "other",
+    }
+}
+
+fn list_label(kind: ListKind) -> &'static str {
+    match kind {
+        ListKind::Unordered => "unordered",
+        _ => "other",
+    }
+}
+
+fn task_label(state: TaskState) -> &'static str {
+    match state {
+        TaskState::Checked => "checked",
+        _ => "other",
+    }
+}
+
+fn inline_event_label(event: InlineEvent) -> &'static str {
+    match event {
+        InlineEvent::SoftBreak => "soft-break",
+        _ => "other",
+    }
+}
+
+fn autolink_label(kind: AutolinkLiteralKind) -> &'static str {
+    match kind {
+        AutolinkLiteralKind::Url => "url",
+        _ => "other",
+    }
+}
+
+#[cfg(feature = "mdx")]
+mod mdx {
+    use ferromark::mdx::render::ComponentNameError;
+    use ferromark::mdx::{MdxDiagnosticCode, MdxEvent, Segment};
+
+    #[test]
+    fn downstream_mdx_matches_include_forward_compatible_fallbacks() {
+        assert_eq!(segment_label(Segment::Markdown("markdown")), "markdown");
+        assert_eq!(
+            diagnostic_label(MdxDiagnosticCode::InvalidJsxTag),
+            "invalid-jsx"
+        );
+        assert_eq!(
+            event_label(MdxEvent::Esm(ferromark::Range::new(0, 0))),
+            "esm"
+        );
+        assert_eq!(error_label(ComponentNameError::Empty), "empty");
+    }
+
+    fn segment_label(segment: Segment<'_>) -> &'static str {
+        match segment {
+            Segment::Markdown(_) => "markdown",
+            _ => "other",
+        }
+    }
+
+    fn diagnostic_label(code: MdxDiagnosticCode) -> &'static str {
+        match code {
+            MdxDiagnosticCode::InvalidJsxTag => "invalid-jsx",
+            _ => "other",
+        }
+    }
+
+    fn event_label(event: MdxEvent) -> &'static str {
+        match event {
+            MdxEvent::Esm(_) => "esm",
+            _ => "other",
+        }
+    }
+
+    fn error_label(error: ComponentNameError) -> &'static str {
+        match error {
+            ComponentNameError::Empty => "empty",
+            _ => "other",
+        }
+    }
+}

--- a/tests/options_tests.rs
+++ b/tests/options_tests.rs
@@ -6,7 +6,7 @@ fn minimal_should_disable_every_optional_syntax_feature() {
 
     assert_eq!(
         options,
-        Options {
+        ferromark::options!(Options::default();
             render_policy: RenderPolicy::Untrusted,
             allow_html: false,
             allow_link_refs: false,
@@ -29,8 +29,7 @@ fn minimal_should_disable_every_optional_syntax_feature() {
             definition_lists: false,
             line_comments: false,
             indented_code_blocks: true,
-            link_base_path: None,
-        }
+            link_base_path: None,)
     );
 }
 
@@ -41,11 +40,9 @@ fn commonmark_should_enable_only_commonmark_syntax_boundaries() {
     assert!(options.allow_html && options.allow_link_refs);
     assert_eq!(
         options,
-        Options {
+        ferromark::options!(Options::minimal();
             allow_html: true,
-            allow_link_refs: true,
-            ..Options::minimal()
-        }
+            allow_link_refs: true,)
     );
 }
 
@@ -55,14 +52,12 @@ fn gfm_should_extend_commonmark_with_exact_gfm_extensions() {
 
     assert_eq!(
         options,
-        Options {
+        ferromark::options!(Options::commonmark();
             tables: true,
             strikethrough: true,
             task_lists: true,
             autolink_literals: true,
-            disallowed_raw_html: true,
-            ..Options::commonmark()
-        }
+            disallowed_raw_html: true,)
     );
 }
 
@@ -77,7 +72,7 @@ fn syntax_presets_should_keep_untrusted_rendering() {
 fn default_should_retain_the_existing_feature_mix() {
     assert_eq!(
         Options::default(),
-        Options {
+        ferromark::options!(Options::default();
             render_policy: RenderPolicy::Untrusted,
             allow_html: true,
             allow_link_refs: true,
@@ -100,8 +95,7 @@ fn default_should_retain_the_existing_feature_mix() {
             definition_lists: false,
             line_comments: false,
             indented_code_blocks: true,
-            link_base_path: None,
-        }
+            link_base_path: None,)
     );
 }
 
@@ -127,10 +121,8 @@ fn commonmark_should_parse_html_without_implicitly_trusting_it() {
     let untrusted = to_html_with_options(markdown, &Options::commonmark());
     let trusted = to_html_with_options(
         markdown,
-        &Options {
-            render_policy: RenderPolicy::Trusted,
-            ..Options::commonmark()
-        },
+        &ferromark::options!(Options::commonmark();
+            render_policy: RenderPolicy::Trusted,),
     );
 
     assert_eq!(untrusted, "&lt;div&gt;content&lt;/div&gt;");

--- a/tests/resource_limits_tests.rs
+++ b/tests/resource_limits_tests.rs
@@ -200,10 +200,8 @@ fn table_columns_are_bounded() {
     let markdown = format!("| {header} |\n| {delimiter} |\n");
     let html = to_html_with_options(
         &markdown,
-        &Options {
-            tables: true,
-            ..Options::default()
-        },
+        &ferromark::options!(Options::default();
+            tables: true,),
     );
 
     assert_eq!(html.matches("<th>").count(), limits::MAX_TABLE_COLUMNS);

--- a/tests/subscript_tests.rs
+++ b/tests/subscript_tests.rs
@@ -3,22 +3,18 @@ use ferromark::{Options, to_html_with_options};
 fn subscript_html(input: &str) -> String {
     to_html_with_options(
         input,
-        &Options {
+        &ferromark::options!(Options::default();
             subscript: true,
-            heading_ids: false,
-            ..Options::default()
-        },
+            heading_ids: false,),
     )
 }
 
 fn no_subscript_html(input: &str) -> String {
     to_html_with_options(
         input,
-        &Options {
+        &ferromark::options!(Options::default();
             subscript: false,
-            heading_ids: false,
-            ..Options::default()
-        },
+            heading_ids: false,),
     )
 }
 

--- a/tests/superscript_tests.rs
+++ b/tests/superscript_tests.rs
@@ -3,22 +3,18 @@ use ferromark::{Options, to_html_with_options};
 fn superscript_html(input: &str) -> String {
     to_html_with_options(
         input,
-        &Options {
+        &ferromark::options!(Options::default();
             superscript: true,
-            heading_ids: false,
-            ..Options::default()
-        },
+            heading_ids: false,),
     )
 }
 
 fn no_superscript_html(input: &str) -> String {
     to_html_with_options(
         input,
-        &Options {
+        &ferromark::options!(Options::default();
             superscript: false,
-            heading_ids: false,
-            ..Options::default()
-        },
+            heading_ids: false,),
     )
 }
 
@@ -97,12 +93,10 @@ fn superscript_does_not_parse_in_link_destinations() {
 fn superscript_does_not_break_footnote_refs() {
     let result = to_html_with_options(
         "[^fn] and 2^2^\n\n[^fn]: Footnote",
-        &Options {
+        &ferromark::options!(Options::default();
             superscript: true,
             footnotes: true,
-            heading_ids: false,
-            ..Options::default()
-        },
+            heading_ids: false,),
     );
 
     assert!(result.contains("<sup>2</sup>"), "{result}");

--- a/tests/untrusted_rendering_tests.rs
+++ b/tests/untrusted_rendering_tests.rs
@@ -49,10 +49,8 @@ fn default_policy_keeps_safe_and_relative_urls() {
 fn literal_autolinks_use_the_untrusted_policy_path() {
     let html = to_html_with_options(
         "https://example.com",
-        &Options {
-            autolink_literals: true,
-            ..Options::default()
-        },
+        &ferromark::options!(Options::default();
+            autolink_literals: true,),
     );
 
     assert!(html.contains("href=\"https://example.com\""));
@@ -62,11 +60,9 @@ fn literal_autolinks_use_the_untrusted_policy_path() {
 fn trusted_policy_is_an_explicit_passthrough_boundary() {
     let html = to_html_with_options(
         "<span onclick=\"run()\">ok</span> [custom](app:open)",
-        &Options {
+        &ferromark::options!(Options::default();
             render_policy: RenderPolicy::Trusted,
-            disallowed_raw_html: false,
-            ..Options::default()
-        },
+            disallowed_raw_html: false,),
     );
 
     assert!(html.contains("<span onclick=\"run()\">"));


### PR DESCRIPTION
## Summary
- Marks `Options` and all twelve relevant public parser, rendering, autolink, and MDX enums `#[non_exhaustive]` before 1.0.
- Replaces external `Options` struct literals with preset mutation and the compact `ferromark::options!` macro across documentation, examples, tests, and benchmarks.
- Adds the 0.8 migration guide and README/rustdoc guidance: Rust rejects external literals, including struct-update literals, for non-exhaustive structs; public enum matches now need a fallback arm.
- Adds external-consumer API coverage for Options configuration plus all enum families in default and `mdx` configurations.

## Breaking change
This intentional pre-1.0 API break makes `Options` non-exhaustive and requires downstream enum matches to include a wildcard. Configure a preset by mutating its public fields or with `ferromark::options!`; see [the 0.8 migration guide](docs/migration-0.8.md). The commit uses `feat(api)!` and includes a `BREAKING CHANGE` footer for release tooling.

## Testing
- `cargo test --locked --test non_exhaustive_api_tests`
- `cargo test --locked --all-features --test non_exhaustive_api_tests`
- `cargo test --manifest-path benchmarks/pulldown-comparison/Cargo.toml --locked`
- `cargo test --workspace --locked --all-features`
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- `cargo doc --workspace --all-features --locked --no-deps`
- `cargo test --doc --all-features --locked`
- `cargo fmt --all -- --check`
- `./scripts/check-workflow-pins.sh`
- `git diff --check`

Fixes #147

🔧 Emily Carter · Implementation Agent