### PR TITLE
fix(ci): verify npm releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,7 @@ jobs:
           components: rustfmt
       - run: cargo fmt --check
       - run: ./scripts/test-check-workflow-pins.sh
+      - run: node ./scripts/test-publish-verification.mjs
       - run: ruby ./scripts/test-node-ci-matrix.rb
       - run: ./scripts/check-workflow-pins.sh
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,6 +7,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: publish-${{ github.repository }}-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   release-please:
     runs-on: ubuntu-latest
@@ -173,3 +177,26 @@ jobs:
       - name: Publish to npm with trusted publishing
         working-directory: node/ferromark
         run: npm publish --access public --provenance
+
+  verify-npm-publish:
+    needs:
+      - release-please
+      - publish-npm
+    if: ${{ always() && needs.release-please.outputs.releases_created == 'true' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+      - name: Set Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+        with:
+          node-version: "22"
+
+      - name: Verify npm release is public
+        env:
+          NPM_PUBLISH_RESULT: ${{ needs.publish-npm.result }}
+        run: node ./node/scripts/verify-npm-publish.mjs

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -32,7 +32,7 @@ jobs:
   publish-crate:
     needs:
       - release-please
-      - publish-npm
+      - verify-npm-publish
     if: ${{ needs.release-please.outputs.releases_created == 'true' }}
     runs-on: ubuntu-latest
     steps:

--- a/node/package.json
+++ b/node/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "build": "pnpm --filter ferromark build",
     "build:native": "pnpm --filter ferromark build:native",
-    "lint": "node --check scripts/clean-install-smoke.mjs && node --check scripts/verify-pack.mjs && node --check scripts/verify-release.mjs && pnpm --filter ferromark lint",
+    "lint": "node --check scripts/clean-install-smoke.mjs && node --check scripts/verify-npm-publish.mjs && node --check scripts/verify-pack.mjs && node --check scripts/verify-release.mjs && pnpm --filter ferromark lint",
     "typecheck": "tsc --noEmit -p tsconfig.json",
     "test": "pnpm --filter ferromark test",
     "pack:check": "node ./scripts/verify-pack.mjs",

--- a/node/scripts/verify-npm-publish.mjs
+++ b/node/scripts/verify-npm-publish.mjs
@@ -1,0 +1,89 @@
+import { readFile } from 'node:fs/promises'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+export const MAX_ATTEMPTS = 8
+export const RETRY_DELAY_MS = 15_000
+export const REQUEST_TIMEOUT_MS = 10_000
+
+export function registryVersionUrl(packageName, version) {
+  return `https://registry.npmjs.org/${encodeURIComponent(packageName)}/${encodeURIComponent(version)}`
+}
+
+const sleep = (milliseconds) => new Promise((resolve) => setTimeout(resolve, milliseconds))
+
+export async function verifyNpmPublication({
+  packageName,
+  version,
+  publishResult,
+  fetchImpl = fetch,
+  sleepImpl = sleep,
+}) {
+  const registryUrl = registryVersionUrl(packageName, version)
+  let published = false
+  let lastObservation = 'the registry did not return the expected package metadata'
+
+  for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt += 1) {
+    try {
+      const response = await fetchImpl(registryUrl, {
+        cache: 'no-store',
+        signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+      })
+
+      if (response.ok) {
+        const metadata = await response.json()
+        if (metadata.name === packageName && metadata.version === version) {
+          published = true
+          console.log(`npm registry confirmed ${packageName}@${version} on attempt ${attempt}`)
+          break
+        }
+        lastObservation = `registry returned ${metadata.name ?? 'unknown'}@${metadata.version ?? 'unknown'}`
+      } else {
+        lastObservation = `registry returned HTTP ${response.status}`
+      }
+    } catch (error) {
+      lastObservation = `registry request failed: ${error.message}`
+    }
+
+    console.log(
+      `npm release verification attempt ${attempt}/${MAX_ATTEMPTS}: ${lastObservation}`,
+    )
+    if (attempt < MAX_ATTEMPTS) {
+      await sleepImpl(RETRY_DELAY_MS)
+    }
+  }
+
+  const failures = []
+  if (publishResult !== 'success') {
+    failures.push(`publish-npm concluded ${publishResult}`)
+  }
+  if (!published) {
+    failures.push(`expected ${packageName}@${version} at ${registryUrl}; ${lastObservation}`)
+  }
+  if (failures.length > 0) {
+    throw new Error(`npm release verification failed: ${failures.join('; ')}`)
+  }
+}
+
+async function main() {
+  const scriptsDirectory = path.dirname(fileURLToPath(import.meta.url))
+  const packageJsonPath = path.join(scriptsDirectory, '..', 'ferromark', 'package.json')
+  const packageJson = JSON.parse(await readFile(packageJsonPath, 'utf8'))
+
+  if (typeof packageJson.name !== 'string' || typeof packageJson.version !== 'string') {
+    throw new Error(`Invalid npm package manifest: ${packageJsonPath}`)
+  }
+
+  await verifyNpmPublication({
+    packageName: packageJson.name,
+    version: packageJson.version,
+    publishResult: process.env.NPM_PUBLISH_RESULT ?? 'unknown',
+  })
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  main().catch((error) => {
+    console.error(error.message)
+    process.exitCode = 1
+  })
+}

--- a/scripts/test-publish-verification.mjs
+++ b/scripts/test-publish-verification.mjs
@@ -31,7 +31,21 @@ function assertValidVerifierJob(source) {
   assert.match(job, /run: node \.\/node\/scripts\/verify-npm-publish\.mjs/)
 }
 
+function assertCratePublicationWaitsForVerification(source) {
+  const crateJob = source.slice(
+    source.indexOf('\n  publish-crate:\n'),
+    source.indexOf('\n  build-native:\n'),
+  )
+  assert.match(
+    crateJob,
+    /needs:\n      - release-please\n      - verify-npm-publish/,
+    'crate publication must wait for successful npm registry verification',
+  )
+  assert.doesNotMatch(crateJob, /- publish-npm/)
+}
+
 assertValidVerifierJob(workflow)
+assertCratePublicationWaitsForVerification(workflow)
 assert.throws(
   () => assertValidVerifierJob(workflow.replace('\n  verify-npm-publish:\n', '\n  npm-check:\n')),
   /verify-npm-publish/,
@@ -53,6 +67,13 @@ assert.throws(
 assert.throws(
   () => assertValidVerifierJob(workflow.replace('timeout-minutes: 5', 'timeout-minutes: 30')),
   /timeout-minutes: 5/,
+)
+assert.throws(
+  () =>
+    assertCratePublicationWaitsForVerification(
+      workflow.replace('- verify-npm-publish', '- publish-npm'),
+    ),
+  /crate publication must wait for successful npm registry verification/,
 )
 
 assert.equal(registryVersionUrl('ferromark', '0.7.0'), 'https://registry.npmjs.org/ferromark/0.7.0')

--- a/scripts/test-publish-verification.mjs
+++ b/scripts/test-publish-verification.mjs
@@ -1,0 +1,116 @@
+import assert from 'node:assert/strict'
+import { readFile } from 'node:fs/promises'
+import path from 'node:path'
+import { fileURLToPath, pathToFileURL } from 'node:url'
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..')
+const workflowPath = path.join(root, '.github', 'workflows', 'publish.yml')
+const workflow = await readFile(workflowPath, 'utf8')
+const { MAX_ATTEMPTS, registryVersionUrl, verifyNpmPublication } = await import(
+  pathToFileURL(path.join(root, 'node', 'scripts', 'verify-npm-publish.mjs')).href,
+)
+
+function verifierJob(source) {
+  const marker = '\n  verify-npm-publish:\n'
+  const start = source.indexOf(marker)
+  assert.notEqual(start, -1, 'publish workflow must define verify-npm-publish')
+  const remaining = source.slice(start + marker.length)
+  const nextJob = remaining.search(/\n  [a-z0-9-]+:\n/)
+  return nextJob === -1 ? remaining : remaining.slice(0, nextJob)
+}
+
+function assertValidVerifierJob(source) {
+  const job = verifierJob(source)
+  assert.match(job, /needs:\n      - release-please\n      - publish-npm/)
+  assert.match(
+    job,
+    /if: \$\{\{ always\(\) && needs\.release-please\.outputs\.releases_created == 'true' \}\}/,
+  )
+  assert.match(job, /timeout-minutes: 5/)
+  assert.match(job, /NPM_PUBLISH_RESULT: \$\{\{ needs\.publish-npm\.result \}\}/)
+  assert.match(job, /run: node \.\/node\/scripts\/verify-npm-publish\.mjs/)
+}
+
+assertValidVerifierJob(workflow)
+assert.throws(
+  () => assertValidVerifierJob(workflow.replace('\n  verify-npm-publish:\n', '\n  npm-check:\n')),
+  /verify-npm-publish/,
+)
+assert.throws(
+  () =>
+    assertValidVerifierJob(
+      workflow.replace(
+        '  verify-npm-publish:\n    needs:\n      - release-please\n      - publish-npm\n',
+        '  verify-npm-publish:\n    needs:\n      - release-please\n      - build-native\n',
+      ),
+    ),
+  /publish-npm/,
+)
+assert.throws(
+  () => assertValidVerifierJob(workflow.replace('always() && ', '')),
+  /always/,
+)
+assert.throws(
+  () => assertValidVerifierJob(workflow.replace('timeout-minutes: 5', 'timeout-minutes: 30')),
+  /timeout-minutes: 5/,
+)
+
+assert.equal(registryVersionUrl('ferromark', '0.7.0'), 'https://registry.npmjs.org/ferromark/0.7.0')
+
+let attempts = 0
+await verifyNpmPublication({
+  packageName: 'ferromark',
+  version: '0.7.0',
+  publishResult: 'success',
+  fetchImpl: async () => {
+    attempts += 1
+    return {
+      ok: attempts === 2,
+      status: attempts === 2 ? 200 : 404,
+      json: async () => ({ name: 'ferromark', version: '0.7.0' }),
+    }
+  },
+  sleepImpl: async () => {},
+})
+assert.equal(attempts, 2)
+
+let wrongVersionAttempts = 0
+await assert.rejects(
+  verifyNpmPublication({
+    packageName: 'ferromark',
+    version: '0.7.0',
+    publishResult: 'success',
+    fetchImpl: async () => {
+      wrongVersionAttempts += 1
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({ name: 'ferromark', version: '0.6.0' }),
+      }
+    },
+    sleepImpl: async () => {},
+  }),
+  /expected ferromark@0\.7\.0/,
+)
+assert.equal(wrongVersionAttempts, MAX_ATTEMPTS, 'registry polling must stay bounded')
+
+await assert.rejects(
+  verifyNpmPublication({
+    packageName: 'ferromark',
+    version: '0.7.0',
+    publishResult: 'failure',
+    fetchImpl: async () => ({
+      ok: true,
+      status: 200,
+      json: async () => ({ name: 'wrong-package', version: '0.7.0' }),
+    }),
+    sleepImpl: async () => {},
+  }),
+  (error) => {
+    assert.match(error.message, /publish-npm concluded failure/)
+    assert.match(error.message, /registry returned wrong-package@0\.7\.0/)
+    return true
+  },
+)
+
+console.log('Publish verification workflow and retry contract checks passed')


### PR DESCRIPTION
Fixes #163

## Summary

- add an always-run post-publish check that makes failed or skipped npm publication visible
- poll the public registry for the exact version in `node/ferromark/package.json` with eight bounded retries, a 15-second delay, and a 10-second request timeout
- report the upstream `publish-npm` result separately from registry propagation failures
- keep crate publication coupled to npm intentionally so the project cannot silently create another split release
- serialize publish workflows without cancellation and run the verifier with read-only permissions and no secrets
- add offline contract tests for the release gate, dependencies, timeouts, retry bounds, package name, and expected-version source

## Validation

- verifier contract and fixture tests
- live read-only npm check against published version 0.7.0
- workflow YAML parse and action pin checks
- CI matrix policy test
- `cargo test --locked`
- `cargo clippy --all-targets --all-features --locked -- -D warnings`
- `cargo fmt --check`
- `git diff --check`

🔧 Emily Carter · Implementation Agent
