### PR TITLE
test(ci): run Node bindings on native targets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,7 @@ jobs:
           components: rustfmt
       - run: cargo fmt --check
       - run: ./scripts/test-check-workflow-pins.sh
+      - run: ruby ./scripts/test-node-ci-matrix.rb
       - run: ./scripts/check-workflow-pins.sh
 
   rustsec:
@@ -113,15 +114,22 @@ jobs:
       - run: pnpm pack:check
       - run: pnpm smoke:clean
 
-  native-windows:
+  native:
+    # Each target is built and loaded on a runner with the same architecture;
+    # this is runtime coverage, not a cross-compilation-only check.
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
       matrix:
         include:
+          - { os: macos-latest, rust_target: aarch64-apple-darwin }
+          - { os: macos-15-intel, rust_target: x86_64-apple-darwin }
+          - { os: ubuntu-24.04-arm, rust_target: aarch64-unknown-linux-gnu }
           - { os: windows-latest, rust_target: x86_64-pc-windows-msvc }
           - { os: windows-11-arm, rust_target: aarch64-pc-windows-msvc }
     runs-on: ${{ matrix.os }}
-    name: native Windows (${{ matrix.rust_target }})
+    name: native (${{ matrix.rust_target }})
     defaults:
       run:
         working-directory: node
@@ -143,3 +151,5 @@ jobs:
       - run: pnpm build:native
         env:
           FERROMARK_RUST_TARGET: ${{ matrix.rust_target }}
+      - name: Test native package
+        run: pnpm test

--- a/scripts/test-node-ci-matrix.rb
+++ b/scripts/test-node-ci-matrix.rb
@@ -1,0 +1,37 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require 'yaml'
+
+workflow_path = File.expand_path('../.github/workflows/ci.yml', __dir__)
+workflow = YAML.safe_load(File.read(workflow_path), aliases: false)
+native = workflow.fetch('jobs').fetch('native')
+
+unless native.fetch('permissions') == { 'contents' => 'read' }
+  abort 'native CI job must use contents: read permissions only'
+end
+
+expected_targets = [
+  { 'os' => 'macos-latest', 'rust_target' => 'aarch64-apple-darwin' },
+  { 'os' => 'macos-15-intel', 'rust_target' => 'x86_64-apple-darwin' },
+  { 'os' => 'ubuntu-24.04-arm', 'rust_target' => 'aarch64-unknown-linux-gnu' },
+  { 'os' => 'windows-latest', 'rust_target' => 'x86_64-pc-windows-msvc' },
+  { 'os' => 'windows-11-arm', 'rust_target' => 'aarch64-pc-windows-msvc' }
+]
+actual_targets = native.fetch('strategy').fetch('matrix').fetch('include')
+
+unless actual_targets == expected_targets
+  abort "native CI matrix must execute the supported macOS, Linux arm64, and Windows targets"
+end
+
+steps = native.fetch('steps')
+build_index = steps.index { |step| step['run'] == 'pnpm build:native' }
+test_index = steps.index { |step| step['run'] == 'pnpm test' }
+
+abort 'native CI job must build the N-API binding' unless build_index
+unless steps.fetch(build_index).fetch('env') == { 'FERROMARK_RUST_TARGET' => '${{ matrix.rust_target }}' }
+  abort 'native CI job must build the N-API binding for the matrix target'
+end
+abort 'native CI job must run pnpm test after building the N-API binding' unless test_index && test_index > build_index
+
+puts 'native CI matrix checks passed'

--- a/scripts/test-node-ci-matrix.rb
+++ b/scripts/test-node-ci-matrix.rb
@@ -7,6 +7,10 @@ workflow_path = File.expand_path('../.github/workflows/ci.yml', __dir__)
 workflow = YAML.safe_load(File.read(workflow_path), aliases: false)
 native = workflow.fetch('jobs').fetch('native')
 
+unless native.fetch('runs-on') == '${{ matrix.os }}'
+  abort 'native CI job must run on the operating system selected by the matrix'
+end
+
 unless native.fetch('permissions') == { 'contents' => 'read' }
   abort 'native CI job must use contents: read permissions only'
 end


### PR DESCRIPTION
## Summary
- Replaces the Windows-only native build check with a native-host matrix for macOS arm64, macOS Intel, Linux arm64, Windows x64, and Windows arm64.
- Runs `pnpm test` immediately after every target-matched `pnpm build:native`, so each matrix entry loads and exercises the produced N-API addon rather than merely compiling it.
- Adds a Ruby static check for the exact runner/target matrix, least-privilege `contents: read`, target wiring, and build-before-test order; CI runs it alongside workflow-pin checks.

## Testing
- `pnpm install --frozen-lockfile`
- `pnpm build`
- `pnpm test`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm pack:check`
- `pnpm smoke:clean`
- `cargo fmt --all -- --check`
- `cargo test --workspace --locked --all-features`
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- `ruby ./scripts/test-node-ci-matrix.rb`
- `./scripts/test-check-workflow-pins.sh`
- `./scripts/check-workflow-pins.sh`
- `git diff --check`

## Baseline
`pnpm audit --audit-level high` still reports the pre-existing `js-yaml@4.3.0` advisory through `@napi-rs/cli`; this PR does not modify Node dependencies.

Fixes #145

🔧 Emily Carter · Implementation Agent