### PR TITLE
perf(mdx): cache unterminated expression scans

### DIFF
--- a/benches/mdx.rs
+++ b/benches/mdx.rs
@@ -53,14 +53,26 @@ fn container_flow_mdx() -> String {
     .repeat(240)
 }
 
+fn unterminated_expression_mdx() -> String {
+    "{unterminated\n".repeat(8_192)
+}
+
+fn unterminated_jsx_attribute_mdx() -> String {
+    "<Component value={unterminated\n".repeat(8_192)
+}
+
 fn bench_mdx(c: &mut Criterion) {
     let root_flow = root_flow_mdx();
     let container_flow = container_flow_mdx();
+    let unterminated_expression = unterminated_expression_mdx();
+    let unterminated_jsx_attribute = unterminated_jsx_attribute_mdx();
 
     // Keep the experiment honest: the probe must actually find the JSX lines
     // present in the fixture before it is used as a benchmarked operation.
     assert_eq!(logical_flow_candidates(&root_flow), 480);
     assert_eq!(logical_flow_candidates(&container_flow), 480);
+    assert_eq!(mdx::segment(&unterminated_expression).len(), 1);
+    assert_eq!(mdx::segment(&unterminated_jsx_attribute).len(), 1);
 
     let mut group = c.benchmark_group("mdx");
     group.sample_size(80);
@@ -71,6 +83,11 @@ fn bench_mdx(c: &mut Criterion) {
         ("plain_markdown", PLAIN_MARKDOWN),
         ("root_flow", root_flow.as_str()),
         ("container_flow", container_flow.as_str()),
+        ("unterminated_expression", unterminated_expression.as_str()),
+        (
+            "unterminated_jsx_attribute",
+            unterminated_jsx_attribute.as_str(),
+        ),
     ] {
         group.throughput(Throughput::Bytes(input.len() as u64));
         group.bench_with_input(format!("segment/{name}"), input, |b, input| {

--- a/src/mdx/expr.rs
+++ b/src/mdx/expr.rs
@@ -1,3 +1,74 @@
+const UNTERMINATED_EXPRESSION: usize = usize::MAX;
+
+/// Cached expression ends for a single input buffer.
+///
+/// Entries are built from right to left. When a scan reaches a later opening
+/// brace in normal expression syntax, its cached result is therefore already
+/// available: a completed nested expression can be skipped as one unit, while
+/// an unterminated nested expression proves that the current one cannot close.
+pub(crate) struct ExpressionEnds {
+    ends: Vec<usize>,
+    #[cfg(test)]
+    scanned_bytes: usize,
+}
+
+impl ExpressionEnds {
+    pub(crate) fn new(bytes: &[u8]) -> Self {
+        if !bytes.contains(&b'{') {
+            return Self {
+                ends: Vec::new(),
+                #[cfg(test)]
+                scanned_bytes: 0,
+            };
+        }
+
+        let mut ends = vec![UNTERMINATED_EXPRESSION; bytes.len()];
+        let mut work = ScanWork::default();
+
+        for start in (0..bytes.len()).rev() {
+            if bytes[start] == b'{' {
+                ends[start] = find_expression_end_from(bytes, start, Some(&ends), &mut work)
+                    .unwrap_or(UNTERMINATED_EXPRESSION);
+            }
+        }
+
+        Self {
+            ends,
+            #[cfg(test)]
+            scanned_bytes: bytes.len() + work.scanned_bytes,
+        }
+    }
+
+    /// Return the absolute offset after the matching `}` for `start`.
+    pub(crate) fn end_at(&self, start: usize) -> Option<usize> {
+        self.ends
+            .get(start)
+            .copied()
+            .filter(|end| *end != UNTERMINATED_EXPRESSION)
+    }
+
+    #[cfg(test)]
+    fn scanned_bytes(&self) -> usize {
+        self.scanned_bytes
+    }
+}
+
+#[derive(Default)]
+struct ScanWork {
+    #[cfg(test)]
+    scanned_bytes: usize,
+}
+
+impl ScanWork {
+    #[inline]
+    fn visit(&mut self) {
+        #[cfg(test)]
+        {
+            self.scanned_bytes += 1;
+        }
+    }
+}
+
 /// Find the end of a JSX expression starting at `{`.
 ///
 /// `bytes` must begin with `{`. Returns the byte offset **after** the closing `}`,
@@ -12,15 +83,34 @@
 /// - Block comments (`/* ... */`)
 pub fn find_expression_end(bytes: &[u8]) -> Option<usize> {
     debug_assert!(bytes.first() == Some(&b'{'));
+    find_expression_end_from(bytes, 0, None, &mut ScanWork::default())
+}
+
+fn find_expression_end_from(
+    bytes: &[u8],
+    start: usize,
+    cached_ends: Option<&[usize]>,
+    work: &mut ScanWork,
+) -> Option<usize> {
+    debug_assert!(bytes.get(start) == Some(&b'{'));
     let len = bytes.len();
-    let mut pos = 1; // skip opening `{`
+    let mut pos = start + 1; // skip opening `{`
     let mut depth: u32 = 1;
 
     while pos < len {
+        work.visit();
         match bytes[pos] {
             b'{' => {
-                depth += 1;
-                pos += 1;
+                if let Some(cached_ends) = cached_ends {
+                    let end = cached_ends[pos];
+                    if end == UNTERMINATED_EXPRESSION {
+                        return None;
+                    }
+                    pos = end;
+                } else {
+                    depth += 1;
+                    pos += 1;
+                }
             }
             b'}' => {
                 depth -= 1;
@@ -30,20 +120,20 @@ pub fn find_expression_end(bytes: &[u8]) -> Option<usize> {
                 pos += 1;
             }
             b'"' => {
-                pos = skip_double_quoted(bytes, pos)?;
+                pos = skip_double_quoted(bytes, pos, work)?;
             }
             b'\'' => {
-                pos = skip_single_quoted(bytes, pos)?;
+                pos = skip_single_quoted(bytes, pos, work)?;
             }
             b'`' => {
-                pos = skip_template_literal(bytes, pos)?;
+                pos = skip_template_literal(bytes, pos, cached_ends, work)?;
             }
             b'/' if pos + 1 < len => match bytes[pos + 1] {
                 b'/' => {
-                    pos = skip_line_comment(bytes, pos);
+                    pos = skip_line_comment(bytes, pos, work);
                 }
                 b'*' => {
-                    pos = skip_block_comment(bytes, pos)?;
+                    pos = skip_block_comment(bytes, pos, work)?;
                 }
                 _ => pos += 1,
             },
@@ -56,10 +146,11 @@ pub fn find_expression_end(bytes: &[u8]) -> Option<usize> {
 
 /// Skip a `"..."` string. `pos` points at the opening `"`.
 /// Returns position after the closing `"`, or `None` if unterminated.
-fn skip_double_quoted(bytes: &[u8], start: usize) -> Option<usize> {
+fn skip_double_quoted(bytes: &[u8], start: usize, work: &mut ScanWork) -> Option<usize> {
     let len = bytes.len();
     let mut pos = start + 1;
     while pos < len {
+        work.visit();
         match bytes[pos] {
             b'\\' => pos += 2, // skip escaped char
             b'"' => return Some(pos + 1),
@@ -71,10 +162,11 @@ fn skip_double_quoted(bytes: &[u8], start: usize) -> Option<usize> {
 
 /// Skip a `'...'` string. `pos` points at the opening `'`.
 /// Returns position after the closing `'`, or `None` if unterminated.
-fn skip_single_quoted(bytes: &[u8], start: usize) -> Option<usize> {
+fn skip_single_quoted(bytes: &[u8], start: usize, work: &mut ScanWork) -> Option<usize> {
     let len = bytes.len();
     let mut pos = start + 1;
     while pos < len {
+        work.visit();
         match bytes[pos] {
             b'\\' => pos += 2,
             b'\'' => return Some(pos + 1),
@@ -87,17 +179,31 @@ fn skip_single_quoted(bytes: &[u8], start: usize) -> Option<usize> {
 /// Skip a `` `...` `` template literal, including nested `${...}`.
 /// `pos` points at the opening `` ` ``.
 /// Returns position after the closing `` ` ``, or `None` if unterminated.
-fn skip_template_literal(bytes: &[u8], start: usize) -> Option<usize> {
+fn skip_template_literal(
+    bytes: &[u8],
+    start: usize,
+    cached_ends: Option<&[usize]>,
+    work: &mut ScanWork,
+) -> Option<usize> {
     let len = bytes.len();
     let mut pos = start + 1;
     while pos < len {
+        work.visit();
         match bytes[pos] {
             b'\\' => pos += 2,
             b'`' => return Some(pos + 1),
             b'$' if pos + 1 < len && bytes[pos + 1] == b'{' => {
                 // Nested expression inside template literal
-                let end = find_expression_end(&bytes[pos + 1..])?;
-                pos = pos + 1 + end;
+                let expression_start = pos + 1;
+                if let Some(cached_ends) = cached_ends {
+                    let end = cached_ends[expression_start];
+                    if end == UNTERMINATED_EXPRESSION {
+                        return None;
+                    }
+                    pos = end;
+                } else {
+                    pos = find_expression_end_from(bytes, expression_start, None, work)?;
+                }
             }
             _ => pos += 1,
         }
@@ -106,10 +212,11 @@ fn skip_template_literal(bytes: &[u8], start: usize) -> Option<usize> {
 }
 
 /// Skip a `// ...` line comment. Returns position after the newline (or EOF).
-fn skip_line_comment(bytes: &[u8], start: usize) -> usize {
+fn skip_line_comment(bytes: &[u8], start: usize, work: &mut ScanWork) -> usize {
     let len = bytes.len();
     let mut pos = start + 2;
     while pos < len {
+        work.visit();
         if bytes[pos] == b'\n' {
             return pos + 1;
         }
@@ -119,10 +226,11 @@ fn skip_line_comment(bytes: &[u8], start: usize) -> usize {
 }
 
 /// Skip a `/* ... */` block comment. Returns position after `*/`, or `None` if unterminated.
-fn skip_block_comment(bytes: &[u8], start: usize) -> Option<usize> {
+fn skip_block_comment(bytes: &[u8], start: usize, work: &mut ScanWork) -> Option<usize> {
     let len = bytes.len();
     let mut pos = start + 2;
     while pos + 1 < len {
+        work.visit();
         if bytes[pos] == b'*' && bytes[pos + 1] == b'/' {
             return Some(pos + 2);
         }
@@ -205,5 +313,67 @@ mod tests {
     fn slash_not_comment() {
         // A lone `/` inside an expression is not a comment start
         assert_eq!(find_expression_end(b"{a / b}"), Some(7));
+    }
+
+    #[test]
+    fn cached_ends_match_individual_expression_scans() {
+        for input in [
+            b"{outer {inner}}".as_slice(),
+            b"{\"{inside string}\"}\n{later}".as_slice(),
+            b"{`template ${value}`}\n{later}".as_slice(),
+            b"{unterminated\n{later}".as_slice(),
+            b"{\"unterminated\n{later}".as_slice(),
+        ] {
+            let ends = ExpressionEnds::new(input);
+            for (start, byte) in input.iter().enumerate() {
+                if *byte == b'{' {
+                    assert_eq!(
+                        ends.end_at(start).map(|end| end - start),
+                        find_expression_end(&input[start..]),
+                        "cache differs at byte {start} in {input:?}",
+                    );
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn cached_ends_bound_unterminated_expression_scan_work() {
+        let input = "{\n".repeat(8_192);
+        let ends = ExpressionEnds::new(input.as_bytes());
+
+        assert!(
+            (0..input.len())
+                .step_by(2)
+                .all(|start| ends.end_at(start).is_none()),
+            "every opening brace is unterminated",
+        );
+        assert!(
+            ends.scanned_bytes() <= input.len() * 3,
+            "cached expression scans visited {} bytes for a {} byte input",
+            ends.scanned_bytes(),
+            input.len(),
+        );
+    }
+
+    #[test]
+    fn cached_ends_bound_unterminated_jsx_attribute_expression_scan_work() {
+        let input = "<Component value={unterminated\n".repeat(8_192);
+        let ends = ExpressionEnds::new(input.as_bytes());
+
+        assert!(
+            input
+                .bytes()
+                .enumerate()
+                .filter(|(_, byte)| *byte == b'{')
+                .all(|(start, _)| ends.end_at(start).is_none()),
+            "every JSX attribute expression is unterminated",
+        );
+        assert!(
+            ends.scanned_bytes() <= input.len() * 3,
+            "cached JSX attribute scans visited {} bytes for a {} byte input",
+            ends.scanned_bytes(),
+            input.len(),
+        );
     }
 }

--- a/src/mdx/expr.rs
+++ b/src/mdx/expr.rs
@@ -1,4 +1,24 @@
+use rustc_hash::FxHashMap;
+
+#[cfg(test)]
+use std::cell::Cell;
+
 const UNTERMINATED_EXPRESSION: usize = usize::MAX;
+
+#[cfg(test)]
+thread_local! {
+    static CACHE_BUILD_COUNT: Cell<usize> = const { Cell::new(0) };
+}
+
+#[cfg(test)]
+pub(crate) fn reset_cache_build_count() {
+    CACHE_BUILD_COUNT.with(|count| count.set(0));
+}
+
+#[cfg(test)]
+pub(crate) fn cache_build_count() -> usize {
+    CACHE_BUILD_COUNT.with(Cell::get)
+}
 
 /// Cached expression ends for a single input buffer.
 ///
@@ -6,29 +26,69 @@ const UNTERMINATED_EXPRESSION: usize = usize::MAX;
 /// brace in normal expression syntax, its cached result is therefore already
 /// available: a completed nested expression can be skipped as one unit, while
 /// an unterminated nested expression proves that the current one cannot close.
+/// Sparse documents store only opening braces; dense documents use a compact
+/// direct index once that is smaller than a hash table.
 pub(crate) struct ExpressionEnds {
-    ends: Vec<usize>,
+    ends: ExpressionEndStorage,
     #[cfg(test)]
     scanned_bytes: usize,
 }
 
+enum ExpressionEndStorage {
+    Sparse(FxHashMap<usize, usize>),
+    Dense(Vec<usize>),
+}
+
+impl ExpressionEndStorage {
+    fn new(input_len: usize, brace_count: usize) -> Self {
+        // A direct index is more compact than a hash table once openings are
+        // dense. Otherwise, retain only the positions that can be queried.
+        if brace_count > input_len / 4 {
+            Self::Dense(vec![UNTERMINATED_EXPRESSION; input_len])
+        } else {
+            Self::Sparse(FxHashMap::default())
+        }
+    }
+
+    fn insert(&mut self, start: usize, end: usize) {
+        match self {
+            Self::Sparse(ends) => {
+                ends.insert(start, end);
+            }
+            Self::Dense(ends) => ends[start] = end,
+        }
+    }
+
+    fn get(&self, start: usize) -> usize {
+        match self {
+            Self::Sparse(ends) => ends[&start],
+            Self::Dense(ends) => ends[start],
+        }
+    }
+
+    #[cfg(test)]
+    fn entry_count(&self) -> usize {
+        match self {
+            Self::Sparse(ends) => ends.len(),
+            Self::Dense(ends) => ends.len(),
+        }
+    }
+}
+
 impl ExpressionEnds {
     pub(crate) fn new(bytes: &[u8]) -> Self {
-        if !bytes.contains(&b'{') {
-            return Self {
-                ends: Vec::new(),
-                #[cfg(test)]
-                scanned_bytes: 0,
-            };
-        }
+        #[cfg(test)]
+        CACHE_BUILD_COUNT.with(|count| count.set(count.get() + 1));
 
-        let mut ends = vec![UNTERMINATED_EXPRESSION; bytes.len()];
+        let brace_count = bytes.iter().filter(|&&byte| byte == b'{').count();
+        let mut ends = ExpressionEndStorage::new(bytes.len(), brace_count);
         let mut work = ScanWork::default();
 
         for start in (0..bytes.len()).rev() {
             if bytes[start] == b'{' {
-                ends[start] = find_expression_end_from(bytes, start, Some(&ends), &mut work)
+                let end = find_expression_end_from(bytes, start, Some(&ends), &mut work)
                     .unwrap_or(UNTERMINATED_EXPRESSION);
+                ends.insert(start, end);
             }
         }
 
@@ -41,15 +101,18 @@ impl ExpressionEnds {
 
     /// Return the absolute offset after the matching `}` for `start`.
     pub(crate) fn end_at(&self, start: usize) -> Option<usize> {
-        self.ends
-            .get(start)
-            .copied()
-            .filter(|end| *end != UNTERMINATED_EXPRESSION)
+        let end = self.ends.get(start);
+        (end != UNTERMINATED_EXPRESSION).then_some(end)
     }
 
     #[cfg(test)]
     fn scanned_bytes(&self) -> usize {
         self.scanned_bytes
+    }
+
+    #[cfg(test)]
+    fn entry_count(&self) -> usize {
+        self.ends.entry_count()
     }
 }
 
@@ -89,7 +152,7 @@ pub fn find_expression_end(bytes: &[u8]) -> Option<usize> {
 fn find_expression_end_from(
     bytes: &[u8],
     start: usize,
-    cached_ends: Option<&[usize]>,
+    cached_ends: Option<&ExpressionEndStorage>,
     work: &mut ScanWork,
 ) -> Option<usize> {
     debug_assert!(bytes.get(start) == Some(&b'{'));
@@ -102,7 +165,7 @@ fn find_expression_end_from(
         match bytes[pos] {
             b'{' => {
                 if let Some(cached_ends) = cached_ends {
-                    let end = cached_ends[pos];
+                    let end = cached_ends.get(pos);
                     if end == UNTERMINATED_EXPRESSION {
                         return None;
                     }
@@ -182,7 +245,7 @@ fn skip_single_quoted(bytes: &[u8], start: usize, work: &mut ScanWork) -> Option
 fn skip_template_literal(
     bytes: &[u8],
     start: usize,
-    cached_ends: Option<&[usize]>,
+    cached_ends: Option<&ExpressionEndStorage>,
     work: &mut ScanWork,
 ) -> Option<usize> {
     let len = bytes.len();
@@ -196,7 +259,7 @@ fn skip_template_literal(
                 // Nested expression inside template literal
                 let expression_start = pos + 1;
                 if let Some(cached_ends) = cached_ends {
-                    let end = cached_ends[expression_start];
+                    let end = cached_ends.get(expression_start);
                     if end == UNTERMINATED_EXPRESSION {
                         return None;
                     }
@@ -374,6 +437,19 @@ mod tests {
             "cached JSX attribute scans visited {} bytes for a {} byte input",
             ends.scanned_bytes(),
             input.len(),
+        );
+    }
+
+    #[test]
+    fn cached_ends_store_only_sparse_opening_braces() {
+        let mut input = "plain Markdown without expressions\n".repeat(32_768);
+        input.push_str("{value}\n");
+        let ends = ExpressionEnds::new(input.as_bytes());
+
+        assert_eq!(ends.entry_count(), 1);
+        assert_eq!(
+            ends.end_at(input.len() - "{value}\n".len()),
+            Some(input.len() - 1)
         );
     }
 }

--- a/src/mdx/expr.rs
+++ b/src/mdx/expr.rs
@@ -34,6 +34,163 @@ pub(crate) struct ExpressionEnds {
     scanned_bytes: usize,
 }
 
+/// Cached ends for lexical constructs that can otherwise make every earlier
+/// expression scan walk to EOF. Unlike expression ends, these values depend
+/// only on the construct's delimiter bytes, so they can be shared safely by
+/// every expression start in the input.
+struct LexicalEnds {
+    double_quotes: FxHashMap<usize, usize>,
+    single_quotes: FxHashMap<usize, usize>,
+    templates: FxHashMap<usize, TemplateEnd>,
+    line_comments: FxHashMap<usize, usize>,
+    block_comments: FxHashMap<usize, usize>,
+}
+
+#[derive(Clone, Copy)]
+struct TemplateEnd {
+    end: usize,
+    has_interpolation: bool,
+}
+
+impl LexicalEnds {
+    fn new(bytes: &[u8]) -> Self {
+        let mut double_quote_positions = Vec::new();
+        let mut single_quote_positions = Vec::new();
+        let mut template_positions = Vec::new();
+        let mut preceding_backslashes = 0usize;
+
+        for (pos, byte) in bytes.iter().copied().enumerate() {
+            if byte == b'\\' {
+                preceding_backslashes += 1;
+                continue;
+            }
+
+            let escaped = preceding_backslashes % 2 == 1;
+            match byte {
+                b'"' => double_quote_positions.push((pos, escaped)),
+                b'\'' => single_quote_positions.push((pos, escaped)),
+                b'`' => template_positions.push((pos, escaped)),
+                _ => {}
+            }
+            preceding_backslashes = 0;
+        }
+
+        let mut lexical_ends = Self {
+            double_quotes: FxHashMap::default(),
+            single_quotes: FxHashMap::default(),
+            templates: FxHashMap::default(),
+            line_comments: FxHashMap::default(),
+            block_comments: FxHashMap::default(),
+        };
+        fill_quoted_ends(&mut lexical_ends.double_quotes, &double_quote_positions);
+        fill_quoted_ends(&mut lexical_ends.single_quotes, &single_quote_positions);
+        let mut next_line_end = bytes.len();
+        let mut next_block_comment_end = None;
+        let mut next_template_interpolation = None;
+        let mut template_interpolations = vec![None; template_positions.len()];
+        let mut template_index = template_positions.len();
+        for pos in (0..bytes.len()).rev() {
+            if bytes[pos] == b'$' && bytes.get(pos + 1) == Some(&b'{') {
+                next_template_interpolation = Some(pos);
+            }
+            if template_index > 0 && template_positions[template_index - 1].0 == pos {
+                template_index -= 1;
+                template_interpolations[template_index] = next_template_interpolation;
+            }
+            if bytes[pos] == b'\n' {
+                next_line_end = pos + 1;
+            }
+            if bytes[pos] == b'*' && bytes.get(pos + 1) == Some(&b'/') {
+                next_block_comment_end = Some(pos + 2);
+            }
+            if bytes[pos] == b'/' && bytes.get(pos + 1) == Some(&b'/') {
+                lexical_ends.line_comments.insert(pos, next_line_end);
+            }
+            if bytes[pos] == b'/' && bytes.get(pos + 1) == Some(&b'*') {
+                lexical_ends.block_comments.insert(
+                    pos,
+                    next_block_comment_end.unwrap_or(UNTERMINATED_EXPRESSION),
+                );
+            }
+        }
+        fill_template_ends(
+            &mut lexical_ends.templates,
+            &template_positions,
+            &template_interpolations,
+        );
+
+        lexical_ends
+    }
+
+    fn double_quote_end(&self, start: usize) -> Option<usize> {
+        cached_end(&self.double_quotes, start)
+    }
+
+    fn single_quote_end(&self, start: usize) -> Option<usize> {
+        cached_end(&self.single_quotes, start)
+    }
+
+    fn template_end(&self, start: usize) -> Option<TemplateEnd> {
+        self.templates
+            .get(&start)
+            .copied()
+            .filter(|end| end.end != UNTERMINATED_EXPRESSION)
+    }
+
+    fn line_comment_end(&self, start: usize) -> usize {
+        self.line_comments[&start]
+    }
+
+    fn block_comment_end(&self, start: usize) -> Option<usize> {
+        cached_end(&self.block_comments, start)
+    }
+}
+
+fn fill_quoted_ends(ends: &mut FxHashMap<usize, usize>, positions: &[(usize, bool)]) {
+    let mut next_closing = None;
+    for &(pos, escaped) in positions.iter().rev() {
+        ends.insert(pos, next_closing.unwrap_or(UNTERMINATED_EXPRESSION));
+        if !escaped {
+            next_closing = Some(pos + 1);
+        }
+    }
+}
+
+fn fill_template_ends(
+    ends: &mut FxHashMap<usize, TemplateEnd>,
+    positions: &[(usize, bool)],
+    interpolations: &[Option<usize>],
+) {
+    let mut next_closing = None;
+    for (&(pos, escaped), interpolation) in positions.iter().zip(interpolations).rev() {
+        let end = next_closing.unwrap_or(UNTERMINATED_EXPRESSION);
+        ends.insert(
+            pos,
+            TemplateEnd {
+                end,
+                has_interpolation: interpolation.is_some_and(|start| start < end),
+            },
+        );
+        if !escaped {
+            next_closing = Some(pos + 1);
+        }
+    }
+}
+
+fn cached_end(ends: &FxHashMap<usize, usize>, start: usize) -> Option<usize> {
+    (*ends
+        .get(&start)
+        .expect("lexical cache contains every queried delimiter")
+        != UNTERMINATED_EXPRESSION)
+        .then(|| ends[&start])
+}
+
+#[derive(Clone, Copy)]
+struct CachedEnds<'a> {
+    expressions: &'a ExpressionEndStorage,
+    lexical: &'a LexicalEnds,
+}
+
 enum ExpressionEndStorage {
     Sparse(FxHashMap<usize, usize>),
     Dense(Vec<usize>),
@@ -82,12 +239,21 @@ impl ExpressionEnds {
 
         let brace_count = bytes.iter().filter(|&&byte| byte == b'{').count();
         let mut ends = ExpressionEndStorage::new(bytes.len(), brace_count);
+        let lexical_ends = LexicalEnds::new(bytes);
         let mut work = ScanWork::default();
 
         for start in (0..bytes.len()).rev() {
             if bytes[start] == b'{' {
-                let end = find_expression_end_from(bytes, start, Some(&ends), &mut work)
-                    .unwrap_or(UNTERMINATED_EXPRESSION);
+                let end = find_expression_end_from(
+                    bytes,
+                    start,
+                    Some(CachedEnds {
+                        expressions: &ends,
+                        lexical: &lexical_ends,
+                    }),
+                    &mut work,
+                )
+                .unwrap_or(UNTERMINATED_EXPRESSION);
                 ends.insert(start, end);
             }
         }
@@ -95,7 +261,7 @@ impl ExpressionEnds {
         Self {
             ends,
             #[cfg(test)]
-            scanned_bytes: bytes.len() + work.scanned_bytes,
+            scanned_bytes: bytes.len() * 2 + work.scanned_bytes,
         }
     }
 
@@ -152,7 +318,7 @@ pub fn find_expression_end(bytes: &[u8]) -> Option<usize> {
 fn find_expression_end_from(
     bytes: &[u8],
     start: usize,
-    cached_ends: Option<&ExpressionEndStorage>,
+    cached_ends: Option<CachedEnds<'_>>,
     work: &mut ScanWork,
 ) -> Option<usize> {
     debug_assert!(bytes.get(start) == Some(&b'{'));
@@ -165,7 +331,7 @@ fn find_expression_end_from(
         match bytes[pos] {
             b'{' => {
                 if let Some(cached_ends) = cached_ends {
-                    let end = cached_ends.get(pos);
+                    let end = cached_ends.expressions.get(pos);
                     if end == UNTERMINATED_EXPRESSION {
                         return None;
                     }
@@ -183,20 +349,20 @@ fn find_expression_end_from(
                 pos += 1;
             }
             b'"' => {
-                pos = skip_double_quoted(bytes, pos, work)?;
+                pos = skip_double_quoted(bytes, pos, cached_ends, work)?;
             }
             b'\'' => {
-                pos = skip_single_quoted(bytes, pos, work)?;
+                pos = skip_single_quoted(bytes, pos, cached_ends, work)?;
             }
             b'`' => {
                 pos = skip_template_literal(bytes, pos, cached_ends, work)?;
             }
             b'/' if pos + 1 < len => match bytes[pos + 1] {
                 b'/' => {
-                    pos = skip_line_comment(bytes, pos, work);
+                    pos = skip_line_comment(bytes, pos, cached_ends, work);
                 }
                 b'*' => {
-                    pos = skip_block_comment(bytes, pos, work)?;
+                    pos = skip_block_comment(bytes, pos, cached_ends, work)?;
                 }
                 _ => pos += 1,
             },
@@ -209,7 +375,15 @@ fn find_expression_end_from(
 
 /// Skip a `"..."` string. `pos` points at the opening `"`.
 /// Returns position after the closing `"`, or `None` if unterminated.
-fn skip_double_quoted(bytes: &[u8], start: usize, work: &mut ScanWork) -> Option<usize> {
+fn skip_double_quoted(
+    bytes: &[u8],
+    start: usize,
+    cached_ends: Option<CachedEnds<'_>>,
+    work: &mut ScanWork,
+) -> Option<usize> {
+    if let Some(cached_ends) = cached_ends {
+        return cached_ends.lexical.double_quote_end(start);
+    }
     let len = bytes.len();
     let mut pos = start + 1;
     while pos < len {
@@ -225,7 +399,15 @@ fn skip_double_quoted(bytes: &[u8], start: usize, work: &mut ScanWork) -> Option
 
 /// Skip a `'...'` string. `pos` points at the opening `'`.
 /// Returns position after the closing `'`, or `None` if unterminated.
-fn skip_single_quoted(bytes: &[u8], start: usize, work: &mut ScanWork) -> Option<usize> {
+fn skip_single_quoted(
+    bytes: &[u8],
+    start: usize,
+    cached_ends: Option<CachedEnds<'_>>,
+    work: &mut ScanWork,
+) -> Option<usize> {
+    if let Some(cached_ends) = cached_ends {
+        return cached_ends.lexical.single_quote_end(start);
+    }
     let len = bytes.len();
     let mut pos = start + 1;
     while pos < len {
@@ -245,10 +427,16 @@ fn skip_single_quoted(bytes: &[u8], start: usize, work: &mut ScanWork) -> Option
 fn skip_template_literal(
     bytes: &[u8],
     start: usize,
-    cached_ends: Option<&ExpressionEndStorage>,
+    cached_ends: Option<CachedEnds<'_>>,
     work: &mut ScanWork,
 ) -> Option<usize> {
     let len = bytes.len();
+    if let Some(cached_ends) = cached_ends {
+        let template_end = cached_ends.lexical.template_end(start)?;
+        if !template_end.has_interpolation {
+            return Some(template_end.end);
+        }
+    }
     let mut pos = start + 1;
     while pos < len {
         work.visit();
@@ -259,7 +447,7 @@ fn skip_template_literal(
                 // Nested expression inside template literal
                 let expression_start = pos + 1;
                 if let Some(cached_ends) = cached_ends {
-                    let end = cached_ends.get(expression_start);
+                    let end = cached_ends.expressions.get(expression_start);
                     if end == UNTERMINATED_EXPRESSION {
                         return None;
                     }
@@ -275,7 +463,15 @@ fn skip_template_literal(
 }
 
 /// Skip a `// ...` line comment. Returns position after the newline (or EOF).
-fn skip_line_comment(bytes: &[u8], start: usize, work: &mut ScanWork) -> usize {
+fn skip_line_comment(
+    bytes: &[u8],
+    start: usize,
+    cached_ends: Option<CachedEnds<'_>>,
+    work: &mut ScanWork,
+) -> usize {
+    if let Some(cached_ends) = cached_ends {
+        return cached_ends.lexical.line_comment_end(start);
+    }
     let len = bytes.len();
     let mut pos = start + 2;
     while pos < len {
@@ -289,7 +485,15 @@ fn skip_line_comment(bytes: &[u8], start: usize, work: &mut ScanWork) -> usize {
 }
 
 /// Skip a `/* ... */` block comment. Returns position after `*/`, or `None` if unterminated.
-fn skip_block_comment(bytes: &[u8], start: usize, work: &mut ScanWork) -> Option<usize> {
+fn skip_block_comment(
+    bytes: &[u8],
+    start: usize,
+    cached_ends: Option<CachedEnds<'_>>,
+    work: &mut ScanWork,
+) -> Option<usize> {
+    if let Some(cached_ends) = cached_ends {
+        return cached_ends.lexical.block_comment_end(start);
+    }
     let len = bytes.len();
     let mut pos = start + 2;
     while pos + 1 < len {
@@ -386,6 +590,14 @@ mod tests {
             b"{`template ${value}`}\n{later}".as_slice(),
             b"{unterminated\n{later}".as_slice(),
             b"{\"unterminated\n{later}".as_slice(),
+            b"{/* unterminated\n{later}".as_slice(),
+            b"{// unterminated {later}".as_slice(),
+            b"{'unterminated\n{later}".as_slice(),
+            b"{`unterminated\n{later}".as_slice(),
+            b"{/* comment */}\n{later}".as_slice(),
+            b"{// comment\n}\n{later}".as_slice(),
+            b"{`plain`}\n{later}".as_slice(),
+            b"{`escaped \\${literal}`}\n{later}".as_slice(),
         ] {
             let ends = ExpressionEnds::new(input);
             for (start, byte) in input.iter().enumerate() {
@@ -438,6 +650,36 @@ mod tests {
             ends.scanned_bytes(),
             input.len(),
         );
+    }
+
+    #[test]
+    fn cached_ends_bound_unterminated_lexical_scan_work() {
+        let inputs = [
+            "{/*\n".repeat(8_192),
+            "{//".repeat(8_192),
+            "{\"".repeat(8_192),
+            "{'".repeat(8_192),
+            "{`".repeat(8_192),
+            "{/unterminated ".repeat(8_192),
+        ];
+
+        for (case, input) in inputs.into_iter().enumerate() {
+            let ends = ExpressionEnds::new(input.as_bytes());
+            assert!(
+                input
+                    .bytes()
+                    .enumerate()
+                    .filter(|(_, byte)| *byte == b'{')
+                    .all(|(start, _)| ends.end_at(start).is_none()),
+                "every opening brace is unterminated for case {case}: {input:?}",
+            );
+            assert!(
+                ends.scanned_bytes() <= input.len() * 3,
+                "case {case}: cached lexical scans visited {} bytes for a {} byte input",
+                ends.scanned_bytes(),
+                input.len(),
+            );
+        }
     }
 
     #[test]

--- a/src/mdx/expr.rs
+++ b/src/mdx/expr.rs
@@ -32,163 +32,87 @@ pub(crate) struct ExpressionEnds {
     ends: ExpressionEndStorage,
     #[cfg(test)]
     scanned_bytes: usize,
+    #[cfg(test)]
+    lexical_failure_count: usize,
 }
 
-/// Cached ends for lexical constructs that can otherwise make every earlier
-/// expression scan walk to EOF. Unlike expression ends, these values depend
-/// only on the construct's delimiter bytes, so they can be shared safely by
-/// every expression start in the input.
-struct LexicalEnds {
-    double_quotes: FxHashMap<usize, usize>,
-    single_quotes: FxHashMap<usize, usize>,
-    templates: FxHashMap<usize, TemplateEnd>,
-    line_comments: FxHashMap<usize, usize>,
-    block_comments: FxHashMap<usize, usize>,
+/// State needed to avoid rescanning the unterminated suffix of consecutive
+/// comments. This is deliberately constant-size: expression-end reuse already
+/// handles nested braces, and indexing every lexical delimiter would make
+/// ordinary Markdown containing many quotes consume memory proportional to
+/// every byte rather than MDX expression starts.
+#[derive(Default)]
+struct LexicalFailures {
+    /// Earliest `/*` known to have no closing delimiter after its own opener.
+    /// Expression ends are constructed right-to-left, so each earlier probe
+    /// need only scan the previously unseen interval before this frontier.
+    unterminated_block_comment_start: std::cell::Cell<Option<usize>>,
+    /// Equivalent frontier for line comments which run through EOF.
+    unterminated_line_comment_start: std::cell::Cell<Option<usize>>,
 }
 
-#[derive(Clone, Copy)]
-struct TemplateEnd {
-    end: usize,
-    has_interpolation: bool,
-}
+impl LexicalFailures {
+    fn block_comment_end(&self, bytes: &[u8], start: usize, work: &mut ScanWork) -> Option<usize> {
+        let mut pos = start + 2;
+        let search_end = self
+            .unterminated_block_comment_start
+            .get()
+            // A preceding comment can close on the `*` that overlaps this
+            // later opener (`/*/`), so include one byte past the frontier.
+            .map_or(bytes.len(), |frontier| {
+                frontier.saturating_add(2).min(bytes.len())
+            });
 
-impl LexicalEnds {
-    fn new(bytes: &[u8]) -> Self {
-        let mut double_quote_positions = Vec::new();
-        let mut single_quote_positions = Vec::new();
-        let mut template_positions = Vec::new();
-        let mut preceding_backslashes = 0usize;
-
-        for (pos, byte) in bytes.iter().copied().enumerate() {
-            if byte == b'\\' {
-                preceding_backslashes += 1;
-                continue;
+        while pos < search_end && pos + 1 < bytes.len() {
+            work.visit();
+            if bytes[pos] == b'*' && bytes[pos + 1] == b'/' {
+                return Some(pos + 2);
             }
-
-            let escaped = preceding_backslashes % 2 == 1;
-            match byte {
-                b'"' => double_quote_positions.push((pos, escaped)),
-                b'\'' => single_quote_positions.push((pos, escaped)),
-                b'`' => template_positions.push((pos, escaped)),
-                _ => {}
-            }
-            preceding_backslashes = 0;
+            pos += 1;
         }
 
-        let mut lexical_ends = Self {
-            double_quotes: FxHashMap::default(),
-            single_quotes: FxHashMap::default(),
-            templates: FxHashMap::default(),
-            line_comments: FxHashMap::default(),
-            block_comments: FxHashMap::default(),
-        };
-        fill_quoted_ends(&mut lexical_ends.double_quotes, &double_quote_positions);
-        fill_quoted_ends(&mut lexical_ends.single_quotes, &single_quote_positions);
-        let mut next_line_end = bytes.len();
-        let mut next_block_comment_end = None;
-        let mut next_template_interpolation = None;
-        let mut template_interpolations = vec![None; template_positions.len()];
-        let mut template_index = template_positions.len();
-        for pos in (0..bytes.len()).rev() {
-            if bytes[pos] == b'$' && bytes.get(pos + 1) == Some(&b'{') {
-                next_template_interpolation = Some(pos);
-            }
-            if template_index > 0 && template_positions[template_index - 1].0 == pos {
-                template_index -= 1;
-                template_interpolations[template_index] = next_template_interpolation;
-            }
+        self.unterminated_block_comment_start.set(Some(
+            self.unterminated_block_comment_start
+                .get()
+                .map_or(start, |old| old.min(start)),
+        ));
+        None
+    }
+
+    fn line_comment_end(&self, bytes: &[u8], start: usize, work: &mut ScanWork) -> usize {
+        let mut pos = start + 2;
+        let search_end = self
+            .unterminated_line_comment_start
+            .get()
+            .unwrap_or(bytes.len());
+
+        while pos < search_end {
+            work.visit();
             if bytes[pos] == b'\n' {
-                next_line_end = pos + 1;
+                return pos + 1;
             }
-            if bytes[pos] == b'*' && bytes.get(pos + 1) == Some(&b'/') {
-                next_block_comment_end = Some(pos + 2);
-            }
-            if bytes[pos] == b'/' && bytes.get(pos + 1) == Some(&b'/') {
-                lexical_ends.line_comments.insert(pos, next_line_end);
-            }
-            if bytes[pos] == b'/' && bytes.get(pos + 1) == Some(&b'*') {
-                lexical_ends.block_comments.insert(
-                    pos,
-                    next_block_comment_end.unwrap_or(UNTERMINATED_EXPRESSION),
-                );
-            }
+            pos += 1;
         }
-        fill_template_ends(
-            &mut lexical_ends.templates,
-            &template_positions,
-            &template_interpolations,
-        );
 
-        lexical_ends
+        self.unterminated_line_comment_start.set(Some(
+            self.unterminated_line_comment_start
+                .get()
+                .map_or(start, |old| old.min(start)),
+        ));
+        bytes.len()
     }
 
-    fn double_quote_end(&self, start: usize) -> Option<usize> {
-        cached_end(&self.double_quotes, start)
+    #[cfg(test)]
+    fn entry_count(&self) -> usize {
+        usize::from(self.unterminated_block_comment_start.get().is_some())
+            + usize::from(self.unterminated_line_comment_start.get().is_some())
     }
-
-    fn single_quote_end(&self, start: usize) -> Option<usize> {
-        cached_end(&self.single_quotes, start)
-    }
-
-    fn template_end(&self, start: usize) -> Option<TemplateEnd> {
-        self.templates
-            .get(&start)
-            .copied()
-            .filter(|end| end.end != UNTERMINATED_EXPRESSION)
-    }
-
-    fn line_comment_end(&self, start: usize) -> usize {
-        self.line_comments[&start]
-    }
-
-    fn block_comment_end(&self, start: usize) -> Option<usize> {
-        cached_end(&self.block_comments, start)
-    }
-}
-
-fn fill_quoted_ends(ends: &mut FxHashMap<usize, usize>, positions: &[(usize, bool)]) {
-    let mut next_closing = None;
-    for &(pos, escaped) in positions.iter().rev() {
-        ends.insert(pos, next_closing.unwrap_or(UNTERMINATED_EXPRESSION));
-        if !escaped {
-            next_closing = Some(pos + 1);
-        }
-    }
-}
-
-fn fill_template_ends(
-    ends: &mut FxHashMap<usize, TemplateEnd>,
-    positions: &[(usize, bool)],
-    interpolations: &[Option<usize>],
-) {
-    let mut next_closing = None;
-    for (&(pos, escaped), interpolation) in positions.iter().zip(interpolations).rev() {
-        let end = next_closing.unwrap_or(UNTERMINATED_EXPRESSION);
-        ends.insert(
-            pos,
-            TemplateEnd {
-                end,
-                has_interpolation: interpolation.is_some_and(|start| start < end),
-            },
-        );
-        if !escaped {
-            next_closing = Some(pos + 1);
-        }
-    }
-}
-
-fn cached_end(ends: &FxHashMap<usize, usize>, start: usize) -> Option<usize> {
-    (*ends
-        .get(&start)
-        .expect("lexical cache contains every queried delimiter")
-        != UNTERMINATED_EXPRESSION)
-        .then(|| ends[&start])
 }
 
 #[derive(Clone, Copy)]
 struct CachedEnds<'a> {
     expressions: &'a ExpressionEndStorage,
-    lexical: &'a LexicalEnds,
+    lexical_failures: &'a LexicalFailures,
 }
 
 enum ExpressionEndStorage {
@@ -239,7 +163,7 @@ impl ExpressionEnds {
 
         let brace_count = bytes.iter().filter(|&&byte| byte == b'{').count();
         let mut ends = ExpressionEndStorage::new(bytes.len(), brace_count);
-        let lexical_ends = LexicalEnds::new(bytes);
+        let lexical_failures = LexicalFailures::default();
         let mut work = ScanWork::default();
 
         for start in (0..bytes.len()).rev() {
@@ -249,7 +173,7 @@ impl ExpressionEnds {
                     start,
                     Some(CachedEnds {
                         expressions: &ends,
-                        lexical: &lexical_ends,
+                        lexical_failures: &lexical_failures,
                     }),
                     &mut work,
                 )
@@ -261,7 +185,9 @@ impl ExpressionEnds {
         Self {
             ends,
             #[cfg(test)]
-            scanned_bytes: bytes.len() * 2 + work.scanned_bytes,
+            scanned_bytes: bytes.len() + work.scanned_bytes,
+            #[cfg(test)]
+            lexical_failure_count: lexical_failures.entry_count(),
         }
     }
 
@@ -279,6 +205,13 @@ impl ExpressionEnds {
     #[cfg(test)]
     fn entry_count(&self) -> usize {
         self.ends.entry_count()
+    }
+
+    #[cfg(test)]
+    fn lexical_entry_count(&self) -> usize {
+        // A lexical failure frontier is deliberately the only lexical state;
+        // it never grows with input delimiter density.
+        self.lexical_failure_count
     }
 }
 
@@ -349,10 +282,10 @@ fn find_expression_end_from(
                 pos += 1;
             }
             b'"' => {
-                pos = skip_double_quoted(bytes, pos, cached_ends, work)?;
+                pos = skip_double_quoted(bytes, pos, work)?;
             }
             b'\'' => {
-                pos = skip_single_quoted(bytes, pos, cached_ends, work)?;
+                pos = skip_single_quoted(bytes, pos, work)?;
             }
             b'`' => {
                 pos = skip_template_literal(bytes, pos, cached_ends, work)?;
@@ -375,15 +308,7 @@ fn find_expression_end_from(
 
 /// Skip a `"..."` string. `pos` points at the opening `"`.
 /// Returns position after the closing `"`, or `None` if unterminated.
-fn skip_double_quoted(
-    bytes: &[u8],
-    start: usize,
-    cached_ends: Option<CachedEnds<'_>>,
-    work: &mut ScanWork,
-) -> Option<usize> {
-    if let Some(cached_ends) = cached_ends {
-        return cached_ends.lexical.double_quote_end(start);
-    }
+fn skip_double_quoted(bytes: &[u8], start: usize, work: &mut ScanWork) -> Option<usize> {
     let len = bytes.len();
     let mut pos = start + 1;
     while pos < len {
@@ -399,15 +324,7 @@ fn skip_double_quoted(
 
 /// Skip a `'...'` string. `pos` points at the opening `'`.
 /// Returns position after the closing `'`, or `None` if unterminated.
-fn skip_single_quoted(
-    bytes: &[u8],
-    start: usize,
-    cached_ends: Option<CachedEnds<'_>>,
-    work: &mut ScanWork,
-) -> Option<usize> {
-    if let Some(cached_ends) = cached_ends {
-        return cached_ends.lexical.single_quote_end(start);
-    }
+fn skip_single_quoted(bytes: &[u8], start: usize, work: &mut ScanWork) -> Option<usize> {
     let len = bytes.len();
     let mut pos = start + 1;
     while pos < len {
@@ -431,12 +348,6 @@ fn skip_template_literal(
     work: &mut ScanWork,
 ) -> Option<usize> {
     let len = bytes.len();
-    if let Some(cached_ends) = cached_ends {
-        let template_end = cached_ends.lexical.template_end(start)?;
-        if !template_end.has_interpolation {
-            return Some(template_end.end);
-        }
-    }
     let mut pos = start + 1;
     while pos < len {
         work.visit();
@@ -470,7 +381,9 @@ fn skip_line_comment(
     work: &mut ScanWork,
 ) -> usize {
     if let Some(cached_ends) = cached_ends {
-        return cached_ends.lexical.line_comment_end(start);
+        return cached_ends
+            .lexical_failures
+            .line_comment_end(bytes, start, work);
     }
     let len = bytes.len();
     let mut pos = start + 2;
@@ -492,7 +405,9 @@ fn skip_block_comment(
     work: &mut ScanWork,
 ) -> Option<usize> {
     if let Some(cached_ends) = cached_ends {
-        return cached_ends.lexical.block_comment_end(start);
+        return cached_ends
+            .lexical_failures
+            .block_comment_end(bytes, start, work);
     }
     let len = bytes.len();
     let mut pos = start + 2;
@@ -591,6 +506,7 @@ mod tests {
             b"{unterminated\n{later}".as_slice(),
             b"{\"unterminated\n{later}".as_slice(),
             b"{/* unterminated\n{later}".as_slice(),
+            b"{/*\n{/*/}".as_slice(),
             b"{// unterminated {later}".as_slice(),
             b"{'unterminated\n{later}".as_slice(),
             b"{`unterminated\n{later}".as_slice(),
@@ -680,6 +596,31 @@ mod tests {
                 input.len(),
             );
         }
+    }
+
+    #[test]
+    fn lexical_failures_use_constant_state() {
+        for input in ["{/*\n".repeat(8_192), "{//".repeat(8_192)] {
+            let ends = ExpressionEnds::new(input.as_bytes());
+            assert_eq!(
+                ends.lexical_entry_count(),
+                1,
+                "only the unterminated lexical frontier is retained",
+            );
+        }
+    }
+
+    #[test]
+    fn sparse_lexical_delimiters_are_not_indexed() {
+        // This is deliberately 8 MiB of ordinary Markdown punctuation. The
+        // expression cache must not allocate one entry per quote/comment
+        // delimiter merely because a document may contain an expression.
+        let mut input = "\"'`///*\n".repeat(1_000_000);
+        input.push_str("{value}");
+        let ends = ExpressionEnds::new(input.as_bytes());
+
+        assert_eq!(ends.entry_count(), 1);
+        assert_eq!(ends.lexical_entry_count(), 0);
     }
 
     #[test]

--- a/src/mdx/expr.rs
+++ b/src/mdx/expr.rs
@@ -49,6 +49,12 @@ struct LexicalFailures {
     unterminated_block_comment_start: std::cell::Cell<Option<usize>>,
     /// Equivalent frontier for line comments which run through EOF.
     unterminated_line_comment_start: std::cell::Cell<Option<usize>>,
+    /// Earliest unterminated lexical opener of each quoted form.  A later
+    /// delimiter may still close an earlier string, so probes scan through
+    /// the frontier once before proving the preceding suffix unterminated.
+    unterminated_double_quote_start: std::cell::Cell<Option<usize>>,
+    unterminated_single_quote_start: std::cell::Cell<Option<usize>>,
+    unterminated_template_start: std::cell::Cell<Option<usize>>,
 }
 
 impl LexicalFailures {
@@ -102,10 +108,34 @@ impl LexicalFailures {
         bytes.len()
     }
 
+    fn quote_search_end(&self, delimiter: u8, len: usize) -> usize {
+        let frontier = match delimiter {
+            b'"' => self.unterminated_double_quote_start.get(),
+            b'\'' => self.unterminated_single_quote_start.get(),
+            b'`' => self.unterminated_template_start.get(),
+            _ => unreachable!("only quoted delimiters use a lexical frontier"),
+        };
+        // Include the frontier delimiter: it can close a preceding string.
+        frontier.map_or(len, |start| start.saturating_add(1).min(len))
+    }
+
+    fn mark_unterminated_quote(&self, delimiter: u8, start: usize) {
+        let frontier = match delimiter {
+            b'"' => &self.unterminated_double_quote_start,
+            b'\'' => &self.unterminated_single_quote_start,
+            b'`' => &self.unterminated_template_start,
+            _ => unreachable!("only quoted delimiters use a lexical frontier"),
+        };
+        frontier.set(Some(frontier.get().map_or(start, |old| old.min(start))));
+    }
+
     #[cfg(test)]
     fn entry_count(&self) -> usize {
         usize::from(self.unterminated_block_comment_start.get().is_some())
             + usize::from(self.unterminated_line_comment_start.get().is_some())
+            + usize::from(self.unterminated_double_quote_start.get().is_some())
+            + usize::from(self.unterminated_single_quote_start.get().is_some())
+            + usize::from(self.unterminated_template_start.get().is_some())
     }
 }
 
@@ -282,10 +312,10 @@ fn find_expression_end_from(
                 pos += 1;
             }
             b'"' => {
-                pos = skip_double_quoted(bytes, pos, work)?;
+                pos = skip_double_quoted(bytes, pos, cached_ends, work)?;
             }
             b'\'' => {
-                pos = skip_single_quoted(bytes, pos, work)?;
+                pos = skip_single_quoted(bytes, pos, cached_ends, work)?;
             }
             b'`' => {
                 pos = skip_template_literal(bytes, pos, cached_ends, work)?;
@@ -308,10 +338,17 @@ fn find_expression_end_from(
 
 /// Skip a `"..."` string. `pos` points at the opening `"`.
 /// Returns position after the closing `"`, or `None` if unterminated.
-fn skip_double_quoted(bytes: &[u8], start: usize, work: &mut ScanWork) -> Option<usize> {
-    let len = bytes.len();
+fn skip_double_quoted(
+    bytes: &[u8],
+    start: usize,
+    cached_ends: Option<CachedEnds<'_>>,
+    work: &mut ScanWork,
+) -> Option<usize> {
+    let search_end = cached_ends.map_or(bytes.len(), |cached| {
+        cached.lexical_failures.quote_search_end(b'"', bytes.len())
+    });
     let mut pos = start + 1;
-    while pos < len {
+    while pos < search_end {
         work.visit();
         match bytes[pos] {
             b'\\' => pos += 2, // skip escaped char
@@ -319,21 +356,38 @@ fn skip_double_quoted(bytes: &[u8], start: usize, work: &mut ScanWork) -> Option
             _ => pos += 1,
         }
     }
+    if let Some(cached_ends) = cached_ends {
+        cached_ends
+            .lexical_failures
+            .mark_unterminated_quote(b'"', start);
+    }
     None
 }
 
 /// Skip a `'...'` string. `pos` points at the opening `'`.
 /// Returns position after the closing `'`, or `None` if unterminated.
-fn skip_single_quoted(bytes: &[u8], start: usize, work: &mut ScanWork) -> Option<usize> {
-    let len = bytes.len();
+fn skip_single_quoted(
+    bytes: &[u8],
+    start: usize,
+    cached_ends: Option<CachedEnds<'_>>,
+    work: &mut ScanWork,
+) -> Option<usize> {
+    let search_end = cached_ends.map_or(bytes.len(), |cached| {
+        cached.lexical_failures.quote_search_end(b'\'', bytes.len())
+    });
     let mut pos = start + 1;
-    while pos < len {
+    while pos < search_end {
         work.visit();
         match bytes[pos] {
             b'\\' => pos += 2,
             b'\'' => return Some(pos + 1),
             _ => pos += 1,
         }
+    }
+    if let Some(cached_ends) = cached_ends {
+        cached_ends
+            .lexical_failures
+            .mark_unterminated_quote(b'\'', start);
     }
     None
 }
@@ -347,14 +401,16 @@ fn skip_template_literal(
     cached_ends: Option<CachedEnds<'_>>,
     work: &mut ScanWork,
 ) -> Option<usize> {
-    let len = bytes.len();
+    let search_end = cached_ends.map_or(bytes.len(), |cached| {
+        cached.lexical_failures.quote_search_end(b'`', bytes.len())
+    });
     let mut pos = start + 1;
-    while pos < len {
+    while pos < search_end {
         work.visit();
         match bytes[pos] {
             b'\\' => pos += 2,
             b'`' => return Some(pos + 1),
-            b'$' if pos + 1 < len && bytes[pos + 1] == b'{' => {
+            b'$' if pos + 1 < search_end && bytes[pos + 1] == b'{' => {
                 // Nested expression inside template literal
                 let expression_start = pos + 1;
                 if let Some(cached_ends) = cached_ends {
@@ -369,6 +425,11 @@ fn skip_template_literal(
             }
             _ => pos += 1,
         }
+    }
+    if let Some(cached_ends) = cached_ends {
+        cached_ends
+            .lexical_failures
+            .mark_unterminated_quote(b'`', start);
     }
     None
 }
@@ -510,6 +571,9 @@ mod tests {
             b"{// unterminated {later}".as_slice(),
             b"{'unterminated\n{later}".as_slice(),
             b"{`unterminated\n{later}".as_slice(),
+            b"{\\\"\n{\\\"\n{later}".as_slice(),
+            b"{\\'\n{\\'\n{later}".as_slice(),
+            b"{\\`\n{\\`\n{later}".as_slice(),
             b"{/* comment */}\n{later}".as_slice(),
             b"{// comment\n}\n{later}".as_slice(),
             b"{`plain`}\n{later}".as_slice(),
@@ -596,6 +660,57 @@ mod tests {
                 input.len(),
             );
         }
+    }
+
+    #[test]
+    fn cached_ends_bound_escaped_quote_and_template_scan_work() {
+        let inputs = [
+            "{\\\"".repeat(8_192),
+            "{\\'".repeat(8_192),
+            "{\\`".repeat(8_192),
+        ];
+
+        for (case, input) in inputs.into_iter().enumerate() {
+            let ends = ExpressionEnds::new(input.as_bytes());
+            assert!(
+                input
+                    .bytes()
+                    .enumerate()
+                    .filter(|(_, byte)| *byte == b'{')
+                    .all(|(start, _)| ends.end_at(start).is_none()),
+                "every escaped lexical opener is unterminated for case {case}",
+            );
+            assert!(
+                ends.scanned_bytes() <= input.len() * 3,
+                "case {case}: cached escaped lexical scans visited {} bytes for a {} byte input",
+                ends.scanned_bytes(),
+                input.len(),
+            );
+            assert_eq!(ends.lexical_entry_count(), 1);
+        }
+    }
+
+    #[test]
+    fn cached_ends_bound_escaped_jsx_attribute_quote_scan_work() {
+        // Roughly 640 KiB, matching the formerly quadratic JSX-attribute
+        // shape without relying on wall-clock timing.
+        let input = "<Component value={\\\"".repeat(32_768);
+        let ends = ExpressionEnds::new(input.as_bytes());
+
+        assert!(
+            input
+                .bytes()
+                .enumerate()
+                .filter(|(_, byte)| *byte == b'{')
+                .all(|(start, _)| ends.end_at(start).is_none()),
+        );
+        assert!(
+            ends.scanned_bytes() <= input.len() * 3,
+            "cached escaped JSX scans visited {} bytes for a {} byte input",
+            ends.scanned_bytes(),
+            input.len(),
+        );
+        assert_eq!(ends.lexical_entry_count(), 1);
     }
 
     #[test]

--- a/src/mdx/jsx_tag.rs
+++ b/src/mdx/jsx_tag.rs
@@ -1,4 +1,4 @@
-use super::expr::find_expression_end;
+use super::expr::{ExpressionEnds, find_expression_end};
 
 /// Information about a parsed JSX tag.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -28,6 +28,26 @@ pub struct TagInfo<'a> {
 /// - Attributes with string values, expression values (`{...}`), and bare attributes
 /// - Multiline attributes (byte-based, not line-based)
 pub fn parse_jsx_tag(input: &[u8]) -> Option<TagInfo<'_>> {
+    parse_jsx_tag_with_expression_ends(input, None)
+}
+
+/// Parse a JSX tag with expression ends cached for the full input buffer.
+///
+/// `input` must be a suffix of the buffer used to construct `expression_ends`.
+/// The cache preserves the ordinary parser's result while avoiding repeated
+/// scans of unterminated expression attributes.
+pub(crate) fn parse_jsx_tag_cached<'a>(
+    input: &'a [u8],
+    input_offset: usize,
+    expression_ends: &'a ExpressionEnds,
+) -> Option<TagInfo<'a>> {
+    parse_jsx_tag_with_expression_ends(input, Some((input_offset, expression_ends)))
+}
+
+fn parse_jsx_tag_with_expression_ends<'a>(
+    input: &'a [u8],
+    expression_ends: Option<(usize, &'a ExpressionEnds)>,
+) -> Option<TagInfo<'a>> {
     let len = input.len();
     if len < 2 || input[0] != b'<' {
         return None;
@@ -106,7 +126,7 @@ pub fn parse_jsx_tag(input: &[u8]) -> Option<TagInfo<'_>> {
         // Attribute: either `{...spread}` or `name` or `name=value`
         if input[pos] == b'{' {
             // Spread attribute or expression
-            let end = find_expression_end(&input[pos..])?;
+            let end = expression_end(input, pos, expression_ends)?;
             pos += end;
         } else if input[pos].is_ascii_alphabetic() || input[pos] == b'_' {
             // Attribute name
@@ -136,7 +156,7 @@ pub fn parse_jsx_tag(input: &[u8]) -> Option<TagInfo<'_>> {
                         pos = skip_single_quoted(input, pos)?;
                     }
                     b'{' => {
-                        let end = find_expression_end(&input[pos..])?;
+                        let end = expression_end(input, pos, expression_ends)?;
                         pos += end;
                     }
                     _ => {
@@ -183,6 +203,19 @@ pub fn parse_jsx_tag(input: &[u8]) -> Option<TagInfo<'_>> {
     }
 
     None
+}
+
+fn expression_end(
+    input: &[u8],
+    pos: usize,
+    expression_ends: Option<(usize, &ExpressionEnds)>,
+) -> Option<usize> {
+    match expression_ends {
+        Some((input_offset, expression_ends)) => expression_ends
+            .end_at(input_offset + pos)
+            .map(|end| end - input_offset - pos),
+        None => find_expression_end(&input[pos..]),
+    }
 }
 
 fn skip_whitespace(bytes: &[u8], mut pos: usize) -> usize {

--- a/src/mdx/mod.rs
+++ b/src/mdx/mod.rs
@@ -264,9 +264,23 @@ pub fn segment_spanned(input: &str) -> Vec<SpannedSegment<'_>> {
 /// input.
 pub fn try_segment_spanned(input: &str) -> Result<Vec<SpannedSegment<'_>>, crate::InputSizeError> {
     crate::validate_input_size(input.len())?;
+    Ok(spanned_segments(input, splitter::split(input)))
+}
+
+pub(crate) fn segment_spanned_with_expression_ends<'a>(
+    input: &'a str,
+    expression_ends: &expr::ExpressionEnds,
+) -> Vec<SpannedSegment<'a>> {
+    spanned_segments(
+        input,
+        splitter::split_with_expression_ends(input, expression_ends),
+    )
+}
+
+fn spanned_segments<'a>(input: &'a str, segments: Vec<Segment<'a>>) -> Vec<SpannedSegment<'a>> {
     let input_start = input.as_ptr() as usize;
 
-    Ok(splitter::split(input)
+    segments
         .into_iter()
         .map(|segment| {
             let text = segment.as_str();
@@ -277,7 +291,7 @@ pub fn try_segment_spanned(input: &str) -> Result<Vec<SpannedSegment<'_>>, crate
             let range = crate::Range::from_usize(start, end);
             SpannedSegment { segment, range }
         })
-        .collect())
+        .collect()
 }
 
 /// Validate structural MDX and return source-spanned segments on success.

--- a/src/mdx/splitter.rs
+++ b/src/mdx/splitter.rs
@@ -13,6 +13,15 @@ use crate::{BlockEvent, BlockParser, CodeBlockKind};
 /// The returned `Vec<Segment>` covers the entire input (no bytes are dropped).
 pub fn split(input: &str) -> Vec<Segment<'_>> {
     let bytes = input.as_bytes();
+    let expression_ends = ExpressionEnds::new(bytes);
+    split_with_expression_ends(input, &expression_ends)
+}
+
+pub(crate) fn split_with_expression_ends<'a>(
+    input: &'a str,
+    expression_ends: &ExpressionEnds,
+) -> Vec<Segment<'a>> {
+    let bytes = input.as_bytes();
     let len = bytes.len();
     let mut segments: Vec<Segment<'_>> = Vec::new();
     let mut pos = 0;
@@ -23,7 +32,6 @@ pub fn split(input: &str) -> Vec<Segment<'_>> {
     let mut in_paragraph = false;
     let mut open_fence: Option<CodeFence> = None;
     let container_fences = container_fence_lines(bytes);
-    let expression_ends = ExpressionEnds::new(bytes);
 
     while pos < len {
         let line_start = pos;
@@ -99,7 +107,7 @@ pub fn split(input: &str) -> Vec<Segment<'_>> {
             && first_non_ws + 1 < len
             && bytes[first_non_ws + 1] == b'/'
             && let Some(tag_info) =
-                parse_jsx_tag_cached(&bytes[first_non_ws..], first_non_ws, &expression_ends)
+                parse_jsx_tag_cached(&bytes[first_non_ws..], first_non_ws, expression_ends)
             && tag_info.is_closing
         {
             let end = first_non_ws + tag_info.end_offset;
@@ -156,7 +164,7 @@ pub fn split(input: &str) -> Vec<Segment<'_>> {
             && first_non_ws + 1 < len
             && (bytes[first_non_ws + 1].is_ascii_alphabetic() || bytes[first_non_ws + 1] == b'>')
             && let Some(tag_info) =
-                parse_jsx_tag_cached(&bytes[first_non_ws..], first_non_ws, &expression_ends)
+                parse_jsx_tag_cached(&bytes[first_non_ws..], first_non_ws, expression_ends)
         {
             let end = first_non_ws + tag_info.end_offset;
             // Flow JSX requires no trailing non-whitespace content on the line

--- a/src/mdx/splitter.rs
+++ b/src/mdx/splitter.rs
@@ -1,6 +1,6 @@
 use super::Segment;
-use super::expr::find_expression_end;
-use super::jsx_tag::parse_jsx_tag;
+use super::expr::ExpressionEnds;
+use super::jsx_tag::parse_jsx_tag_cached;
 use crate::{BlockEvent, BlockParser, CodeBlockKind};
 
 /// Split MDX input into typed segments.
@@ -23,6 +23,7 @@ pub fn split(input: &str) -> Vec<Segment<'_>> {
     let mut in_paragraph = false;
     let mut open_fence: Option<CodeFence> = None;
     let container_fences = container_fence_lines(bytes);
+    let expression_ends = ExpressionEnds::new(bytes);
 
     while pos < len {
         let line_start = pos;
@@ -97,7 +98,8 @@ pub fn split(input: &str) -> Vec<Segment<'_>> {
         if first == b'<'
             && first_non_ws + 1 < len
             && bytes[first_non_ws + 1] == b'/'
-            && let Some(tag_info) = parse_jsx_tag(&bytes[first_non_ws..])
+            && let Some(tag_info) =
+                parse_jsx_tag_cached(&bytes[first_non_ws..], first_non_ws, &expression_ends)
             && tag_info.is_closing
         {
             let end = first_non_ws + tag_info.end_offset;
@@ -134,9 +136,8 @@ pub fn split(input: &str) -> Vec<Segment<'_>> {
 
         // 3. Expression: `{` as first non-whitespace
         if first == b'{'
-            && let Some(expr_len) = find_expression_end(&bytes[first_non_ws..])
+            && let Some(end) = expression_ends.end_at(first_non_ws)
         {
-            let end = first_non_ws + expr_len;
             // Flow expression requires no trailing non-whitespace content
             if !has_trailing_content(bytes, end) {
                 flush_markdown(input, &mut md_start, line_start, &mut segments);
@@ -154,7 +155,8 @@ pub fn split(input: &str) -> Vec<Segment<'_>> {
         if first == b'<'
             && first_non_ws + 1 < len
             && (bytes[first_non_ws + 1].is_ascii_alphabetic() || bytes[first_non_ws + 1] == b'>')
-            && let Some(tag_info) = parse_jsx_tag(&bytes[first_non_ws..])
+            && let Some(tag_info) =
+                parse_jsx_tag_cached(&bytes[first_non_ws..], first_non_ws, &expression_ends)
         {
             let end = first_non_ws + tag_info.end_offset;
             // Flow JSX requires no trailing non-whitespace content on the line

--- a/src/mdx/strict.rs
+++ b/src/mdx/strict.rs
@@ -4,7 +4,9 @@ use super::splitter::{
     CodeFence, EsmScan, container_fence_lines, is_blank_line, is_esm_start, opening_code_fence,
     scan_esm,
 };
-use super::{MdxDiagnostic, MdxDiagnosticCode, SpannedSegment, segment_spanned};
+use super::{
+    MdxDiagnostic, MdxDiagnosticCode, SpannedSegment, segment_spanned_with_expression_ends,
+};
 use crate::Range;
 
 const UNTERMINATED_EXPRESSION: &str = "expected `}` to close this flow expression";
@@ -25,15 +27,19 @@ struct OpenTag {
 }
 
 pub(super) fn segment_strict(input: &str) -> Result<Vec<SpannedSegment<'_>>, Vec<MdxDiagnostic>> {
-    let diagnostics = validate(input);
+    let expression_ends = ExpressionEnds::new(input.as_bytes());
+    let diagnostics = validate(input, &expression_ends);
     if diagnostics.is_empty() {
-        Ok(segment_spanned(input))
+        Ok(segment_spanned_with_expression_ends(
+            input,
+            &expression_ends,
+        ))
     } else {
         Err(diagnostics)
     }
 }
 
-fn validate(input: &str) -> Vec<MdxDiagnostic> {
+fn validate(input: &str, expression_ends: &ExpressionEnds) -> Vec<MdxDiagnostic> {
     let bytes = input.as_bytes();
     let len = bytes.len();
     let mut diagnostics = Vec::new();
@@ -42,7 +48,6 @@ fn validate(input: &str) -> Vec<MdxDiagnostic> {
     let mut pos = 0;
     let mut open_fence: Option<CodeFence> = None;
     let container_fences = container_fence_lines(bytes);
-    let expression_ends = ExpressionEnds::new(bytes);
 
     while pos < len {
         let line_start = pos;
@@ -158,7 +163,7 @@ fn validate(input: &str) -> Vec<MdxDiagnostic> {
 
         if is_jsx_candidate(bytes, first_non_ws) {
             if let Some(tag) =
-                parse_jsx_tag_cached(&bytes[first_non_ws..], first_non_ws, &expression_ends)
+                parse_jsx_tag_cached(&bytes[first_non_ws..], first_non_ws, expression_ends)
             {
                 let end = first_non_ws + tag.end_offset;
                 if !has_trailing_content(bytes, end) {
@@ -442,4 +447,20 @@ fn consume_trailing_newline(bytes: &[u8], mut pos: usize) -> usize {
         pos += 1;
     }
     pos
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::mdx::expr::{cache_build_count, reset_cache_build_count};
+
+    #[test]
+    fn successful_strict_segmentation_reuses_its_expression_cache() {
+        let input = "{value}\n";
+        reset_cache_build_count();
+
+        let segments = segment_strict(input).unwrap();
+        assert_eq!(segments.len(), 1);
+        assert_eq!(cache_build_count(), 1);
+    }
 }

--- a/src/mdx/strict.rs
+++ b/src/mdx/strict.rs
@@ -1,5 +1,5 @@
-use super::expr::find_expression_end;
-use super::jsx_tag::parse_jsx_tag;
+use super::expr::{ExpressionEnds, find_expression_end};
+use super::jsx_tag::parse_jsx_tag_cached;
 use super::splitter::{
     CodeFence, EsmScan, container_fence_lines, is_blank_line, is_esm_start, opening_code_fence,
     scan_esm,
@@ -42,6 +42,7 @@ fn validate(input: &str) -> Vec<MdxDiagnostic> {
     let mut pos = 0;
     let mut open_fence: Option<CodeFence> = None;
     let container_fences = container_fence_lines(bytes);
+    let expression_ends = ExpressionEnds::new(bytes);
 
     while pos < len {
         let line_start = pos;
@@ -134,9 +135,8 @@ fn validate(input: &str) -> Vec<MdxDiagnostic> {
         }
 
         if first == b'{' {
-            match find_expression_end(&bytes[first_non_ws..]) {
-                Some(expression_len) => {
-                    let end = first_non_ws + expression_len;
+            match expression_ends.end_at(first_non_ws) {
+                Some(end) => {
                     if !has_trailing_content(bytes, end) {
                         in_paragraph = false;
                         pos = consume_trailing_newline(bytes, end);
@@ -157,7 +157,9 @@ fn validate(input: &str) -> Vec<MdxDiagnostic> {
         }
 
         if is_jsx_candidate(bytes, first_non_ws) {
-            if let Some(tag) = parse_jsx_tag(&bytes[first_non_ws..]) {
+            if let Some(tag) =
+                parse_jsx_tag_cached(&bytes[first_non_ws..], first_non_ws, &expression_ends)
+            {
                 let end = first_non_ws + tag.end_offset;
                 if !has_trailing_content(bytes, end) {
                     let range = Range::from_usize(first_non_ws, end);

--- a/tests/mdx_segment_tests.rs
+++ b/tests/mdx_segment_tests.rs
@@ -978,6 +978,70 @@ fn strict_mode_reports_unterminated_expression_with_its_source_range() {
 }
 
 #[test]
+fn unterminated_expression_keeps_later_flow_mdx_available_to_permissive_segmenting() {
+    let input = "{unterminated\n{later}\n<After />\n";
+
+    assert_eq!(
+        segment(input),
+        vec![
+            Segment::Markdown("{unterminated\n"),
+            Segment::Expression("{later}\n"),
+            Segment::JsxBlockSelfClose("<After />\n"),
+        ]
+    );
+
+    let rendered = render(input).body;
+    assert!(rendered.contains("<p>{unterminated</p>"));
+    assert!(rendered.contains("{later}\n<After />"));
+
+    let diagnostics = segment_strict(input).unwrap_err();
+    assert_eq!(diagnostics.len(), 1);
+    assert_eq!(
+        diagnostics[0].code,
+        MdxDiagnosticCode::UnterminatedExpression
+    );
+    assert_eq!(
+        diagnostics[0]
+            .primary_range
+            .slice_str(input.as_bytes())
+            .unwrap(),
+        input
+    );
+}
+
+#[test]
+fn unterminated_jsx_attribute_keeps_later_flow_mdx_available_to_permissive_segmenting() {
+    let input = "<Broken value={\n{later}\n<After />\n";
+
+    assert_eq!(
+        segment(input),
+        vec![
+            Segment::Markdown("<Broken value={\n"),
+            Segment::Expression("{later}\n"),
+            Segment::JsxBlockSelfClose("<After />\n"),
+        ]
+    );
+
+    let rendered = render(input).body;
+    assert!(rendered.contains("Broken value={"), "{rendered}");
+    assert!(rendered.contains("{later}\n<After />"));
+
+    let diagnostics = segment_strict(input).unwrap_err();
+    assert_eq!(diagnostics.len(), 1);
+    assert_eq!(
+        diagnostics[0].code,
+        MdxDiagnosticCode::UnterminatedExpression
+    );
+    assert_eq!(
+        diagnostics[0]
+            .primary_range
+            .slice_str(input.as_bytes())
+            .unwrap(),
+        "{\n{later}\n<After />\n"
+    );
+}
+
+#[test]
 fn strict_mode_reports_unterminated_jsx_tag_with_its_source_range() {
     let input = "<Card title=\"example\"";
     let diagnostics = segment_strict(input).unwrap_err();

--- a/tests/mdx_segment_tests.rs
+++ b/tests/mdx_segment_tests.rs
@@ -1010,6 +1010,38 @@ fn unterminated_expression_keeps_later_flow_mdx_available_to_permissive_segmenti
 }
 
 #[test]
+fn unterminated_comment_expression_keeps_later_flow_mdx_available_to_permissive_segmenting() {
+    let input = "{/* unterminated\n{later}\n<After />\n";
+
+    assert_eq!(
+        segment(input),
+        vec![
+            Segment::Markdown("{/* unterminated\n"),
+            Segment::Expression("{later}\n"),
+            Segment::JsxBlockSelfClose("<After />\n"),
+        ]
+    );
+
+    let rendered = render(input).body;
+    assert!(rendered.contains("<p>{/* unterminated</p>"));
+    assert!(rendered.contains("{later}\n<After />"));
+
+    let diagnostics = segment_strict(input).unwrap_err();
+    assert_eq!(diagnostics.len(), 1);
+    assert_eq!(
+        diagnostics[0].code,
+        MdxDiagnosticCode::UnterminatedExpression
+    );
+    assert_eq!(
+        diagnostics[0]
+            .primary_range
+            .slice_str(input.as_bytes())
+            .unwrap(),
+        input
+    );
+}
+
+#[test]
 fn unterminated_jsx_attribute_keeps_later_flow_mdx_available_to_permissive_segmenting() {
     let input = "<Broken value={\n{later}\n<After />\n";
 


### PR DESCRIPTION
Fixes #149

## Summary

- Precompute expression ends right-to-left, allowing MDX flow detection to jump over proven nested expressions or stop at proven unterminated ones instead of rescanning every suffix.
- Reuse the cache in JSX attribute parsing and strict validation without changing the public parser APIs.
- Preserve permissive Markdown recovery, later valid flow MDX, rendered output, and strict malformed-expression diagnostics; add deterministic work-budget regressions and MDX Criterion lanes for both adversarial inputs.

## Validation

- `cargo test --locked`
- `cargo test --all-features --locked`
- `cargo test --features mdx --test mdx_segment_tests unterminated_`
- `cargo clippy --all-targets --all-features --locked -- -D warnings`
- `cargo fmt --check`
- `./scripts/test-check-workflow-pins.sh`
- `git diff --check`
- `cargo bench --bench mdx --features mdx -- unterminated` (release: expression segment 343–345 µs / ~318 MiB/s; JSX-attribute segment 1.247–1.254 ms / ~193 MiB/s)

🔧 Emily Carter · Implementation Agent
