### PR TITLE
fix: reject oversized inputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,9 @@ ferromark::to_html_into("# Reuse me", &mut buffer);
 
 ### Input-size limit
 
-Source ranges use compact `u32` byte offsets, so a document may contain at
-most 4,294,967,295 bytes. Use the fallible `try_*` entry points when input size
+Source positions use compact `u32` values, so a document may contain at most
+4,294,967,294 bytes. This keeps both byte offsets and one-based line/column
+values representable. Use the fallible `try_*` entry points when input size
 is not already bounded:
 
 ```rust

--- a/README.md
+++ b/README.md
@@ -34,6 +34,25 @@ ferromark::to_html_into("# Reuse me", &mut buffer);
 // buffer survives across calls — zero repeated allocation
 ```
 
+### Input-size limit
+
+Source ranges use compact `u32` byte offsets, so a document may contain at
+most 4,294,967,295 bytes. Use the fallible `try_*` entry points when input size
+is not already bounded:
+
+```rust
+fn main() -> Result<(), ferromark::InputSizeError> {
+    let markdown = "# Hello";
+    let html = ferromark::try_to_html(markdown)?;
+    assert!(html.contains("Hello"));
+    Ok(())
+}
+```
+
+`validate_input_size` is available when a caller needs to preflight a shared
+input before selecting an API. The legacy infallible APIs preserve their return
+types and panic with the same error if this limit is exceeded.
+
 ## Benchmarks
 
 Numbers, not adjectives. Apple Silicon (M-series), July 2026. All parsers run

--- a/node/ferromark/README.md
+++ b/node/ferromark/README.md
@@ -10,8 +10,8 @@ const html = toHtml('# Hello')
 
 ## Input size limit
 
-ferromark source ranges use `u32` byte offsets, so input is limited to
-4,294,967,295 bytes. Calls above that limit throw an `InvalidArg` native error
+ferromark source positions use compact `u32` values, so input is limited to
+4,294,967,294 bytes. Calls above that limit throw an `InvalidArg` native error
 instead of parsing with truncated source offsets.
 
 ## Syntax highlighting with Ferriki

--- a/node/ferromark/README.md
+++ b/node/ferromark/README.md
@@ -8,6 +8,12 @@ import { toHtml } from 'ferromark'
 const html = toHtml('# Hello')
 ```
 
+## Input size limit
+
+ferromark source ranges use `u32` byte offsets, so input is limited to
+4,294,967,295 bytes. Calls above that limit throw an `InvalidArg` native error
+instead of parsing with truncated source offsets.
+
 ## Syntax highlighting with Ferriki
 
 An initialized [Ferriki](https://github.com/sebastian-software/ferriki) highlighter plugs into the fenced-code renderer without coupling the two native cores:

--- a/node/native/src/lib.rs
+++ b/node/native/src/lib.rs
@@ -1,5 +1,6 @@
 use ferromark::{
-    FencedCodeBlock, FencedCodeRenderer, Options as CoreOptions, RenderPolicy, TrustedHtml,
+    FencedCodeBlock, FencedCodeRenderer, InputSizeError, Options as CoreOptions, RenderPolicy,
+    TrustedHtml,
 };
 use napi::bindgen_prelude::{Error, FnArgs, Function, Result, Status};
 use napi_derive::napi;
@@ -91,12 +92,14 @@ fn core_options(options: Option<Options>) -> Result<CoreOptions> {
     options.map_or_else(|| Ok(CoreOptions::default()), Options::into_core)
 }
 
+fn input_size_error(error: InputSizeError) -> Error {
+    Error::new(Status::InvalidArg, error.to_string())
+}
+
 #[napi(catch_unwind)]
 pub fn to_html(markdown: String, options: Option<Options>) -> Result<String> {
-    Ok(ferromark::to_html_with_options(
-        &markdown,
-        &core_options(options)?,
-    ))
+    ferromark::try_to_html_with_options(&markdown, &core_options(options)?)
+        .map_err(input_size_error)
 }
 
 /// One document heading, in source order.
@@ -141,9 +144,9 @@ fn transform_result(result: ferromark::ParseResult<'_>) -> TransformResult {
 #[napi(catch_unwind)]
 pub fn transform(markdown: String, options: Option<Options>) -> Result<TransformResult> {
     let options = core_options(options)?;
-    Ok(transform_result(ferromark::parse_with_options(
-        &markdown, &options,
-    )))
+    ferromark::try_parse_with_options(&markdown, &options)
+        .map(transform_result)
+        .map_err(input_size_error)
 }
 
 #[allow(clippy::type_complexity)]
@@ -174,11 +177,8 @@ pub fn to_html_with_renderer(
 ) -> Result<String> {
     let options = core_options(options)?;
     let mut renderer = CallbackRenderer { callback: renderer };
-    Ok(ferromark::to_html_with_renderer(
-        &markdown,
-        &options,
-        &mut renderer,
-    ))
+    ferromark::try_to_html_with_renderer(&markdown, &options, &mut renderer)
+        .map_err(input_size_error)
 }
 
 /// `transform` with an opt-in fenced-code renderer callback.
@@ -195,9 +195,7 @@ pub fn transform_with_renderer(
 ) -> Result<TransformResult> {
     let options = core_options(options)?;
     let mut renderer = CallbackRenderer { callback: renderer };
-    Ok(transform_result(ferromark::parse_with_renderer(
-        &markdown,
-        &options,
-        &mut renderer,
-    )))
+    ferromark::try_parse_with_renderer(&markdown, &options, &mut renderer)
+        .map(transform_result)
+        .map_err(input_size_error)
 }

--- a/src/block/parser.rs
+++ b/src/block/parser.rs
@@ -1,8 +1,9 @@
 //! Block parser implementation.
 
-use crate::Range;
 use crate::cursor::Cursor;
 use crate::limits;
+use crate::range::offset_to_u32;
+use crate::{InputSizeError, Range, validate_input_size};
 use smallvec::SmallVec;
 
 // Parser branches establish these bounds through `peek`, `at`, `remaining`,
@@ -205,12 +206,38 @@ pub struct BlockParser<'a> {
 
 impl<'a> BlockParser<'a> {
     /// Create a new block parser.
+    ///
+    /// # Panics
+    ///
+    /// Panics when `input` exceeds [`crate::MAX_INPUT_BYTES`]. Use
+    /// [`Self::try_new`] to handle that limit as an error.
     pub fn new(input: &'a [u8]) -> Self {
-        Self::new_with_options(input, Options::default())
+        Self::try_new(input).unwrap_or_else(|error| panic!("{error}"))
+    }
+
+    /// Create a new block parser without panicking for oversized input.
+    pub fn try_new(input: &'a [u8]) -> Result<Self, InputSizeError> {
+        Self::try_new_with_options(input, Options::default())
     }
 
     /// Create a new block parser with options.
+    ///
+    /// # Panics
+    ///
+    /// Panics when `input` exceeds [`crate::MAX_INPUT_BYTES`]. Use
+    /// [`Self::try_new_with_options`] to handle that limit as an error.
     pub fn new_with_options(input: &'a [u8], options: Options) -> Self {
+        Self::try_new_with_options(input, options).unwrap_or_else(|error| panic!("{error}"))
+    }
+
+    /// Create a new block parser with options without panicking for oversized
+    /// input.
+    pub fn try_new_with_options(input: &'a [u8], options: Options) -> Result<Self, InputSizeError> {
+        validate_input_size(input.len())?;
+        Ok(Self::new_unchecked(input, options))
+    }
+
+    fn new_unchecked(input: &'a [u8], options: Options) -> Self {
         Self {
             input,
             cursor: Cursor::new(input),
@@ -375,7 +402,7 @@ impl<'a> BlockParser<'a> {
                     let extra_spaces = cols.saturating_sub(4) as u8;
                     self.pending_code_blanks.push((
                         extra_spaces,
-                        Range::new(newline_start as u32, ws_end as u32),
+                        Range::new(offset_to_u32(newline_start), offset_to_u32(ws_end)),
                     ));
                     return;
                 }
@@ -528,8 +555,8 @@ impl<'a> BlockParser<'a> {
                     events.push(BlockEvent::VirtualSpaces(extra_spaces as u8));
                 }
                 events.push(BlockEvent::Code(Range::new(
-                    text_start as u32,
-                    content_end as u32,
+                    offset_to_u32(text_start),
+                    offset_to_u32(content_end),
                 )));
                 return;
             } else {
@@ -2441,8 +2468,8 @@ impl<'a> BlockParser<'a> {
         }
         // Emit the content (including newline) - use Code event to skip inline parsing
         events.push(BlockEvent::Code(Range::new(
-            text_start as u32,
-            content_end as u32,
+            offset_to_u32(text_start),
+            offset_to_u32(content_end),
         )));
     }
 
@@ -3125,8 +3152,8 @@ impl<'a> BlockParser<'a> {
                 // End of line - emit last cell
                 let (s, e) = Self::trim_cell(&line[cell_start..scan_end], cell_start);
                 cells.push(TableCell {
-                    start: s as u32,
-                    end: e as u32,
+                    start: offset_to_u32(s),
+                    end: offset_to_u32(e),
                     colspan: 1,
                 });
                 break;
@@ -3137,8 +3164,8 @@ impl<'a> BlockParser<'a> {
                 // Cell boundary
                 let (s, e) = Self::trim_cell(&line[cell_start..pos], cell_start);
                 cells.push(TableCell {
-                    start: s as u32,
-                    end: e as u32,
+                    start: offset_to_u32(s),
+                    end: offset_to_u32(e),
                     colspan: 1,
                 });
                 pos += 1;
@@ -3197,8 +3224,8 @@ impl<'a> BlockParser<'a> {
                 }
                 let (start, end) = Self::trim_cell(&line[cell_start..pos - pipe_count], cell_start);
                 cells.push(TableCell {
-                    start: start as u32,
-                    end: end as u32,
+                    start: offset_to_u32(start),
+                    end: offset_to_u32(end),
                     colspan: pipe_count.min(u16::MAX as usize) as u16,
                 });
                 if cells.len() >= limits::MAX_TABLE_COLUMNS || pos == line_end {
@@ -3212,8 +3239,8 @@ impl<'a> BlockParser<'a> {
 
         let (start, end) = Self::trim_cell(&line[cell_start..line_end], cell_start);
         cells.push(TableCell {
-            start: start as u32,
-            end: end as u32,
+            start: offset_to_u32(start),
+            end: offset_to_u32(end),
             colspan: 1,
         });
         cells

--- a/src/inline/marks.rs
+++ b/src/inline/marks.rs
@@ -6,6 +6,7 @@
 #[cfg(all(target_arch = "aarch64", target_feature = "neon"))]
 use super::simd;
 use crate::limits;
+use crate::range::{assert_input_size, offset_to_u32};
 use memchr::memchr3;
 
 /// Flags for mark state.
@@ -225,22 +226,42 @@ pub static SPECIAL_CHARS: [bool; 256] = {
 };
 
 /// Scan text and collect marks for the default inline syntax set.
+///
+/// # Panics
+///
+/// Panics when `text` exceeds [`crate::MAX_INPUT_BYTES`].
 pub fn collect_marks(text: &[u8], buffer: &mut MarkBuffer) -> MarkSummary {
+    assert_input_size(text.len());
     collect_marks_impl::<false, false>(text, buffer)
 }
 
 /// Scan text and collect marks with highlight support enabled.
+///
+/// # Panics
+///
+/// Panics when `text` exceeds [`crate::MAX_INPUT_BYTES`].
 pub fn collect_marks_highlight(text: &[u8], buffer: &mut MarkBuffer) -> MarkSummary {
+    assert_input_size(text.len());
     collect_marks_impl::<true, false>(text, buffer)
 }
 
 /// Scan text and collect marks with superscript support enabled.
+///
+/// # Panics
+///
+/// Panics when `text` exceeds [`crate::MAX_INPUT_BYTES`].
 pub fn collect_marks_superscript(text: &[u8], buffer: &mut MarkBuffer) -> MarkSummary {
+    assert_input_size(text.len());
     collect_marks_impl::<false, true>(text, buffer)
 }
 
 /// Scan text and collect marks with highlight and superscript enabled.
+///
+/// # Panics
+///
+/// Panics when `text` exceeds [`crate::MAX_INPUT_BYTES`].
 pub fn collect_marks_highlight_superscript(text: &[u8], buffer: &mut MarkBuffer) -> MarkSummary {
+    assert_input_size(text.len());
     collect_marks_impl::<true, true>(text, buffer)
 }
 
@@ -274,8 +295,8 @@ fn collect_marks_impl<const HIGHLIGHT: bool, const SUPERSCRIPT: bool>(
                 // Code span backticks can be both opener and closer
                 if run_len <= limits::MAX_CODE_SPAN_BACKTICKS {
                     buffer.push(Mark::new(
-                        start as u32,
-                        pos as u32,
+                        offset_to_u32(start),
+                        offset_to_u32(pos),
                         b'`',
                         flags::POTENTIAL_OPENER | flags::POTENTIAL_CLOSER,
                     ));
@@ -293,8 +314,8 @@ fn collect_marks_impl<const HIGHLIGHT: bool, const SUPERSCRIPT: bool>(
                 // Only collect runs of 1 or 2
                 if run_len <= 2 {
                     buffer.push(Mark::new(
-                        start as u32,
-                        pos as u32,
+                        offset_to_u32(start),
+                        offset_to_u32(pos),
                         b'$',
                         flags::POTENTIAL_OPENER | flags::POTENTIAL_CLOSER,
                     ));
@@ -338,7 +359,12 @@ fn collect_marks_impl<const HIGHLIGHT: bool, const SUPERSCRIPT: bool>(
                 );
 
                 if flags != 0 {
-                    buffer.push(Mark::new(start as u32, pos as u32, ch, flags));
+                    buffer.push(Mark::new(
+                        offset_to_u32(start),
+                        offset_to_u32(pos),
+                        ch,
+                        flags,
+                    ));
                 }
             }
 
@@ -351,8 +377,8 @@ fn collect_marks_impl<const HIGHLIGHT: bool, const SUPERSCRIPT: bool>(
                     if is_escapable(next) || next == b'\n' {
                         // Regular escape or hard line break (backslash before newline)
                         buffer.push(Mark::new(
-                            pos as u32,
-                            (pos + 2) as u32,
+                            offset_to_u32(pos),
+                            offset_to_u32(pos + 2),
                             b'\\',
                             flags::POTENTIAL_OPENER, // Mark for processing
                         ));
@@ -361,8 +387,8 @@ fn collect_marks_impl<const HIGHLIGHT: bool, const SUPERSCRIPT: bool>(
                         if next == b'`' {
                             summary.record(MarkSummary::CODE);
                             buffer.push(Mark::new(
-                                (pos + 1) as u32,
-                                (pos + 2) as u32,
+                                offset_to_u32(pos + 1),
+                                offset_to_u32(pos + 2),
                                 b'`',
                                 flags::POTENTIAL_OPENER | flags::POTENTIAL_CLOSER,
                             ));
@@ -387,8 +413,8 @@ fn collect_marks_impl<const HIGHLIGHT: bool, const SUPERSCRIPT: bool>(
                         space_start -= 1;
                     }
                     buffer.push(Mark::new(
-                        space_start as u32,
-                        (pos + 1) as u32,
+                        offset_to_u32(space_start),
+                        offset_to_u32(pos + 1),
                         b'\n',
                         flags::POTENTIAL_OPENER, // Hard break marker
                     ));
@@ -406,8 +432,8 @@ fn collect_marks_impl<const HIGHLIGHT: bool, const SUPERSCRIPT: bool>(
                         space_end += 1;
                     }
                     buffer.push(Mark::new(
-                        space_start as u32,
-                        space_end as u32,
+                        offset_to_u32(space_start),
+                        offset_to_u32(space_end),
                         b'\n',
                         flags::POTENTIAL_CLOSER, // Soft break marker (distinguished from hard break)
                     ));
@@ -419,8 +445,8 @@ fn collect_marks_impl<const HIGHLIGHT: bool, const SUPERSCRIPT: bool>(
                 // Check for image: ![
                 let is_image = pos > 0 && text[pos - 1] == b'!' && !is_escaped(text, pos - 1);
                 buffer.push(Mark::new(
-                    pos as u32,
-                    (pos + 1) as u32,
+                    offset_to_u32(pos),
+                    offset_to_u32(pos + 1),
                     b'[',
                     if is_image {
                         flags::POTENTIAL_OPENER | flags::IN_CODE
@@ -433,8 +459,8 @@ fn collect_marks_impl<const HIGHLIGHT: bool, const SUPERSCRIPT: bool>(
 
             b']' => {
                 buffer.push(Mark::new(
-                    pos as u32,
-                    (pos + 1) as u32,
+                    offset_to_u32(pos),
+                    offset_to_u32(pos + 1),
                     b']',
                     flags::POTENTIAL_CLOSER,
                 ));
@@ -445,8 +471,8 @@ fn collect_marks_impl<const HIGHLIGHT: bool, const SUPERSCRIPT: bool>(
                 summary.record(MarkSummary::LESS_THAN);
                 // Potential autolink
                 buffer.push(Mark::new(
-                    pos as u32,
-                    (pos + 1) as u32,
+                    offset_to_u32(pos),
+                    offset_to_u32(pos + 1),
                     b'<',
                     flags::POTENTIAL_OPENER,
                 ));

--- a/src/inline/mod.rs
+++ b/src/inline/mod.rs
@@ -20,9 +20,10 @@ mod superscript;
 pub use event::InlineEvent;
 pub use links::AutolinkLiteralKind;
 
-use crate::Range;
 use crate::footnote::FootnoteStore;
 use crate::link_ref::LinkRefStore;
+use crate::range::assert_input_size;
+use crate::{InputSizeError, Range};
 use code_span::{CodeSpan, extract_code_spans, resolve_code_spans};
 use emphasis::{EmphasisMatch, EmphasisStacks, resolve_emphasis_with_stacks_into};
 use highlight::{HighlightMatch, resolve_highlight_into};
@@ -136,6 +137,11 @@ impl InlineParser {
     }
 
     /// Parse inline content and emit events.
+    ///
+    /// # Panics
+    ///
+    /// Panics when `text` exceeds [`crate::MAX_INPUT_BYTES`]. Use
+    /// [`Self::try_parse`] to handle the limit as an error.
     pub fn parse(
         &mut self,
         text: &[u8],
@@ -143,11 +149,25 @@ impl InlineParser {
         allow_html: bool,
         events: &mut Vec<InlineEvent>,
     ) {
+        self.try_parse(text, link_refs, allow_html, events)
+            .unwrap_or_else(|error| panic!("{error}"));
+    }
+
+    /// Parse inline content without panicking for oversized input.
+    pub fn try_parse(
+        &mut self,
+        text: &[u8],
+        link_refs: Option<&LinkRefStore>,
+        allow_html: bool,
+        events: &mut Vec<InlineEvent>,
+    ) -> Result<(), InputSizeError> {
+        crate::validate_input_size(text.len())?;
         self.begin_document();
         self.parse_with_options_in_document(
             text, link_refs, allow_html, true, false, false, false, true, false, false, None,
             events,
         );
+        Ok(())
     }
 
     /// Parse inline Markdown with opt-in MDX expressions and JSX tags.
@@ -159,6 +179,11 @@ impl InlineParser {
     ///
     /// Inline HTML is intentionally disabled for this mode so valid JSX tags
     /// are not consumed as raw HTML before MDX recognition.
+    ///
+    /// # Panics
+    ///
+    /// Panics when `text` exceeds [`crate::MAX_INPUT_BYTES`]. Use
+    /// [`Self::try_parse_mdx`] to handle the limit as an error.
     #[cfg(feature = "mdx")]
     pub fn parse_mdx(
         &mut self,
@@ -166,8 +191,23 @@ impl InlineParser {
         link_refs: Option<&LinkRefStore>,
         events: &mut Vec<InlineEvent>,
     ) {
+        self.try_parse_mdx(text, link_refs, events)
+            .unwrap_or_else(|error| panic!("{error}"));
+    }
+
+    /// Parse inline Markdown with MDX support without panicking for oversized
+    /// input.
+    #[cfg(feature = "mdx")]
+    pub fn try_parse_mdx(
+        &mut self,
+        text: &[u8],
+        link_refs: Option<&LinkRefStore>,
+        events: &mut Vec<InlineEvent>,
+    ) -> Result<(), InputSizeError> {
+        crate::validate_input_size(text.len())?;
         self.begin_document();
         self.parse_mdx_in_document(text, link_refs, events);
+        Ok(())
     }
 
     /// Begin a document-level inline parsing session.
@@ -196,6 +236,11 @@ impl InlineParser {
     }
 
     /// Parse inline content with configurable inline extensions.
+    ///
+    /// # Panics
+    ///
+    /// Panics when `text` exceeds [`crate::MAX_INPUT_BYTES`]. Use
+    /// [`Self::try_parse_with_options`] to handle the limit as an error.
     #[allow(clippy::too_many_arguments)]
     pub fn parse_with_options(
         &mut self,
@@ -212,6 +257,42 @@ impl InlineParser {
         footnote_store: Option<&FootnoteStore>,
         events: &mut Vec<InlineEvent>,
     ) {
+        self.try_parse_with_options(
+            text,
+            link_refs,
+            allow_html,
+            strikethrough,
+            highlight,
+            superscript,
+            subscript,
+            autolink_literals,
+            math,
+            inline_footnotes,
+            footnote_store,
+            events,
+        )
+        .unwrap_or_else(|error| panic!("{error}"));
+    }
+
+    /// Parse inline content with configurable extensions without panicking for
+    /// oversized input.
+    #[allow(clippy::too_many_arguments)]
+    pub fn try_parse_with_options(
+        &mut self,
+        text: &[u8],
+        link_refs: Option<&LinkRefStore>,
+        allow_html: bool,
+        strikethrough: bool,
+        highlight: bool,
+        superscript: bool,
+        subscript: bool,
+        autolink_literals: bool,
+        math: bool,
+        inline_footnotes: bool,
+        footnote_store: Option<&FootnoteStore>,
+        events: &mut Vec<InlineEvent>,
+    ) -> Result<(), InputSizeError> {
+        crate::validate_input_size(text.len())?;
         self.begin_document();
         self.parse_with_options_in_document(
             text,
@@ -227,6 +308,7 @@ impl InlineParser {
             footnote_store,
             events,
         );
+        Ok(())
     }
 
     /// Parse inline content as part of an active document-level parsing session.
@@ -246,6 +328,10 @@ impl InlineParser {
         footnote_store: Option<&FootnoteStore>,
         events: &mut Vec<InlineEvent>,
     ) {
+        // Every source offset produced by the inline pipeline is narrowed to
+        // `u32`; keep that invariant at this shared entry point for reusable
+        // parser sessions as well as the public `try_*` methods.
+        assert_input_size(text.len());
         #[cfg(feature = "profiling")]
         let event_start = events.len();
         let may_have_inline_footnotes = inline_footnotes && has_inline_footnote_candidate(text);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,7 +36,7 @@ pub use block::{Alignment, BlockEvent, BlockParser, CalloutType, CodeBlockKind, 
 pub use footnote::FootnoteStore;
 pub use inline::{InlineEvent, InlineParser};
 pub use link_ref::{LinkRefDef, LinkRefStore};
-pub use range::Range;
+pub use range::{InputSizeError, MAX_INPUT_BYTES, Range, validate_input_size};
 pub use render::HtmlWriter;
 
 /// A complete fenced code block passed to a custom renderer.
@@ -496,20 +496,44 @@ fn extract_front_matter(input: &str) -> Option<(&str, usize)> {
 /// assert_eq!(result.headings[0].id.as_deref(), Some("content"));
 /// assert_eq!(result.headings[0].text, "Content");
 /// ```
+///
+/// # Panics
+///
+/// Panics when the input exceeds [`MAX_INPUT_BYTES`]. Use [`try_parse`] to
+/// handle the limit as an error.
 pub fn parse(input: &str) -> ParseResult<'_> {
+    try_parse(input).unwrap_or_else(|error| panic!("{error}"))
+}
+
+/// Parse Markdown with default options without panicking for oversized input.
+pub fn try_parse(input: &str) -> Result<ParseResult<'_>, InputSizeError> {
     let options = Options {
         front_matter: true,
         ..Options::default()
     };
-    parse_with_options(input, &options)
+    try_parse_with_options(input, &options)
 }
 
 /// Parse Markdown with options and return HTML, front matter, and headings.
 ///
 /// Front matter is only extracted when `options.front_matter` is `true`.
 /// Heading IDs are only present when `options.heading_ids` is enabled.
+///
+/// # Panics
+///
+/// Panics when the input exceeds [`MAX_INPUT_BYTES`]. Use
+/// [`try_parse_with_options`] to handle the limit as an error.
 pub fn parse_with_options<'a>(input: &'a str, options: &Options) -> ParseResult<'a> {
-    parse_impl(input, options, None)
+    try_parse_with_options(input, options).unwrap_or_else(|error| panic!("{error}"))
+}
+
+/// Parse Markdown with options without panicking for oversized input.
+pub fn try_parse_with_options<'a>(
+    input: &'a str,
+    options: &Options,
+) -> Result<ParseResult<'a>, InputSizeError> {
+    validate_input_size(input.len())?;
+    Ok(parse_impl(input, options, None))
 }
 
 /// Parse Markdown with options and an opt-in fenced-code renderer, returning
@@ -517,12 +541,28 @@ pub fn parse_with_options<'a>(input: &'a str, options: &Options) -> ParseResult<
 ///
 /// See [`FencedCodeRenderer`] for the escaping contract the renderer must
 /// uphold.
+///
+/// # Panics
+///
+/// Panics when the input exceeds [`MAX_INPUT_BYTES`]. Use
+/// [`try_parse_with_renderer`] to handle the limit as an error.
 pub fn parse_with_renderer<'a>(
     input: &'a str,
     options: &Options,
     renderer: &mut dyn FencedCodeRenderer,
 ) -> ParseResult<'a> {
-    parse_impl(input, options, Some(renderer))
+    try_parse_with_renderer(input, options, renderer).unwrap_or_else(|error| panic!("{error}"))
+}
+
+/// Parse Markdown with options and a fenced-code renderer without panicking
+/// for oversized input.
+pub fn try_parse_with_renderer<'a>(
+    input: &'a str,
+    options: &Options,
+    renderer: &mut dyn FencedCodeRenderer,
+) -> Result<ParseResult<'a>, InputSizeError> {
+    validate_input_size(input.len())?;
+    Ok(parse_impl(input, options, Some(renderer)))
 }
 
 fn parse_impl<'a>(
@@ -568,39 +608,71 @@ fn parse_impl<'a>(
 /// assert!(html.contains("Hello</h1>"));
 /// assert!(html.contains("<p>World</p>"));
 /// ```
+///
+/// # Panics
+///
+/// Panics when the input exceeds [`MAX_INPUT_BYTES`]. Use [`try_to_html`] to
+/// handle the limit as an error.
 pub fn to_html(input: &str) -> String {
-    let mut writer = HtmlWriter::with_capacity_for(input.len());
-    render_to_writer(input.as_bytes(), &mut writer, &Options::default());
-    writer
-        .into_string()
-        .expect("rendering from a UTF-8 Markdown string must produce UTF-8 HTML")
+    try_to_html(input).unwrap_or_else(|error| panic!("{error}"))
+}
+
+/// Convert Markdown to HTML without panicking for oversized input.
+pub fn try_to_html(input: &str) -> Result<String, InputSizeError> {
+    try_to_html_with_options(input, &Options::default())
 }
 
 /// Convert Markdown to HTML, writing into a provided buffer.
 ///
 /// This avoids allocation if the buffer has sufficient capacity.
+///
+/// # Panics
+///
+/// Panics when the input exceeds [`MAX_INPUT_BYTES`]. Use
+/// [`try_to_html_into`] to handle the limit as an error.
 pub fn to_html_into(input: &str, out: &mut Vec<u8>) {
-    to_html_into_with_options(input, out, &Options::default());
+    try_to_html_into(input, out).unwrap_or_else(|error| panic!("{error}"));
+}
+
+/// Convert Markdown to HTML into a provided buffer without panicking for
+/// oversized input.
+pub fn try_to_html_into(input: &str, out: &mut Vec<u8>) -> Result<(), InputSizeError> {
+    try_to_html_into_with_options(input, out, &Options::default())
 }
 
 /// Convert Markdown to HTML with options.
 ///
 /// When `options.front_matter` is `true`, any front matter at the start of the
 /// document is silently stripped before parsing.
+///
+/// # Panics
+///
+/// Panics when the input exceeds [`MAX_INPUT_BYTES`]. Use
+/// [`try_to_html_with_options`] to handle the limit as an error.
 pub fn to_html_with_options(input: &str, options: &Options) -> String {
-    let markdown = if options.front_matter {
+    try_to_html_with_options(input, options).unwrap_or_else(|error| panic!("{error}"))
+}
+
+/// Convert Markdown to HTML with options without panicking for oversized input.
+pub fn try_to_html_with_options(input: &str, options: &Options) -> Result<String, InputSizeError> {
+    validate_input_size(input.len())?;
+    let markdown = markdown_without_front_matter(input, options);
+    let mut writer = HtmlWriter::with_capacity_for(markdown.len());
+    render_to_writer(markdown.as_bytes(), &mut writer, options);
+    Ok(writer
+        .into_string()
+        .expect("rendering from a UTF-8 Markdown string must produce UTF-8 HTML"))
+}
+
+fn markdown_without_front_matter<'a>(input: &'a str, options: &Options) -> &'a str {
+    if options.front_matter {
         match extract_front_matter(input) {
             Some((_, offset)) => &input[offset..],
             None => input,
         }
     } else {
         input
-    };
-    let mut writer = HtmlWriter::with_capacity_for(markdown.len());
-    render_to_writer(markdown.as_bytes(), &mut writer, options);
-    writer
-        .into_string()
-        .expect("rendering from a UTF-8 Markdown string must produce UTF-8 HTML")
+    }
 }
 
 /// Convert Markdown to HTML with an opt-in fenced-code renderer.
@@ -608,39 +680,57 @@ pub fn to_html_with_options(input: &str, options: &Options) -> String {
 /// The renderer sees only fenced code blocks. Returning `None` preserves the
 /// normal escaped code-block output. Installing a renderer is an explicit HTML
 /// trust boundary; see [`TrustedHtml`].
+///
+/// # Panics
+///
+/// Panics when the input exceeds [`MAX_INPUT_BYTES`]. Use
+/// [`try_to_html_with_renderer`] to handle the limit as an error.
 pub fn to_html_with_renderer(
     input: &str,
     options: &Options,
     renderer: &mut dyn FencedCodeRenderer,
 ) -> String {
-    let markdown = if options.front_matter {
-        match extract_front_matter(input) {
-            Some((_, offset)) => &input[offset..],
-            None => input,
-        }
-    } else {
-        input
-    };
+    try_to_html_with_renderer(input, options, renderer).unwrap_or_else(|error| panic!("{error}"))
+}
+
+/// Convert Markdown to HTML with a fenced-code renderer without panicking for
+/// oversized input.
+pub fn try_to_html_with_renderer(
+    input: &str,
+    options: &Options,
+    renderer: &mut dyn FencedCodeRenderer,
+) -> Result<String, InputSizeError> {
+    validate_input_size(input.len())?;
+    let markdown = markdown_without_front_matter(input, options);
     let mut writer = HtmlWriter::with_capacity_for(markdown.len());
     render_to_writer_with_renderer(markdown.as_bytes(), &mut writer, options, Some(renderer));
-    writer
+    Ok(writer
         .into_string()
-        .expect("rendering from a UTF-8 Markdown string must produce UTF-8 HTML")
+        .expect("rendering from a UTF-8 Markdown string must produce UTF-8 HTML"))
 }
 
 /// Convert Markdown to HTML into a provided buffer with options.
 ///
 /// When `options.front_matter` is `true`, any front matter at the start of the
 /// document is silently stripped before parsing.
+///
+/// # Panics
+///
+/// Panics when the input exceeds [`MAX_INPUT_BYTES`]. Use
+/// [`try_to_html_into_with_options`] to handle the limit as an error.
 pub fn to_html_into_with_options(input: &str, out: &mut Vec<u8>, options: &Options) {
-    let markdown = if options.front_matter {
-        match extract_front_matter(input) {
-            Some((_, offset)) => &input[offset..],
-            None => input,
-        }
-    } else {
-        input
-    };
+    try_to_html_into_with_options(input, out, options).unwrap_or_else(|error| panic!("{error}"));
+}
+
+/// Convert Markdown into a provided buffer with options without panicking for
+/// oversized input.
+pub fn try_to_html_into_with_options(
+    input: &str,
+    out: &mut Vec<u8>,
+    options: &Options,
+) -> Result<(), InputSizeError> {
+    validate_input_size(input.len())?;
+    let markdown = markdown_without_front_matter(input, options);
     out.clear();
     out.reserve(markdown.len() + markdown.len() / 4);
     let mut writer = HtmlWriter::with_capacity(0);
@@ -648,29 +738,42 @@ pub fn to_html_into_with_options(input: &str, out: &mut Vec<u8>, options: &Optio
     std::mem::swap(writer.buffer_mut(), out);
     render_to_writer(markdown.as_bytes(), &mut writer, options);
     std::mem::swap(writer.buffer_mut(), out);
+    Ok(())
 }
 
 /// Convert Markdown into a reusable buffer with an opt-in fenced-code renderer.
+///
+/// # Panics
+///
+/// Panics when the input exceeds [`MAX_INPUT_BYTES`]. Use
+/// [`try_to_html_into_with_renderer`] to handle the limit as an error.
 pub fn to_html_into_with_renderer(
     input: &str,
     out: &mut Vec<u8>,
     options: &Options,
     renderer: &mut dyn FencedCodeRenderer,
 ) {
-    let markdown = if options.front_matter {
-        match extract_front_matter(input) {
-            Some((_, offset)) => &input[offset..],
-            None => input,
-        }
-    } else {
-        input
-    };
+    try_to_html_into_with_renderer(input, out, options, renderer)
+        .unwrap_or_else(|error| panic!("{error}"));
+}
+
+/// Convert Markdown into a reusable buffer with a fenced-code renderer without
+/// panicking for oversized input.
+pub fn try_to_html_into_with_renderer(
+    input: &str,
+    out: &mut Vec<u8>,
+    options: &Options,
+    renderer: &mut dyn FencedCodeRenderer,
+) -> Result<(), InputSizeError> {
+    validate_input_size(input.len())?;
+    let markdown = markdown_without_front_matter(input, options);
     out.clear();
     out.reserve(markdown.len() + markdown.len() / 4);
     let mut writer = HtmlWriter::with_capacity(0);
     std::mem::swap(writer.buffer_mut(), out);
     render_to_writer_with_renderer(markdown.as_bytes(), &mut writer, options, Some(renderer));
     std::mem::swap(writer.buffer_mut(), out);
+    Ok(())
 }
 
 /// State for collecting paragraph content before inline parsing.

--- a/src/mdx/events.rs
+++ b/src/mdx/events.rs
@@ -10,7 +10,7 @@ use crate::{
     fixup_list_tight,
 };
 
-use super::{MdxDiagnostic, Segment, segment_spanned};
+use super::{MdxDiagnostic, Segment};
 
 /// Version of the public MDX event ordering and balancing contract.
 ///
@@ -120,17 +120,30 @@ impl MdxEventStream {
 /// contract and remains Markdown text. Use
 /// [`parse_events_strict`](super::parse_events_strict) when structural
 /// diagnostics are required.
+///
+/// # Panics
+///
+/// Panics when the input exceeds [`crate::MAX_INPUT_BYTES`]. Use
+/// [`try_parse_events`] to handle the limit as an error.
 #[must_use]
 pub fn parse_events(input: &str) -> MdxEventStream {
-    assert!(
-        u32::try_from(input.len()).is_ok(),
-        "MDX input exceeds the supported u32 source range"
-    );
+    try_parse_events(input).unwrap_or_else(|error| panic!("{error}"))
+}
+
+/// Build a permissive semantic event stream without panicking for oversized
+/// input.
+pub fn try_parse_events(input: &str) -> Result<MdxEventStream, crate::InputSizeError> {
+    crate::validate_input_size(input.len())?;
 
     let (content_start, front_matter) = front_matter_event(input);
     let content = &input[content_start..];
-    let segments = segment_spanned(content);
-    build_event_stream(input, content_start, front_matter, segments)
+    let segments = super::try_segment_spanned(content)?;
+    Ok(build_event_stream(
+        input,
+        content_start,
+        front_matter,
+        segments,
+    ))
 }
 
 /// Build a strict semantic MDX event stream.
@@ -146,10 +159,7 @@ pub fn parse_events(input: &str) -> MdxEventStream {
 /// constructs; malformed inline MDX retains the permissive `InlineEvent::Text`
 /// recovery in both event modes.
 pub fn parse_events_strict(input: &str) -> Result<MdxEventStream, Vec<MdxDiagnostic>> {
-    assert!(
-        u32::try_from(input.len()).is_ok(),
-        "MDX input exceeds the supported u32 source range"
-    );
+    super::validate_mdx_input_size(input.len())?;
 
     let (content_start, front_matter) = front_matter_event(input);
     match super::segment_strict(&input[content_start..]) {

--- a/src/mdx/mod.rs
+++ b/src/mdx/mod.rs
@@ -123,6 +123,7 @@ mod strict;
 
 pub use events::{
     MDX_EVENT_STREAM_VERSION, MdxEvent, MdxEventStream, parse_events, parse_events_strict,
+    try_parse_events,
 };
 
 /// A typed segment of an MDX document.
@@ -168,6 +169,8 @@ pub struct SpannedSegment<'a> {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum MdxDiagnosticCode {
+    /// The document exceeds the maximum size representable by source ranges.
+    InputTooLarge,
     /// A flow expression has no closing `}`.
     UnterminatedExpression,
     /// A JSX tag has no closing `>`.
@@ -214,9 +217,20 @@ pub struct SourceLocation {
 ///
 /// This is the primary entry point. The returned segments cover the entire
 /// input — no bytes are dropped.
+///
+/// # Panics
+///
+/// Panics when the input exceeds [`crate::MAX_INPUT_BYTES`]. Use
+/// [`try_segment`] to handle the limit as an error.
 #[must_use]
 pub fn segment(input: &str) -> Vec<Segment<'_>> {
-    splitter::split(input)
+    try_segment(input).unwrap_or_else(|error| panic!("{error}"))
+}
+
+/// Segment an MDX document without panicking for oversized input.
+pub fn try_segment(input: &str) -> Result<Vec<Segment<'_>>, crate::InputSizeError> {
+    crate::validate_input_size(input.len())?;
+    Ok(splitter::split(input))
 }
 
 /// Segment an MDX document and retain exact byte ranges for each segment.
@@ -229,13 +243,21 @@ pub fn segment(input: &str) -> Vec<Segment<'_>> {
 ///
 /// # Panics
 ///
-/// Panics when `input` is larger than [`u32::MAX`] bytes, matching the size
-/// limit of [`crate::Range`].
+/// Panics when the input exceeds [`crate::MAX_INPUT_BYTES`]. Use
+/// [`try_segment_spanned`] to handle the limit as an error.
+///
 #[must_use]
 pub fn segment_spanned(input: &str) -> Vec<SpannedSegment<'_>> {
+    try_segment_spanned(input).unwrap_or_else(|error| panic!("{error}"))
+}
+
+/// Segment an MDX document with byte ranges without panicking for oversized
+/// input.
+pub fn try_segment_spanned(input: &str) -> Result<Vec<SpannedSegment<'_>>, crate::InputSizeError> {
+    crate::validate_input_size(input.len())?;
     let input_start = input.as_ptr() as usize;
 
-    segment(input)
+    Ok(splitter::split(input)
         .into_iter()
         .map(|segment| {
             let text = segment.as_str();
@@ -246,7 +268,7 @@ pub fn segment_spanned(input: &str) -> Vec<SpannedSegment<'_>> {
             let range = crate::Range::from_usize(start, end);
             SpannedSegment { segment, range }
         })
-        .collect()
+        .collect())
 }
 
 /// Validate structural MDX and return source-spanned segments on success.
@@ -260,12 +282,22 @@ pub fn segment_spanned(input: &str) -> Vec<SpannedSegment<'_>> {
 /// When a malformed construct makes later segmentation ambiguous, validation
 /// stops at that construct. Otherwise, independent diagnostics are collected.
 ///
-/// # Panics
-///
-/// Panics when `input` is larger than [`u32::MAX`] bytes, matching the size
-/// limit of [`crate::Range`].
 pub fn segment_strict(input: &str) -> Result<Vec<SpannedSegment<'_>>, Vec<MdxDiagnostic>> {
+    validate_mdx_input_size(input.len())?;
     strict::segment_strict(input)
+}
+
+pub(super) fn validate_mdx_input_size(input_len: usize) -> Result<(), Vec<MdxDiagnostic>> {
+    crate::validate_input_size(input_len).map_err(|_| vec![input_size_diagnostic()])
+}
+
+fn input_size_diagnostic() -> MdxDiagnostic {
+    MdxDiagnostic {
+        code: MdxDiagnosticCode::InputTooLarge,
+        message: "input exceeds the maximum supported size of 4294967295 bytes",
+        primary_range: crate::Range::empty_at(0),
+        related_range: None,
+    }
 }
 
 /// Translate a UTF-8 byte offset into a one-based line and Unicode scalar column.
@@ -280,6 +312,7 @@ pub fn segment_strict(input: &str) -> Result<Vec<SpannedSegment<'_>>, Vec<MdxDia
 /// character boundary.
 #[must_use]
 pub fn source_location(input: &str, byte_offset: usize) -> SourceLocation {
+    crate::range::assert_input_size(input.len());
     assert!(
         byte_offset <= input.len(),
         "byte offset is outside the input"
@@ -315,4 +348,19 @@ impl<'a> Segment<'a> {
     }
 }
 
-pub use render::{MdxOutput, render, render_with_options};
+pub use render::{MdxOutput, render, render_with_options, try_render, try_render_with_options};
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[cfg(target_pointer_width = "64")]
+    #[test]
+    fn strict_size_validation_returns_a_stable_diagnostic() {
+        let diagnostics = validate_mdx_input_size(crate::MAX_INPUT_BYTES + 1).unwrap_err();
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].code, MdxDiagnosticCode::InputTooLarge);
+        assert_eq!(diagnostics[0].primary_range, crate::Range::empty_at(0));
+    }
+}

--- a/src/mdx/mod.rs
+++ b/src/mdx/mod.rs
@@ -294,7 +294,7 @@ pub(super) fn validate_mdx_input_size(input_len: usize) -> Result<(), Vec<MdxDia
 fn input_size_diagnostic() -> MdxDiagnostic {
     MdxDiagnostic {
         code: MdxDiagnosticCode::InputTooLarge,
-        message: "input exceeds the maximum supported size of 4294967295 bytes",
+        message: "input exceeds the maximum supported size of 4294967294 bytes",
         primary_range: crate::Range::empty_at(0),
         related_range: None,
     }
@@ -369,6 +369,11 @@ mod tests {
         assert_eq!(diagnostics.len(), 1);
         assert_eq!(diagnostics[0].code, MdxDiagnosticCode::InputTooLarge);
         assert_eq!(diagnostics[0].primary_range, crate::Range::empty_at(0));
+        assert!(
+            diagnostics[0]
+                .message
+                .contains(&crate::MAX_INPUT_BYTES.to_string())
+        );
     }
 
     #[test]

--- a/src/mdx/mod.rs
+++ b/src/mdx/mod.rs
@@ -323,14 +323,21 @@ pub fn source_location(input: &str, byte_offset: usize) -> SourceLocation {
     );
 
     let before = &input[..byte_offset];
-    let line = before.bytes().filter(|byte| *byte == b'\n').count() + 1;
+    let line = before.bytes().filter(|byte| *byte == b'\n').count();
     let line_start = before.rfind('\n').map_or(0, |offset| offset + 1);
-    let column = input[line_start..byte_offset].chars().count() + 1;
+    let column = input[line_start..byte_offset].chars().count();
 
     SourceLocation {
-        line: u32::try_from(line).expect("line number exceeds u32::MAX"),
-        column: u32::try_from(column).expect("column number exceeds u32::MAX"),
+        line: one_based_source_count(line),
+        column: one_based_source_count(column),
     }
+}
+
+fn one_based_source_count(zero_based_count: usize) -> u32 {
+    let one_based_count = zero_based_count
+        .checked_add(1)
+        .expect("source position exceeds usize::MAX");
+    u32::try_from(one_based_count).expect("source position exceeds u32::MAX")
 }
 
 impl<'a> Segment<'a> {
@@ -362,5 +369,10 @@ mod tests {
         assert_eq!(diagnostics.len(), 1);
         assert_eq!(diagnostics[0].code, MdxDiagnosticCode::InputTooLarge);
         assert_eq!(diagnostics[0].primary_range, crate::Range::empty_at(0));
+    }
+
+    #[test]
+    fn maximum_input_length_preserves_one_based_source_positions() {
+        assert_eq!(one_based_source_count(crate::MAX_INPUT_BYTES), u32::MAX);
     }
 }

--- a/src/mdx/render.rs
+++ b/src/mdx/render.rs
@@ -2,7 +2,7 @@ use std::fmt::Write;
 
 use crate::{Options, RenderPolicy};
 
-use super::{Segment, segment};
+use super::Segment;
 
 /// Error returned when a component name cannot be used as a JavaScript binding.
 ///
@@ -187,13 +187,37 @@ impl MdxOutput<'_> {
 }
 
 /// Render MDX to HTML body with default options.
+///
+/// # Panics
+///
+/// Panics when the input exceeds [`crate::MAX_INPUT_BYTES`]. Use
+/// [`try_render`] to handle the limit as an error.
 pub fn render(input: &str) -> MdxOutput<'_> {
-    render_with_options(input, &mdx_default_options())
+    try_render(input).unwrap_or_else(|error| panic!("{error}"))
+}
+
+/// Render MDX to HTML without panicking for oversized input.
+pub fn try_render(input: &str) -> Result<MdxOutput<'_>, crate::InputSizeError> {
+    try_render_with_options(input, &mdx_default_options())
 }
 
 /// Render MDX to HTML body with custom Markdown options.
+///
+/// # Panics
+///
+/// Panics when the input exceeds [`crate::MAX_INPUT_BYTES`]. Use
+/// [`try_render_with_options`] to handle the limit as an error.
 pub fn render_with_options<'a>(input: &'a str, options: &Options) -> MdxOutput<'a> {
-    let segments = segment(input);
+    try_render_with_options(input, options).unwrap_or_else(|error| panic!("{error}"))
+}
+
+/// Render MDX to HTML with custom Markdown options without panicking for
+/// oversized input.
+pub fn try_render_with_options<'a>(
+    input: &'a str,
+    options: &Options,
+) -> Result<MdxOutput<'a>, crate::InputSizeError> {
+    let segments = super::try_segment(input)?;
     let mut body = String::with_capacity(input.len());
     let mut esm: Vec<&'a str> = Vec::new();
     let mut front_matter: Option<&'a str> = None;
@@ -204,7 +228,7 @@ pub fn render_with_options<'a>(input: &'a str, options: &Options) -> MdxOutput<'
                 esm.push(s);
             }
             Segment::Markdown(s) => {
-                let result = crate::parse_with_options(s, options);
+                let result = crate::try_parse_with_options(s, options)?;
                 body.push_str(&result.html);
                 if front_matter.is_none() {
                     front_matter = result.front_matter;
@@ -220,11 +244,11 @@ pub fn render_with_options<'a>(input: &'a str, options: &Options) -> MdxOutput<'
         }
     }
 
-    MdxOutput {
+    Ok(MdxOutput {
         body,
         esm,
         front_matter,
-    }
+    })
 }
 
 fn mdx_default_options() -> Options {

--- a/src/range.rs
+++ b/src/range.rs
@@ -5,8 +5,11 @@
 
 use std::fmt;
 
-/// Largest input size supported by ferromark's compact source ranges.
-pub const MAX_INPUT_BYTES: usize = u32::MAX as usize;
+/// Largest input size supported by ferromark's compact source positions.
+///
+/// One byte is reserved so one-based line and column values remain
+/// representable even when every byte is a newline or a single-byte scalar.
+pub const MAX_INPUT_BYTES: usize = u32::MAX as usize - 1;
 
 /// Error returned when an input cannot be represented by [`Range`] offsets.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -228,7 +231,7 @@ mod tests {
         assert_eq!(error.input_len(), too_large);
         assert_eq!(
             error.to_string(),
-            "input is 4294967296 bytes, exceeding the maximum supported size of 4294967295 bytes"
+            "input is 4294967295 bytes, exceeding the maximum supported size of 4294967294 bytes"
         );
     }
 

--- a/src/range.rs
+++ b/src/range.rs
@@ -1,7 +1,64 @@
 //! Compact range representation for zero-copy text references.
 //!
 //! Uses `u32` offsets to save memory (8 bytes vs 16 for usize pair).
-//! Supports documents up to 4GB in size.
+//! Supports documents up to [`MAX_INPUT_BYTES`] bytes in size.
+
+use std::fmt;
+
+/// Largest input size supported by ferromark's compact source ranges.
+pub const MAX_INPUT_BYTES: usize = u32::MAX as usize;
+
+/// Error returned when an input cannot be represented by [`Range`] offsets.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct InputSizeError {
+    input_len: usize,
+}
+
+impl InputSizeError {
+    /// The rejected input length in bytes.
+    #[must_use]
+    pub const fn input_len(self) -> usize {
+        self.input_len
+    }
+}
+
+impl fmt::Display for InputSizeError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            formatter,
+            "input is {} bytes, exceeding the maximum supported size of {MAX_INPUT_BYTES} bytes",
+            self.input_len
+        )
+    }
+}
+
+impl std::error::Error for InputSizeError {}
+
+/// Validate that an input length fits every ferromark source offset.
+///
+/// This is useful for callers of infallible legacy APIs, which panic when the
+/// input is too large to represent. APIs that can return an error use the same
+/// validation internally.
+pub fn validate_input_size(input_len: usize) -> Result<(), InputSizeError> {
+    if input_len <= MAX_INPUT_BYTES {
+        Ok(())
+    } else {
+        Err(InputSizeError { input_len })
+    }
+}
+
+#[inline]
+pub(crate) fn assert_input_size(input_len: usize) {
+    if let Err(error) = validate_input_size(input_len) {
+        panic!("{error}");
+    }
+}
+
+/// Convert a source offset after the input-size invariant has been checked.
+#[inline]
+pub(crate) fn offset_to_u32(offset: usize) -> u32 {
+    u32::try_from(offset).expect("source offset exceeds the supported u32 range")
+}
 
 /// Compact range into an input buffer.
 ///
@@ -35,14 +92,12 @@ impl Range {
     /// Create a range from usize values.
     ///
     /// # Panics
-    /// Panics if either value exceeds `u32::MAX`.
+    /// Panics if either value exceeds [`u32::MAX`].
     #[inline]
     pub fn from_usize(start: usize, end: usize) -> Self {
-        assert!(start <= u32::MAX as usize, "range start exceeds u32::MAX");
-        assert!(end <= u32::MAX as usize, "range end exceeds u32::MAX");
         Self {
-            start: start as u32,
-            end: end as u32,
+            start: offset_to_u32(start),
+            end: offset_to_u32(end),
         }
     }
 
@@ -160,6 +215,31 @@ mod tests {
     }
 
     #[test]
+    fn input_size_boundary_is_accepted() {
+        assert!(validate_input_size(MAX_INPUT_BYTES).is_ok());
+    }
+
+    #[cfg(target_pointer_width = "64")]
+    #[test]
+    fn input_size_rejection_reports_the_actual_length() {
+        let too_large = MAX_INPUT_BYTES + 1;
+        let error = validate_input_size(too_large).unwrap_err();
+
+        assert_eq!(error.input_len(), too_large);
+        assert_eq!(
+            error.to_string(),
+            "input is 4294967296 bytes, exceeding the maximum supported size of 4294967295 bytes"
+        );
+    }
+
+    #[cfg(target_pointer_width = "64")]
+    #[test]
+    #[should_panic(expected = "exceeding the maximum supported size")]
+    fn legacy_input_guard_rejects_oversized_lengths() {
+        assert_input_size(MAX_INPUT_BYTES + 1);
+    }
+
+    #[test]
     fn test_range_new() {
         let r = Range::new(10, 20);
         assert_eq!(r.start, 10);
@@ -205,7 +285,7 @@ mod tests {
 
     #[cfg(target_pointer_width = "64")]
     #[test]
-    #[should_panic(expected = "range start exceeds u32::MAX")]
+    #[should_panic(expected = "source offset exceeds the supported u32 range")]
     fn range_from_usize_rejects_truncation() {
         let _ = Range::from_usize(u32::MAX as usize + 1, u32::MAX as usize + 1);
     }

--- a/tests/input_size_tests.rs
+++ b/tests/input_size_tests.rs
@@ -1,0 +1,53 @@
+use ferromark::{
+    BlockParser, InlineParser, MAX_INPUT_BYTES, Options, try_parse, try_parse_with_options,
+    try_to_html, try_to_html_into, try_to_html_with_options, validate_input_size,
+};
+
+#[test]
+fn checked_public_apis_preserve_normal_rendering() {
+    let options = Options::default();
+    assert!(try_to_html("# Heading").unwrap().contains("Heading</h1>"));
+    assert!(
+        try_to_html_with_options("*text*", &options)
+            .unwrap()
+            .contains("<em>text</em>")
+    );
+
+    let mut output = Vec::new();
+    try_to_html_into("paragraph", &mut output).unwrap();
+    assert_eq!(output, b"<p>paragraph</p>\n");
+
+    assert_eq!(try_parse("# Heading").unwrap().headings.len(), 1);
+    assert_eq!(
+        try_parse_with_options("# Heading", &options).unwrap().html,
+        "<h1 id=\"heading\">Heading</h1>\n"
+    );
+
+    let mut parser = BlockParser::try_new(b"paragraph").unwrap();
+    let mut events = Vec::new();
+    parser.parse(&mut events);
+    assert!(!events.is_empty());
+
+    let mut inline = InlineParser::new();
+    let mut inline_events = Vec::new();
+    inline
+        .try_parse(b"paragraph", None, false, &mut inline_events)
+        .unwrap();
+    assert!(!inline_events.is_empty());
+}
+
+#[test]
+fn public_size_check_exposes_a_non_panicking_preflight() {
+    assert!(validate_input_size(MAX_INPUT_BYTES).is_ok());
+}
+
+#[cfg(all(feature = "mdx", target_pointer_width = "64"))]
+#[test]
+fn mdx_checked_apis_compile_and_preserve_normal_results() {
+    use ferromark::mdx::{try_parse_events, try_render, try_segment, try_segment_spanned};
+
+    assert_eq!(try_segment("{value}").unwrap().len(), 1);
+    assert_eq!(try_segment_spanned("{value}").unwrap().len(), 1);
+    assert!(try_render("{value}").unwrap().body.contains("{value}"));
+    assert!(!try_parse_events("{value}").unwrap().events.is_empty());
+}


### PR DESCRIPTION
Fixes #164

## Summary

- define the supported byte limit once through `MAX_INPUT_BYTES`, `InputSizeError`, and `validate_input_size`
- add fallible `try_*` variants for the public parse, render, block, inline, and MDX entry points
- keep existing infallible APIs source-compatible while documenting and consistently enforcing their oversized-input precondition
- map oversized Node inputs to `InvalidArg` and surface a dedicated strict-MDX diagnostic
- centralize checked source-offset narrowing and remove unguarded block/mark truncating casts
- document the limit and migration path in the Rust and Node READMEs

## Validation

- `cargo test --locked --all-features`
- `cargo clippy --all-targets --all-features --locked -- -D warnings`
- `cargo fmt --check`
- `git diff --check`
- Node native crate check
- Node build, lint, and test suite (8/8)
- checked-boundary/API tests without allocating a 4 GiB input
- source-offset cast audit

🔧 Emily Carter · Implementation Agent
