### PR TITLE
fix(mdx): emit valid JSX components

### DIFF
--- a/homepage/pnpm-lock.yaml
+++ b/homepage/pnpm-lock.yaml
@@ -5,10 +5,12 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  brace-expansion@<=5.0.7: 5.0.8
+  brace-expansion@<=5.0.8: 5.0.9
+  browserslist@<=4.28.6: 4.28.7
   esbuild@>=0.27.3 <0.28.1: 0.28.1
-  js-yaml@<3.15.0: 3.15.0
+  js-yaml@<3.15.1: 3.15.1
   lodash@<=4.17.23: 4.18.1
+  nanoid@<3.3.18: 3.3.18
   picomatch@>=4.0.0 <4.0.4: 4.0.5
   postcss@<8.5.18: 8.5.18
   rollup@>=4.0.0 <4.59.0: 4.59.0
@@ -1121,16 +1123,17 @@ packages:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
     engines: {node: 18 || 20 || >=22}
 
-  baseline-browser-mapping@2.9.19:
-    resolution: {integrity: sha512-ipDqC8FrAl/76p2SSWKSI+H9tFwm7vYqXQrItCuiVPt26Km0jS+NzSsBWAaBusvSbQcfJG+JitdMm+wZAgTYqg==}
+  baseline-browser-mapping@2.11.20:
+    resolution: {integrity: sha512-H0ulySigv6icDJ1F7SjtdCD6PrhTpdYCmP0CactWy1+ekh0AFd0o1Wn5T8b+hnTmdBx19u9yhL6wvCylXMY7zw==}
+    engines: {node: '>=6.0.0'}
     hasBin: true
 
-  brace-expansion@5.0.8:
-    resolution: {integrity: sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==}
+  brace-expansion@5.0.9:
+    resolution: {integrity: sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==}
     engines: {node: 20 || >=22}
 
-  browserslist@4.28.1:
-    resolution: {integrity: sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==}
+  browserslist@4.28.7:
+    resolution: {integrity: sha512-JxV13hNrFxqjOc8alRbq9dK1MM79NEXYpma2B2J4wAtpWS5zIEIKqWPGCl7N4o7Uc7B7itylh7SuDujATRyyTw==}
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
 
@@ -1138,8 +1141,8 @@ packages:
     resolution: {integrity: sha512-tixWYgm5ZoOD+3g6UTea91eow5z6AAHaho3g0V9CNSNb45gM8SmflpAc+GRd1InC4AqN/07Unrgp56Y94N9hJQ==}
     engines: {node: '>=20.19.0'}
 
-  caniuse-lite@1.0.30001769:
-    resolution: {integrity: sha512-BCfFL1sHijQlBGWBMuJyhZUhzo7wer5sVj9hqekB/7xn0Ypy+pER/edCYQm4exbXj4WiySGp40P8UuTh6w1srg==}
+  caniuse-lite@1.0.30001810:
+    resolution: {integrity: sha512-TITQPUkaz+aVk5GL6NhOdwk1aEaNTSDPsGFWrTuhKGtjTF70jL/Oht2W4c6rXUe5fu7Ie19VIahAXHIIiWWNeg==}
 
   ccount@2.0.1:
     resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
@@ -1402,8 +1405,8 @@ packages:
   dompurify@3.4.12:
     resolution: {integrity: sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg==}
 
-  electron-to-chromium@1.5.286:
-    resolution: {integrity: sha512-9tfDXhJ4RKFNerfjdCcZfufu49vg620741MNs26a9+bhLThdB+plgMeou98CAaHu/WATj2iHOOHTp1hWtABj2A==}
+  electron-to-chromium@1.5.420:
+    resolution: {integrity: sha512-2yD6XreGusOfNV+dUcvipJEXc3n/n7fgr7996aszTG+YY5E4mqM4tOq/3uhP129cazL9YHbVWSpc79ePotWtPA==}
 
   entities@4.5.0:
     resolution: {integrity: sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==}
@@ -1600,8 +1603,8 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
-  js-yaml@3.15.0:
-    resolution: {integrity: sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==}
+  js-yaml@3.15.1:
+    resolution: {integrity: sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==}
     hasBin: true
 
   jsesc@3.1.0:
@@ -1939,13 +1942,14 @@ packages:
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
-  nanoid@3.3.16:
-    resolution: {integrity: sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==}
+  nanoid@3.3.18:
+    resolution: {integrity: sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
-  node-releases@2.0.27:
-    resolution: {integrity: sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==}
+  node-releases@2.0.54:
+    resolution: {integrity: sha512-YHs7BmmcsdAI5Ozuf8JZo6PT0mv2GIWC9vMfvUC3dp65M8hn7Ux8CPL+2oBI7juNuj9d0ndhTcznq2ODBps9cQ==}
+    engines: {node: '>=18'}
 
   normalize-package-data@8.0.0:
     resolution: {integrity: sha512-RWk+PI433eESQ7ounYxIp67CYuVsS1uYSonX3kA6ps/3LWfjVQa/ptEg6Y3T6uAMq1mWpX9PQ+qx+QaHpsc7gQ==}
@@ -2292,7 +2296,7 @@ packages:
     resolution: {integrity: sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==}
     hasBin: true
     peerDependencies:
-      browserslist: '>= 4.21.0'
+      browserslist: 4.28.7
 
   use-sync-external-store@1.6.0:
     resolution: {integrity: sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==}
@@ -2479,7 +2483,7 @@ snapshots:
     dependencies:
       '@babel/compat-data': 7.29.7
       '@babel/helper-validator-option': 7.29.7
-      browserslist: 4.28.1
+      browserslist: 4.28.7
       lru-cache: 5.1.1
       semver: 6.3.1
 
@@ -3518,23 +3522,23 @@ snapshots:
 
   balanced-match@4.0.4: {}
 
-  baseline-browser-mapping@2.9.19: {}
+  baseline-browser-mapping@2.11.20: {}
 
-  brace-expansion@5.0.8:
+  brace-expansion@5.0.9:
     dependencies:
       balanced-match: 4.0.4
 
-  browserslist@4.28.1:
+  browserslist@4.28.7:
     dependencies:
-      baseline-browser-mapping: 2.9.19
-      caniuse-lite: 1.0.30001769
-      electron-to-chromium: 1.5.286
-      node-releases: 2.0.27
-      update-browserslist-db: 1.2.3(browserslist@4.28.1)
+      baseline-browser-mapping: 2.11.20
+      caniuse-lite: 1.0.30001810
+      electron-to-chromium: 1.5.420
+      node-releases: 2.0.54
+      update-browserslist-db: 1.2.3(browserslist@4.28.7)
 
   cac@7.0.0: {}
 
-  caniuse-lite@1.0.30001769: {}
+  caniuse-lite@1.0.30001810: {}
 
   ccount@2.0.1: {}
 
@@ -3794,7 +3798,7 @@ snapshots:
     optionalDependencies:
       '@types/trusted-types': 2.0.7
 
-  electron-to-chromium@1.5.286: {}
+  electron-to-chromium@1.5.420: {}
 
   entities@4.5.0: {}
 
@@ -3931,7 +3935,7 @@ snapshots:
 
   gray-matter@4.0.3:
     dependencies:
-      js-yaml: 3.15.0
+      js-yaml: 3.15.1
       kind-of: 6.0.3
       section-matter: 1.0.0
       strip-bom-string: 1.0.0
@@ -4042,7 +4046,7 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
-  js-yaml@3.15.0:
+  js-yaml@3.15.1:
     dependencies:
       argparse: 1.0.10
       esprima: 4.0.1
@@ -4632,7 +4636,7 @@ snapshots:
 
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.8
+      brace-expansion: 5.0.9
 
   minisearch@7.2.0: {}
 
@@ -4647,9 +4651,9 @@ snapshots:
 
   ms@2.1.3: {}
 
-  nanoid@3.3.16: {}
+  nanoid@3.3.18: {}
 
-  node-releases@2.0.27: {}
+  node-releases@2.0.54: {}
 
   normalize-package-data@8.0.0:
     dependencies:
@@ -4726,7 +4730,7 @@ snapshots:
 
   postcss@8.5.18:
     dependencies:
-      nanoid: 3.3.16
+      nanoid: 3.3.18
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
@@ -5102,9 +5106,9 @@ snapshots:
       unist-util-is: 6.0.1
       unist-util-visit-parents: 6.0.2
 
-  update-browserslist-db@1.2.3(browserslist@4.28.1):
+  update-browserslist-db@1.2.3(browserslist@4.28.7):
     dependencies:
-      browserslist: 4.28.1
+      browserslist: 4.28.7
       escalade: 3.2.0
       picocolors: 1.1.1
 

--- a/homepage/pnpm-workspace.yaml
+++ b/homepage/pnpm-workspace.yaml
@@ -2,10 +2,12 @@ allowBuilds:
   esbuild: true
 
 overrides:
-  brace-expansion@<=5.0.7: 5.0.8
+  brace-expansion@<=5.0.8: 5.0.9
+  browserslist@<=4.28.6: 4.28.7
   esbuild@>=0.27.3 <0.28.1: 0.28.1
-  js-yaml@<3.15.0: 3.15.0
+  js-yaml@<3.15.1: 3.15.1
   lodash@<=4.17.23: 4.18.1
+  nanoid@<3.3.18: 3.3.18
   picomatch@>=4.0.0 <4.0.4: 4.0.5
   postcss@<8.5.18: 8.5.18
   rollup@>=4.0.0 <4.59.0: 4.59.0

--- a/node/pnpm-lock.yaml
+++ b/node/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  js-yaml@<4.3.1: 4.3.1
+
 importers:
 
   .:
@@ -763,8 +766,8 @@ packages:
     resolution: {integrity: sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==}
     engines: {node: '>=0.10.0'}
 
-  js-yaml@4.3.0:
-    resolution: {integrity: sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==}
+  js-yaml@4.3.1:
+    resolution: {integrity: sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==}
     hasBin: true
 
   json-with-bigint@3.5.10:
@@ -973,7 +976,7 @@ snapshots:
       colorette: 2.0.20
       emnapi: 1.11.2
       es-toolkit: 1.50.0
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
       obug: 2.1.4
       semver: 7.8.5
       typanion: 3.14.0
@@ -1391,7 +1394,7 @@ snapshots:
     dependencies:
       safer-buffer: 2.1.2
 
-  js-yaml@4.3.0:
+  js-yaml@4.3.1:
     dependencies:
       argparse: 2.0.1
 

--- a/node/pnpm-workspace.yaml
+++ b/node/pnpm-workspace.yaml
@@ -3,3 +3,6 @@ packages:
 
 onlyBuiltDependencies:
   - '@napi-rs/cli'
+
+overrides:
+  js-yaml@<4.3.1: 4.3.1

--- a/src/mdx/render.rs
+++ b/src/mdx/render.rs
@@ -233,7 +233,17 @@ fn write_component_body(out: &mut String, body: &str) {
         }
 
         if bytes[pos..].starts_with(b"<!--") {
-            pos = comment_end(bytes, pos).unwrap_or(bytes.len());
+            if let Some(end) = comment_end(bytes, pos) {
+                pos = end;
+                continue;
+            }
+
+            // Bound malformed-comment recovery just like incomplete
+            // declarations so a later real element is not swallowed.
+            indent_component_line(out, at_line_start, pre_depth);
+            out.push_str("&lt;");
+            at_line_start = false;
+            pos += 1;
             continue;
         }
 
@@ -611,6 +621,10 @@ fn generic_declaration_end(bytes: &[u8], start: usize) -> Option<usize> {
                 .map(|offset| pos + 2 + offset + 2)?;
             continue;
         }
+        if bracket_depth > 0 && conditional_section_content_start(bytes, pos).is_some() {
+            pos = conditional_section_end(bytes, pos)?;
+            continue;
+        }
 
         match bytes[pos] {
             b'\'' | b'"' => quote = Some(bytes[pos]),
@@ -631,6 +645,85 @@ fn generic_declaration_end(bytes: &[u8], start: usize) -> Option<usize> {
     }
 
     None
+}
+
+fn conditional_section_end(bytes: &[u8], start: usize) -> Option<usize> {
+    let mut pos = conditional_section_content_start(bytes, start)?;
+    let mut depth = 1_u32;
+
+    while pos < bytes.len() {
+        if bytes[pos..].starts_with(b"<!--") {
+            pos = comment_end(bytes, pos)?;
+            continue;
+        }
+        if bytes[pos..].starts_with(b"<?") {
+            pos = bytes[pos + 2..]
+                .windows(2)
+                .position(|window| window == b"?>")
+                .map(|offset| pos + 2 + offset + 2)?;
+            continue;
+        }
+        if bytes[pos..].starts_with(b"<![CDATA[") {
+            pos = bytes[pos + 9..]
+                .windows(3)
+                .position(|window| window == b"]]>")
+                .map(|offset| pos + 9 + offset + 3)?;
+            continue;
+        }
+        if let Some(content_start) = conditional_section_content_start(bytes, pos) {
+            depth = depth.checked_add(1)?;
+            pos = content_start;
+            continue;
+        }
+        if bytes[pos..].starts_with(b"]]>") {
+            depth -= 1;
+            pos += 3;
+            if depth == 0 {
+                return Some(pos);
+            }
+            continue;
+        }
+
+        match bytes[pos] {
+            b'\'' | b'"' => pos = declaration_quote_end(bytes, pos)?,
+            _ => pos += 1,
+        }
+    }
+
+    None
+}
+
+fn conditional_section_content_start(bytes: &[u8], start: usize) -> Option<usize> {
+    if !bytes[start..].starts_with(b"<![") {
+        return None;
+    }
+
+    let mut pos = skip_ascii_whitespace(bytes, start + 3);
+    if bytes[pos..].starts_with(b"INCLUDE") {
+        pos += b"INCLUDE".len();
+    } else if bytes[pos..].starts_with(b"IGNORE") {
+        pos += b"IGNORE".len();
+    } else {
+        return None;
+    }
+    pos = skip_ascii_whitespace(bytes, pos);
+
+    (bytes.get(pos) == Some(&b'[')).then_some(pos + 1)
+}
+
+fn declaration_quote_end(bytes: &[u8], start: usize) -> Option<usize> {
+    let quote = bytes[start];
+    bytes[start + 1..]
+        .iter()
+        .position(|byte| *byte == quote)
+        .map(|offset| start + 1 + offset + 1)
+}
+
+fn skip_ascii_whitespace(bytes: &[u8], mut pos: usize) -> usize {
+    while bytes.get(pos).is_some_and(u8::is_ascii_whitespace) {
+        pos += 1;
+    }
+    pos
 }
 
 fn standalone_expression_end(bytes: &[u8], start: usize) -> Option<usize> {
@@ -1391,6 +1484,50 @@ Content
             ] {
                 assert!(component.contains(paragraph), "{component}");
             }
+        }
+    }
+
+    #[test]
+    fn to_component_omits_conditional_sections_containing_markup() {
+        for line_break in ["\n", "\r\n"] {
+            let body = format!(
+                "<!DOCTYPE html [{line_break}<![ INCLUDE [{line_break}<p data-end=']]>'>literal</p>{line_break}<![IGNORE[<section>nested</section><!-- comment ]]> --><?inside ]]>?><![CDATA[<em>cdata</em>]]>]]>{line_break}]]>{line_break}]>{line_break}<p>after section</p>"
+            );
+            let out = MdxOutput {
+                body: body.clone(),
+                esm: vec![],
+                front_matter: None,
+            };
+            let component = out.to_component("Page").unwrap();
+
+            assert_eq!(out.body, body);
+            for omitted in [
+                "DOCTYPE", "data-end", "literal", "nested", "comment", "<?inside", "cdata",
+            ] {
+                assert!(!component.contains(omitted), "{component}");
+            }
+            assert!(component.contains("<p>after section</p>"), "{component}");
+        }
+    }
+
+    #[test]
+    fn to_component_bounds_incomplete_conditional_sections() {
+        for body in [
+            "<!DOCTYPE html [<![INCLUDE[<section>inside</section>\n<p>after missing close</p>",
+            "<!DOCTYPE html [<![IGNORE['unterminated\n<p>after quote</p>",
+            "<!DOCTYPE html [<![INCLUDE[<!-- unterminated\n<p>after comment</p>",
+            "<!DOCTYPE html [<![INCLUDE[<?unterminated\n<p>after pi</p>",
+            "<!DOCTYPE html [<![INCLUD[near match\n<p>after near match</p>",
+        ] {
+            let out = MdxOutput {
+                body: body.to_owned(),
+                esm: vec![],
+                front_matter: None,
+            };
+            let component = out.to_component("Page").unwrap();
+
+            assert!(component.contains("&lt;!DOCTYPE"), "{component}");
+            assert!(component.contains("<p>after"), "{component}");
         }
     }
 

--- a/src/mdx/render.rs
+++ b/src/mdx/render.rs
@@ -1,4 +1,4 @@
-use std::fmt::Write;
+use std::{collections::HashMap, fmt::Write};
 
 use crate::{Options, RenderPolicy};
 
@@ -229,6 +229,9 @@ fn write_component_body(out: &mut String, body: &str) {
     let mut at_line_start = true;
     let mut pre_depth = 0_u32;
     let mut html_openings = Vec::new();
+    // A crossed owner is balanced at the first mismatched closer. Remember that
+    // its eventual source closer must be consumed if no newer live owner claims it.
+    let mut synthetic_closings = HashMap::new();
 
     while pos < bytes.len() {
         if pre_depth > 0 && bytes[pos] != b'<' {
@@ -303,6 +306,7 @@ fn write_component_body(out: &mut String, body: &str) {
                     &body[pos..pos + tag.end_offset],
                     &tag,
                     &mut html_openings,
+                    &mut synthetic_closings,
                 )
             };
             at_line_start = false;
@@ -381,6 +385,7 @@ fn write_component_tag<'a>(
     source: &str,
     tag: &TagInfo<'a>,
     html_openings: &mut Vec<(&'static str, Option<&'a str>)>,
+    synthetic_closings: &mut HashMap<(&'static str, bool), usize>,
 ) -> ComponentTagEffect {
     if tag.is_closing {
         if let Some(canonical_name) = html_element_ignore_ascii_case(tag.name) {
@@ -410,6 +415,9 @@ fn write_component_tag<'a>(
                         .pop()
                         .expect("an intervening HTML opening was just counted");
                     write_synthetic_closing_tag(out, component_name.unwrap_or(intervening_name));
+                    *synthetic_closings
+                        .entry((intervening_name, component_name.is_some()))
+                        .or_default() += 1;
                     closed_pre_count +=
                         u32::from(component_name.is_none() && intervening_name == "pre");
                 }
@@ -423,6 +431,25 @@ fn write_component_tag<'a>(
                 } else {
                     ComponentTagEffect::None
                 };
+            }
+            let exact_key = (canonical_name, component_syntax);
+            let fallback_key = (canonical_name, !component_syntax);
+            let synthetic_key = synthetic_closings
+                .get(&exact_key)
+                .is_some_and(|count| *count > 0)
+                .then_some(exact_key)
+                .or_else(|| {
+                    synthetic_closings
+                        .get(&fallback_key)
+                        .is_some_and(|count| *count > 0)
+                        .then_some(fallback_key)
+                });
+            if let Some(synthetic_key) = synthetic_key {
+                let count = synthetic_closings
+                    .get_mut(&synthetic_key)
+                    .expect("a synthetic closing was just located");
+                *count -= 1;
+                return ComponentTagEffect::None;
             }
             if HTML_VOID_ELEMENTS.contains(&canonical_name) {
                 return ComponentTagEffect::None;
@@ -1870,6 +1897,46 @@ Content
             component.contains("<Pre><pre>{\"first\\n  second {value}\\n\"}</pre></Pre>"),
             "{component}"
         );
+    }
+
+    #[test]
+    fn to_component_drops_source_closers_for_synthetically_closed_owners() {
+        let cases = [
+            ("<Div><div>a</Div></div>", "<Div><div>a</div></Div>"),
+            ("<div><Div>a</div></Div>", "<div><Div>a</Div></div>"),
+            (
+                "<Section><div><span>a</Section></span></div>",
+                "<Section><div><span>a</span></div></Section>",
+            ),
+            (
+                "<Div><div>a</Div><div>b</div></div>",
+                "<Div><div>a</div></Div><div>b</div>",
+            ),
+            ("<Div><DIV>a</Div></DIV>", "<Div><div>a</div></Div>"),
+        ];
+
+        for (body, expected) in cases {
+            let out = MdxOutput {
+                body: body.to_owned(),
+                esm: vec![],
+                front_matter: None,
+            };
+            let component = out.to_component("Page").unwrap();
+
+            assert!(component.contains(expected), "{body}: {component}");
+            assert_eq!(
+                component.matches("</div>").count(),
+                expected.matches("</div>").count()
+            );
+            assert_eq!(
+                component.matches("</Div>").count(),
+                expected.matches("</Div>").count()
+            );
+            assert_eq!(
+                component.matches("</span>").count(),
+                expected.matches("</span>").count()
+            );
+        }
     }
 
     #[test]

--- a/src/mdx/render.rs
+++ b/src/mdx/render.rs
@@ -10,6 +10,12 @@ use super::{
 
 const COMPONENT_BODY_INDENT: &str = "      ";
 
+#[derive(Clone, Copy)]
+enum HtmlTextKind {
+    Raw,
+    Rcdata,
+}
+
 /// Error returned when a component name cannot be used as a JavaScript binding.
 ///
 /// Future releases may add validation failures. Downstream matches must include a wildcard arm.
@@ -226,6 +232,11 @@ fn write_component_body(out: &mut String, body: &str) {
             continue;
         }
 
+        if bytes[pos] == b'<' && matches!(bytes.get(pos + 1), Some(b'!' | b'?')) {
+            pos = declaration_end(bytes, pos).unwrap_or(bytes.len());
+            continue;
+        }
+
         if bytes[pos] == b'<'
             && let Some(tag) = parse_jsx_tag(&bytes[pos..])
         {
@@ -233,12 +244,13 @@ fn write_component_body(out: &mut String, body: &str) {
             write_component_tag(out, &body[pos..pos + tag.end_offset], &tag);
             at_line_start = false;
 
-            let is_raw_text_open = !tag.is_closing
-                && !tag.is_self_closing
-                && (tag.name.eq_ignore_ascii_case("script")
-                    || tag.name.eq_ignore_ascii_case("style"));
+            let text_kind = if !tag.is_closing && !tag.is_self_closing {
+                html_text_kind(tag.name)
+            } else {
+                None
+            };
 
-            if tag.name.eq_ignore_ascii_case("pre") && !tag.is_self_closing {
+            if tag.name == "pre" && !tag.is_self_closing {
                 if tag.is_closing {
                     pre_depth = pre_depth.saturating_sub(1);
                 } else {
@@ -247,9 +259,13 @@ fn write_component_body(out: &mut String, body: &str) {
             }
 
             pos += tag.end_offset;
-            if is_raw_text_open {
+            if let Some(text_kind) = text_kind {
                 let end = raw_text_end(bytes, pos, tag.name).unwrap_or(bytes.len());
-                write_jsx_string_child(out, &body[pos..end], false);
+                write_jsx_string_child(
+                    out,
+                    &body[pos..end],
+                    matches!(text_kind, HtmlTextKind::Rcdata),
+                );
                 // The raw text's line breaks are escaped inside the string child,
                 // so the generated JSX source is still on the opening tag's line.
                 at_line_start = false;
@@ -329,6 +345,14 @@ fn is_html_void_element(name: &str) -> bool {
     )
 }
 
+fn html_text_kind(name: &str) -> Option<HtmlTextKind> {
+    match name {
+        "script" | "style" | "xmp" | "iframe" | "noembed" | "noframes" => Some(HtmlTextKind::Raw),
+        "textarea" | "title" => Some(HtmlTextKind::Rcdata),
+        _ => None,
+    }
+}
+
 fn indent_component_line(out: &mut String, at_line_start: bool, pre_depth: u32) {
     if at_line_start && pre_depth == 0 {
         out.push_str(COMPONENT_BODY_INDENT);
@@ -375,7 +399,7 @@ fn raw_text_end(bytes: &[u8], start: usize, tag_name: &str) -> Option<usize> {
         pos += offset;
         if let Some(tag) = parse_jsx_tag(&bytes[pos..])
             && tag.is_closing
-            && tag.name.eq_ignore_ascii_case(tag_name)
+            && tag.name == tag_name
         {
             return Some(pos);
         }
@@ -399,6 +423,30 @@ fn comment_end(bytes: &[u8], start: usize) -> Option<usize> {
         .windows(3)
         .position(|window| window == b"-->")
         .map(|offset| start + 4 + offset + 3)
+}
+
+fn declaration_end(bytes: &[u8], start: usize) -> Option<usize> {
+    if bytes[start..].starts_with(b"<![CDATA[") {
+        return bytes[start + 9..]
+            .windows(3)
+            .position(|window| window == b"]]>")
+            .map(|offset| start + 9 + offset + 3);
+    }
+
+    let mut pos = start + 2;
+    let mut quote = None;
+    while pos < bytes.len() {
+        match (quote, bytes[pos]) {
+            (Some(expected), current) if current == expected => quote = None,
+            (Some(_), _) => {}
+            (None, b'"' | b'\'') => quote = Some(bytes[pos]),
+            (None, b'>') => return Some(pos + 1),
+            (None, _) => {}
+        }
+        pos += 1;
+    }
+
+    None
 }
 
 fn standalone_expression_end(bytes: &[u8], start: usize) -> Option<usize> {
@@ -804,6 +852,57 @@ Content
             "{component}"
         );
         assert!(component.contains("line<br />\n"), "{component}");
+    }
+
+    #[test]
+    fn to_component_omits_html_declarations() {
+        let out = MdxOutput {
+            body:
+                "<!DOCTYPE html>\n<?xml version=\"1.0\"?>\n<![CDATA[ignored > text]]>\n<p>Safe</p>"
+                    .to_owned(),
+            esm: vec![],
+            front_matter: None,
+        };
+        let component = out.to_component("Page").unwrap();
+
+        assert!(!component.contains("<!"), "{component}");
+        assert!(!component.contains("<?"), "{component}");
+        assert!(!component.contains("ignored"), "{component}");
+        assert!(component.contains("<p>Safe</p>"), "{component}");
+    }
+
+    #[test]
+    fn to_component_preserves_textarea_and_title_text() {
+        let out = MdxOutput {
+            body: "<textarea data-kind=\"example\">first\r\n  second {value}&amp;\r\n</textarea>\r\n<title>first\n  second {value}&amp;\n</title>"
+                .to_owned(),
+            esm: vec![],
+            front_matter: None,
+        };
+        let component = out.to_component("Page").unwrap();
+
+        assert!(component.contains(
+            "<textarea data-kind=\"example\">{\"first\\r\\n  second {value}&\\r\\n\"}</textarea>"
+        ), "{component}");
+        assert!(
+            component.contains("<title>{\"first\\n  second {value}&\\n\"}</title>"),
+            "{component}"
+        );
+    }
+
+    #[test]
+    fn to_component_does_not_treat_component_names_as_html_text_elements() {
+        let out = render("<Pre>\n\n{value}\n\n</Pre>\n\n<Style>\n\n{text}\n\n</Style>\n");
+        let component = out.to_component("Page").unwrap();
+
+        assert!(
+            component.contains("      <Pre>\n      {value}\n      </Pre>"),
+            "{component}"
+        );
+        assert!(
+            component.contains("      <Style>\n      {text}\n      </Style>"),
+            "{component}"
+        );
     }
 
     #[test]

--- a/src/mdx/render.rs
+++ b/src/mdx/render.rs
@@ -13,11 +13,28 @@ const HTML_VOID_ELEMENTS: [&str; 14] = [
     "area", "base", "br", "col", "embed", "hr", "img", "input", "link", "meta", "param", "source",
     "track", "wbr",
 ];
+const HTML_INTRINSIC_ELEMENTS: &str = concat!(
+    "a abbr acronym address applet area article aside audio b base bdi bdo big blink blockquote ",
+    "body br button canvas caption center cite code col colgroup data datalist dd del details dfn ",
+    "dialog dir div dl dt em embed fieldset figcaption figure font footer form frameset h1 h2 h3 ",
+    "h4 h5 h6 head header hgroup hr html i iframe img input ins kbd label legend li link main map ",
+    "mark marquee menu menuitem meta meter nav nobr noembed noframes noscript object ol optgroup ",
+    "option output p param picture plaintext pre progress q rb rp rt rtc ruby s samp script search ",
+    "section select slot small source span strike strong style sub summary sup table tbody td ",
+    "template textarea tfoot th thead time title tr track tt u ul var video wbr xmp",
+);
 
 #[derive(Clone, Copy)]
 enum HtmlTextKind {
     Raw,
     Rcdata,
+}
+
+#[derive(Clone, Copy)]
+enum ComponentTagEffect {
+    None,
+    PreOpen,
+    PreClose,
 }
 
 /// Error returned when a component name cannot be used as a JavaScript binding.
@@ -211,7 +228,7 @@ fn write_component_body(out: &mut String, body: &str) {
     let mut pos = 0;
     let mut at_line_start = true;
     let mut pre_depth = 0_u32;
-    let mut void_component_openings = Vec::new();
+    let mut html_component_openings = Vec::new();
 
     while pos < bytes.len() {
         if pre_depth > 0 && bytes[pos] != b'<' {
@@ -272,29 +289,28 @@ fn write_component_body(out: &mut String, body: &str) {
                 None
             };
             indent_component_line(out, at_line_start, pre_depth);
-            if let Some((_, canonical_name)) = text_element {
-                write_html_text_opening_tag(
+            let tag_effect = if let Some((_, canonical_name)) = text_element {
+                write_html_opening_tag(
                     out,
                     &body[pos..pos + tag.end_offset],
                     tag.name,
                     canonical_name,
                 );
+                ComponentTagEffect::None
             } else {
                 write_component_tag(
                     out,
                     &body[pos..pos + tag.end_offset],
                     &tag,
-                    &mut void_component_openings,
-                );
-            }
+                    &mut html_component_openings,
+                )
+            };
             at_line_start = false;
 
-            if tag.name == "pre" && !tag.is_self_closing {
-                if tag.is_closing {
-                    pre_depth = pre_depth.saturating_sub(1);
-                } else {
-                    pre_depth = pre_depth.saturating_add(1);
-                }
+            match tag_effect {
+                ComponentTagEffect::PreOpen => pre_depth = pre_depth.saturating_add(1),
+                ComponentTagEffect::PreClose => pre_depth = pre_depth.saturating_sub(1),
+                ComponentTagEffect::None => {}
             }
 
             pos += tag.end_offset;
@@ -362,36 +378,57 @@ fn write_component_tag<'a>(
     out: &mut String,
     source: &str,
     tag: &TagInfo<'a>,
-    void_component_openings: &mut Vec<(usize, &'a str)>,
-) {
+    html_component_openings: &mut Vec<(&'static str, &'a str)>,
+) -> ComponentTagEffect {
     if tag.is_closing {
-        if let Some(index) = html_void_element_index_ignore_ascii_case(tag.name) {
-            if void_component_openings
+        if let Some(canonical_name) = html_element_ignore_ascii_case(tag.name) {
+            if html_component_openings
                 .last()
-                .is_some_and(|(opening_index, _)| *opening_index == index)
+                .is_some_and(|(opening_canonical, _)| *opening_canonical == canonical_name)
             {
-                let (_, opening_name) = void_component_openings
+                let (_, opening_name) = html_component_openings
                     .pop()
                     .expect("last component opening was just checked");
                 write_closing_tag(out, source, opening_name);
+                return ComponentTagEffect::None;
             }
-            return;
+            if HTML_VOID_ELEMENTS.contains(&canonical_name) {
+                return ComponentTagEffect::None;
+            }
+            if uses_html_intrinsic_syntax(tag.name) {
+                write_closing_tag(out, source, canonical_name);
+                return if canonical_name == "pre" {
+                    ComponentTagEffect::PreClose
+                } else {
+                    ComponentTagEffect::None
+                };
+            }
         }
         out.push_str(source);
-        return;
+        return ComponentTagEffect::None;
     }
 
-    if let Some((_, canonical_name)) = html_void_element(tag.name) {
+    if let Some(canonical_name) = html_void_element(tag.name) {
         write_html_void_opening_tag(out, source, tag.name, canonical_name, tag.is_self_closing);
-        return;
+        return ComponentTagEffect::None;
+    }
+
+    if let Some(canonical_name) = html_element(tag.name) {
+        write_html_opening_tag(out, source, tag.name, canonical_name);
+        return if canonical_name == "pre" && !tag.is_self_closing {
+            ComponentTagEffect::PreOpen
+        } else {
+            ComponentTagEffect::None
+        };
     }
 
     if !tag.is_self_closing
-        && let Some(index) = html_void_element_index_ignore_ascii_case(tag.name)
+        && let Some(canonical_name) = html_element_ignore_ascii_case(tag.name)
     {
-        void_component_openings.push((index, tag.name));
+        html_component_openings.push((canonical_name, tag.name));
     }
     out.push_str(source);
+    ComponentTagEffect::None
 }
 
 fn write_html_void_opening_tag(
@@ -422,22 +459,27 @@ fn write_html_void_opening_tag(
     out.push('>');
 }
 
-fn html_void_element(name: &str) -> Option<(usize, &'static str)> {
+fn html_void_element(name: &str) -> Option<&'static str> {
     if !uses_html_intrinsic_syntax(name) {
         return None;
     }
 
     HTML_VOID_ELEMENTS
         .iter()
-        .enumerate()
-        .find(|(_, element)| element.eq_ignore_ascii_case(name))
-        .map(|(index, element)| (index, *element))
+        .find(|element| element.eq_ignore_ascii_case(name))
+        .copied()
 }
 
-fn html_void_element_index_ignore_ascii_case(name: &str) -> Option<usize> {
-    HTML_VOID_ELEMENTS
-        .iter()
-        .position(|element| element.eq_ignore_ascii_case(name))
+fn html_element(name: &str) -> Option<&'static str> {
+    uses_html_intrinsic_syntax(name)
+        .then(|| html_element_ignore_ascii_case(name))
+        .flatten()
+}
+
+fn html_element_ignore_ascii_case(name: &str) -> Option<&'static str> {
+    HTML_INTRINSIC_ELEMENTS
+        .split_ascii_whitespace()
+        .find(|element| element.eq_ignore_ascii_case(name))
 }
 
 fn html_text_element(name: &str) -> Option<(HtmlTextKind, &'static str)> {
@@ -520,7 +562,7 @@ fn write_closing_tag(out: &mut String, source: &str, opening_name: &str) {
     out.push_str(&source[opening_name.len() + 2..]);
 }
 
-fn write_html_text_opening_tag(
+fn write_html_opening_tag(
     out: &mut String,
     source: &str,
     original_name: &str,
@@ -1706,6 +1748,53 @@ Content
             component.contains("      <Title>\n      {text}\n      </Title>"),
             "{component}"
         );
+    }
+
+    #[test]
+    fn to_component_canonicalizes_rendered_case_variant_pre_and_code() {
+        let out = render("<PRE><CODE>first\n  second {value}\n</CODE></PRE>\n");
+        let component = out.to_component("Page").unwrap();
+
+        assert!(
+            component.contains("      <pre><code>{\"first\\n  second {value}\\n\"}</code></pre>"),
+            "{component}"
+        );
+    }
+
+    #[test]
+    fn to_component_preserves_case_variant_pre_text_and_nested_html_kinds() {
+        for body in [
+            "<PRE data-kind=\"upper\"><CODE>first\r\n  second {value}&amp;\r\n</cOdE></pRe><p>after</p>",
+            "<pRe><cOdE>first\n  second {value}\n</CODE><TEXTAREA>third\n  fourth &amp; {value}\n</textarea><SCRIPT>if (left < right) { run(); }</script></PRE>",
+        ] {
+            let out = MdxOutput {
+                body: body.to_owned(),
+                esm: vec![],
+                front_matter: None,
+            };
+            let component = out.to_component("Page").unwrap();
+
+            assert!(!component.contains("<PRE"), "{component}");
+            assert!(!component.contains("<CODE"), "{component}");
+            assert!(component.contains("<pre"), "{component}");
+            assert!(component.contains("<code>"), "{component}");
+            assert!(component.contains("second {value}"), "{component}");
+            assert!(!component.contains("      second"), "{component}");
+            assert!(component.contains("</code>"), "{component}");
+            assert!(component.contains("</pre>"), "{component}");
+        }
+    }
+
+    #[test]
+    fn to_component_keeps_pascal_case_pre_and_code_components() {
+        let out = render("<Pre>\n\n<Code>\n\n{value}\n\n</Code>\n\n</Pre>\n");
+        let component = out.to_component("Page").unwrap();
+
+        assert!(component.contains("      <Pre>"), "{component}");
+        assert!(component.contains("      <Code>"), "{component}");
+        assert!(component.contains("      {value}"), "{component}");
+        assert!(component.contains("      </Code>"), "{component}");
+        assert!(component.contains("      </Pre>"), "{component}");
     }
 
     #[test]

--- a/src/mdx/render.rs
+++ b/src/mdx/render.rs
@@ -259,7 +259,8 @@ fn write_component_body(out: &mut String, body: &str) {
             }
 
             // Bound malformed-comment recovery just like incomplete
-            // declarations so a later real element is not swallowed.
+            // declarations so a later real element is not swallowed. The
+            // ordinary text path below also encodes its braces and closing `>`.
             indent_component_line(out, at_line_start, pre_depth);
             out.push_str("&lt;");
             at_line_start = false;
@@ -274,8 +275,9 @@ fn write_component_body(out: &mut String, body: &str) {
             }
 
             // An incomplete or declaration-like near-match is not an HTML node.
-            // Escape only its opening delimiter so later real JSX/HTML nodes are
-            // still processed instead of truncating the rest of the component.
+            // Escape its opening delimiter and let the ordinary text path encode
+            // the remaining JSX-significant bytes. Later real JSX/HTML nodes are
+            // still processed instead of being swallowed by malformed recovery.
             indent_component_line(out, at_line_start, pre_depth);
             out.push_str("&lt;");
             at_line_start = false;
@@ -366,6 +368,10 @@ fn write_component_body(out: &mut String, body: &str) {
             }
             b'}' => {
                 out.push_str("&#125;");
+                pos += 1;
+            }
+            b'>' => {
+                out.push_str("&gt;");
                 pos += 1;
             }
             _ => {
@@ -1687,6 +1693,35 @@ Content
 
             assert!(component.contains("&lt;"), "{component}");
             assert!(component.contains("<p>after"), "{component}");
+        }
+    }
+
+    #[test]
+    fn to_component_escapes_complete_malformed_declaration_text() {
+        for line_break in ["\n", "\r\n"] {
+            for malformed in [
+                "<?bad>",
+                "<?bad data='value>still' {literal}>",
+                "<![not-cdata]>",
+                "<![not-cdata data=\"value>still\"]>",
+                "<!-- no terminator>",
+                "<!-- no terminator {literal}>",
+                "<!-near-match>",
+            ] {
+                let markdown = format!("{malformed}{line_break}{line_break}<p>after</p>");
+                let component = render(&markdown).to_component("Page").unwrap();
+
+                assert!(component.contains("&lt;"), "{malformed}: {component}");
+                assert!(component.contains("&gt;"), "{malformed}: {component}");
+                assert!(!component.contains("{literal}"), "{malformed}: {component}");
+                if malformed.contains("{literal}") {
+                    assert!(component.contains("&#123;literal&#125;"), "{component}");
+                }
+                assert!(
+                    component.contains("<p>after</p>"),
+                    "{malformed}: {component}"
+                );
+            }
         }
     }
 

--- a/src/mdx/render.rs
+++ b/src/mdx/render.rs
@@ -229,6 +229,7 @@ fn write_component_body(out: &mut String, body: &str) {
     let mut at_line_start = true;
     let mut pre_depth = 0_u32;
     let mut html_openings = Vec::new();
+    let mut generic_declaration_ends = None;
     // A crossed owner is balanced at the first mismatched closer. Remember that
     // its eventual source closer must be consumed if no newer live owner claims it.
     let mut synthetic_closings = HashMap::new();
@@ -269,7 +270,7 @@ fn write_component_body(out: &mut String, body: &str) {
         }
 
         if bytes[pos] == b'<' && matches!(bytes.get(pos + 1), Some(b'!' | b'?')) {
-            if let Some(end) = declaration_end(bytes, pos) {
+            if let Some(end) = declaration_end(bytes, pos, &mut generic_declaration_ends) {
                 pos = end;
                 continue;
             }
@@ -729,7 +730,112 @@ fn comment_end(bytes: &[u8], start: usize) -> Option<usize> {
         .map(|offset| start + 4 + offset + 3)
 }
 
-fn declaration_end(bytes: &[u8], start: usize) -> Option<usize> {
+#[derive(Clone, Copy)]
+struct GenericDeclarationEnd {
+    start: usize,
+    outcome: GenericDeclarationScan,
+}
+
+/// Cached generic declaration ends for a single component body.
+///
+/// Entries are built from right to left. A complete declaration nested in an
+/// internal subset can therefore be skipped as a balanced unit. An inner scan
+/// which reaches EOF proves that an enclosing declaration with additional
+/// bracket depth cannot close either. Boundary failures are deliberately not
+/// propagated because an enclosing subset can assign different meaning to the
+/// same `<` byte.
+struct GenericDeclarationEnds {
+    entries: Vec<GenericDeclarationEnd>,
+    next_entry: usize,
+    #[cfg(test)]
+    scanned_bytes: usize,
+}
+
+#[derive(Default)]
+struct DeclarationScanWork {
+    #[cfg(test)]
+    scanned_bytes: usize,
+}
+
+impl DeclarationScanWork {
+    #[inline]
+    fn visit(&mut self) {
+        #[cfg(test)]
+        {
+            self.scanned_bytes += 1;
+        }
+    }
+}
+
+impl GenericDeclarationEnds {
+    fn new(bytes: &[u8], first_start: usize) -> Self {
+        let mut entries = Vec::new();
+        for start in first_start..bytes.len() {
+            if is_generic_declaration_start(bytes, start) {
+                entries.push(GenericDeclarationEnd {
+                    start,
+                    outcome: GenericDeclarationScan::BoundaryFailure,
+                });
+            }
+        }
+
+        let mut work = DeclarationScanWork::default();
+        for entry_index in (0..entries.len()).rev() {
+            let outcome = generic_declaration_scan(
+                bytes,
+                entries[entry_index].start,
+                Some((&entries, entry_index + 1)),
+                &mut work,
+            );
+            entries[entry_index].outcome = outcome;
+        }
+
+        Self {
+            entries,
+            next_entry: 0,
+            #[cfg(test)]
+            scanned_bytes: bytes.len().saturating_sub(first_start) + work.scanned_bytes,
+        }
+    }
+
+    fn end_at(&mut self, start: usize) -> Option<usize> {
+        while self
+            .entries
+            .get(self.next_entry)
+            .is_some_and(|entry| entry.start < start)
+        {
+            self.next_entry += 1;
+        }
+
+        let outcome = self
+            .entries
+            .get(self.next_entry)
+            .filter(|entry| entry.start == start)
+            .map_or(GenericDeclarationScan::BoundaryFailure, |entry| {
+                entry.outcome
+            });
+        match outcome {
+            GenericDeclarationScan::Complete { end, .. } => Some(end),
+            GenericDeclarationScan::BoundaryFailure | GenericDeclarationScan::EofFailure => None,
+        }
+    }
+
+    #[cfg(test)]
+    fn scanned_bytes(&self) -> usize {
+        self.scanned_bytes
+    }
+
+    #[cfg(test)]
+    fn entry_count(&self) -> usize {
+        self.entries.len()
+    }
+}
+
+fn declaration_end(
+    bytes: &[u8],
+    start: usize,
+    generic_ends: &mut Option<GenericDeclarationEnds>,
+) -> Option<usize> {
     if bytes[start..].starts_with(b"<![CDATA[") {
         return bytes[start + 9..]
             .windows(3)
@@ -744,22 +850,47 @@ fn declaration_end(bytes: &[u8], start: usize) -> Option<usize> {
             .map(|offset| start + 2 + offset + 2);
     }
 
-    if bytes
-        .get(start + 2)
-        .is_none_or(|byte| !byte.is_ascii_alphabetic())
-    {
+    if !is_generic_declaration_start(bytes, start) {
         return None;
     }
 
-    generic_declaration_end(bytes, start)
+    generic_ends
+        .get_or_insert_with(|| GenericDeclarationEnds::new(bytes, start))
+        .end_at(start)
 }
 
-fn generic_declaration_end(bytes: &[u8], start: usize) -> Option<usize> {
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum GenericDeclarationScan {
+    Complete {
+        end: usize,
+        /// Whether the declaration's internal subset brackets are balanced
+        /// without borrowing a closing bracket from an enclosing subset.
+        independently_balanced: bool,
+    },
+    BoundaryFailure,
+    EofFailure,
+}
+
+fn is_generic_declaration_start(bytes: &[u8], start: usize) -> bool {
+    bytes.get(start) == Some(&b'<')
+        && bytes.get(start + 1) == Some(&b'!')
+        && bytes.get(start + 2).is_some_and(u8::is_ascii_alphabetic)
+}
+
+fn generic_declaration_scan(
+    bytes: &[u8],
+    start: usize,
+    cached_entries: Option<(&[GenericDeclarationEnd], usize)>,
+    work: &mut DeclarationScanWork,
+) -> GenericDeclarationScan {
     let mut pos = start + 2;
     let mut bracket_depth = 0_u32;
+    let mut independently_balanced = true;
     let mut quote = None;
+    let mut next_cached_entry = cached_entries.map_or(0, |(_, entry_index)| entry_index);
 
     while pos < bytes.len() {
+        work.visit();
         if let Some(delimiter) = quote {
             if bytes[pos] == delimiter {
                 quote = None;
@@ -767,47 +898,110 @@ fn generic_declaration_end(bytes: &[u8], start: usize) -> Option<usize> {
                 // A new top-level tag cannot belong to an unclosed declaration
                 // literal. Bound recovery here so a later quote and `>` cannot
                 // make the following node look like the declaration's suffix.
-                return None;
+                return GenericDeclarationScan::BoundaryFailure;
             }
             pos += 1;
             continue;
         }
 
         if bracket_depth > 0 && bytes[pos..].starts_with(b"<!--") {
-            pos = comment_end(bytes, pos)?;
+            let Some(end) = comment_end(bytes, pos) else {
+                return GenericDeclarationScan::EofFailure;
+            };
+            pos = end;
             continue;
         }
         if bracket_depth > 0 && bytes[pos..].starts_with(b"<?") {
-            pos = bytes[pos + 2..]
+            let Some(end) = bytes[pos + 2..]
                 .windows(2)
                 .position(|window| window == b"?>")
-                .map(|offset| pos + 2 + offset + 2)?;
+                .map(|offset| pos + 2 + offset + 2)
+            else {
+                return GenericDeclarationScan::EofFailure;
+            };
+            pos = end;
             continue;
         }
         if bracket_depth > 0 && conditional_section_content_start(bytes, pos).is_some() {
-            pos = conditional_section_end(bytes, pos)?;
+            let Some(end) = conditional_section_end(bytes, pos) else {
+                return GenericDeclarationScan::EofFailure;
+            };
+            pos = end;
             continue;
+        }
+
+        if bracket_depth > 0
+            && is_generic_declaration_start(bytes, pos)
+            && let Some((entries, _)) = cached_entries
+        {
+            while entries
+                .get(next_cached_entry)
+                .is_some_and(|entry| entry.start < pos)
+            {
+                next_cached_entry += 1;
+            }
+            if let Some(entry) = entries
+                .get(next_cached_entry)
+                .filter(|entry| entry.start == pos)
+            {
+                match entry.outcome {
+                    GenericDeclarationScan::EofFailure => {
+                        return GenericDeclarationScan::EofFailure;
+                    }
+                    GenericDeclarationScan::BoundaryFailure
+                    | GenericDeclarationScan::Complete {
+                        independently_balanced: false,
+                        ..
+                    } => {}
+                    GenericDeclarationScan::Complete {
+                        end,
+                        independently_balanced: true,
+                    } => {
+                        pos = end;
+                        continue;
+                    }
+                }
+            }
         }
 
         match bytes[pos] {
             b'\'' | b'"' => quote = Some(bytes[pos]),
-            b'[' => bracket_depth = bracket_depth.checked_add(1)?,
+            b'[' => {
+                let Some(next_depth) = bracket_depth.checked_add(1) else {
+                    return GenericDeclarationScan::BoundaryFailure;
+                };
+                bracket_depth = next_depth;
+            }
             b']' if bracket_depth > 0 => bracket_depth -= 1,
+            b']' => independently_balanced = false,
             b'<' => {
                 // Internal subsets contain nested declarations and processing
                 // instructions. An ordinary tag is instead the recovery
                 // boundary for an incomplete outer declaration.
                 if bracket_depth == 0 || !matches!(bytes.get(pos + 1), Some(b'!' | b'?')) {
-                    return None;
+                    return GenericDeclarationScan::BoundaryFailure;
                 }
             }
-            b'>' if bracket_depth == 0 => return Some(pos + 1),
+            b'>' if bracket_depth == 0 => {
+                return GenericDeclarationScan::Complete {
+                    end: pos + 1,
+                    independently_balanced,
+                };
+            }
             _ => {}
         }
         pos += 1;
     }
 
-    None
+    GenericDeclarationScan::EofFailure
+}
+
+#[cfg(test)]
+fn generic_declaration_end_uncached(bytes: &[u8], start: usize) -> Option<usize> {
+    match generic_declaration_scan(bytes, start, None, &mut DeclarationScanWork::default()) {
+        GenericDeclarationScan::Complete { end, .. } => Some(end),
+        GenericDeclarationScan::BoundaryFailure | GenericDeclarationScan::EofFailure => None,
+    }
 }
 
 fn conditional_section_end(bytes: &[u8], start: usize) -> Option<usize> {
@@ -1719,6 +1913,134 @@ Content
                 "{component}"
             );
         }
+    }
+
+    #[test]
+    fn generic_declaration_cache_matches_the_sequential_scanner() {
+        let repeated = "<!DOCTYPE [".repeat(32);
+        let bodies = [
+            "<!DOCTYPE html>",
+            "<!DOCTYPE html [<!ENTITY example \"value\">]><p>after</p>",
+            "<!OUTER [<!INNER [<!LEAF value>]>]><p>after</p>",
+            "<!DOCTYPE [<!INNER complete>",
+            "<!OUTER [<!INNER ]>",
+            "<!OUTER [<!INNER ]><p>after borrowed close</p>",
+            "<!OUTER [<!INNER \"unterminated <p> literal\">]><p>after</p>",
+            "<!DOCTYPE html [<!-- comment --><?inside value?><![INCLUDE[<p>literal</p>]]>]>",
+            "<!DOCTYPE html [<!ENTITY example \"unterminated\n<p>after</p>",
+            "<!near-match><p>after</p>",
+            repeated.as_str(),
+        ];
+
+        for body in bodies {
+            let bytes = body.as_bytes();
+            let starts: Vec<_> = (0..bytes.len())
+                .filter(|&start| is_generic_declaration_start(bytes, start))
+                .collect();
+            let mut cached = GenericDeclarationEnds::new(bytes, starts[0]);
+
+            for start in starts {
+                assert_eq!(
+                    cached.end_at(start),
+                    generic_declaration_end_uncached(bytes, start),
+                    "cache changed the declaration boundary at {start} in {body:?}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn repeated_unterminated_subsets_have_a_deterministic_linear_work_bound() {
+        const REPEATS: usize = 8_192;
+        let unit = "<!DOCTYPE [";
+        let body = unit.repeat(REPEATS);
+        let mut cached = GenericDeclarationEnds::new(body.as_bytes(), 0);
+
+        assert_eq!(cached.entry_count(), REPEATS);
+        for start in (0..body.len()).step_by(unit.len()) {
+            assert_eq!(cached.end_at(start), None);
+        }
+        assert!(
+            cached.scanned_bytes() <= body.len() * 3,
+            "{} scan visits for {} input bytes",
+            cached.scanned_bytes(),
+            body.len()
+        );
+    }
+
+    #[test]
+    fn repeated_unterminated_subsets_keep_public_output_and_strict_parity() {
+        let input = "<!DOCTYPE [".repeat(1_024);
+        let output = render(&input);
+        let component = output.to_component("Page").unwrap();
+
+        assert_eq!(component.matches("&lt;!DOCTYPE [").count(), 1_024);
+        assert!(!component.contains("<!DOCTYPE"), "{component}");
+        assert_eq!(
+            crate::mdx::segment_strict(&input).unwrap(),
+            crate::mdx::segment_spanned(&input)
+        );
+    }
+
+    #[test]
+    fn declaration_cache_preserves_nested_recovery_semantics() {
+        let incomplete_outer = MdxOutput {
+            body: "<!DOCTYPE [<!INNER complete><p>after outer failure</p>".to_owned(),
+            esm: vec![],
+            front_matter: None,
+        }
+        .to_component("Page")
+        .unwrap();
+        assert!(
+            incomplete_outer.contains("&lt;!DOCTYPE ["),
+            "{incomplete_outer}"
+        );
+        assert!(!incomplete_outer.contains("INNER"), "{incomplete_outer}");
+        assert!(
+            incomplete_outer.contains("<p>after outer failure</p>"),
+            "{incomplete_outer}"
+        );
+
+        let context_dependent_inner = MdxOutput {
+            body: "<!OUTER [<!INNER \"unterminated <p> literal\">]><p>after complete outer</p>"
+                .to_owned(),
+            esm: vec![],
+            front_matter: None,
+        }
+        .to_component("Page")
+        .unwrap();
+        assert!(
+            !context_dependent_inner.contains("OUTER"),
+            "{context_dependent_inner}"
+        );
+        assert!(
+            !context_dependent_inner.contains("INNER"),
+            "{context_dependent_inner}"
+        );
+        assert!(
+            context_dependent_inner.contains("<p>after complete outer</p>"),
+            "{context_dependent_inner}"
+        );
+
+        let borrowed_subset_close = MdxOutput {
+            body: "<!OUTER [<!INNER ]><p>after borrowed close</p>".to_owned(),
+            esm: vec![],
+            front_matter: None,
+        }
+        .to_component("Page")
+        .unwrap();
+        assert!(
+            !borrowed_subset_close.contains("OUTER"),
+            "{borrowed_subset_close}"
+        );
+        assert!(
+            !borrowed_subset_close.contains("INNER"),
+            "{borrowed_subset_close}"
+        );
+        assert!(
+            borrowed_subset_close.contains("<p>after borrowed close</p>"),
+            "{borrowed_subset_close}"
+        );
     }
 
     #[test]

--- a/src/mdx/render.rs
+++ b/src/mdx/render.rs
@@ -229,7 +229,8 @@ fn write_component_body(out: &mut String, body: &str) {
     let mut at_line_start = true;
     let mut pre_depth = 0_u32;
     let mut html_openings = Vec::new();
-    let mut generic_declaration_ends = None;
+    let mut declaration_ends = DeclarationEnds::default();
+    let mut declaration_scan_work = DeclarationScanWork::default();
     // A crossed owner is balanced at the first mismatched closer. Remember that
     // its eventual source closer must be consumed if no newer live owner claims it.
     let mut synthetic_closings = HashMap::new();
@@ -270,7 +271,12 @@ fn write_component_body(out: &mut String, body: &str) {
         }
 
         if bytes[pos] == b'<' && matches!(bytes.get(pos + 1), Some(b'!' | b'?')) {
-            if let Some(end) = declaration_end(bytes, pos, &mut generic_declaration_ends) {
+            if let Some(end) = declaration_end(
+                bytes,
+                pos,
+                &mut declaration_ends,
+                &mut declaration_scan_work,
+            ) {
                 pos = end;
                 continue;
             }
@@ -741,14 +747,52 @@ struct GenericDeclarationEnd {
 /// Entries are built from right to left. A complete declaration nested in an
 /// internal subset can therefore be skipped as a balanced unit. An inner scan
 /// which reaches EOF proves that an enclosing declaration with additional
-/// bracket depth cannot close either. Boundary failures are deliberately not
-/// propagated because an enclosing subset can assign different meaning to the
-/// same `<` byte.
+/// bracket depth cannot close either. Ordinary-tag boundaries are reusable at
+/// every subset depth; quote and declaration boundaries remain context-local
+/// because an enclosing subset can assign different meaning to the same byte.
 struct GenericDeclarationEnds {
     entries: Vec<GenericDeclarationEnd>,
     next_entry: usize,
     #[cfg(test)]
     scanned_bytes: usize,
+}
+
+#[derive(Default)]
+struct DeclarationEnds {
+    generic: Option<GenericDeclarationEnds>,
+    processing_instructions: Option<DeclarationTerminatorEnds>,
+    cdata: Option<DeclarationTerminatorEnds>,
+}
+
+struct DeclarationTerminatorEnds {
+    ends: Vec<usize>,
+    next_end: usize,
+}
+
+impl DeclarationTerminatorEnds {
+    fn new(bytes: &[u8], terminator: &[u8], work: &mut DeclarationScanWork) -> Self {
+        let mut ends = Vec::new();
+        let mut pos = 0;
+        while pos + terminator.len() <= bytes.len() {
+            work.visit();
+            if bytes[pos..].starts_with(terminator) {
+                ends.push(pos + terminator.len());
+            }
+            pos += 1;
+        }
+        Self { ends, next_end: 0 }
+    }
+
+    fn end_after(&mut self, content_start: usize) -> Option<usize> {
+        while self
+            .ends
+            .get(self.next_end)
+            .is_some_and(|end| *end < content_start)
+        {
+            self.next_end += 1;
+        }
+        self.ends.get(self.next_end).copied()
+    }
 }
 
 #[derive(Default)]
@@ -774,7 +818,7 @@ impl GenericDeclarationEnds {
             if is_generic_declaration_start(bytes, start) {
                 entries.push(GenericDeclarationEnd {
                     start,
-                    outcome: GenericDeclarationScan::BoundaryFailure,
+                    outcome: GenericDeclarationScan::BoundaryFailure { reusable: false },
                 });
             }
         }
@@ -811,12 +855,15 @@ impl GenericDeclarationEnds {
             .entries
             .get(self.next_entry)
             .filter(|entry| entry.start == start)
-            .map_or(GenericDeclarationScan::BoundaryFailure, |entry| {
-                entry.outcome
-            });
+            .map_or(
+                GenericDeclarationScan::BoundaryFailure { reusable: false },
+                |entry| entry.outcome,
+            );
         match outcome {
             GenericDeclarationScan::Complete { end, .. } => Some(end),
-            GenericDeclarationScan::BoundaryFailure | GenericDeclarationScan::EofFailure => None,
+            GenericDeclarationScan::BoundaryFailure { .. } | GenericDeclarationScan::EofFailure => {
+                None
+            }
         }
     }
 
@@ -834,27 +881,28 @@ impl GenericDeclarationEnds {
 fn declaration_end(
     bytes: &[u8],
     start: usize,
-    generic_ends: &mut Option<GenericDeclarationEnds>,
+    ends: &mut DeclarationEnds,
+    work: &mut DeclarationScanWork,
 ) -> Option<usize> {
     if bytes[start..].starts_with(b"<![CDATA[") {
-        return bytes[start + 9..]
-            .windows(3)
-            .position(|window| window == b"]]>")
-            .map(|offset| start + 9 + offset + 3);
+        return ends
+            .cdata
+            .get_or_insert_with(|| DeclarationTerminatorEnds::new(bytes, b"]]>", work))
+            .end_after(start + 9);
     }
 
     if bytes[start..].starts_with(b"<?") {
-        return bytes[start + 2..]
-            .windows(2)
-            .position(|window| window == b"?>")
-            .map(|offset| start + 2 + offset + 2);
+        return ends
+            .processing_instructions
+            .get_or_insert_with(|| DeclarationTerminatorEnds::new(bytes, b"?>", work))
+            .end_after(start + 2);
     }
 
     if !is_generic_declaration_start(bytes, start) {
         return None;
     }
 
-    generic_ends
+    ends.generic
         .get_or_insert_with(|| GenericDeclarationEnds::new(bytes, start))
         .end_at(start)
 }
@@ -867,7 +915,11 @@ enum GenericDeclarationScan {
         /// without borrowing a closing bracket from an enclosing subset.
         independently_balanced: bool,
     },
-    BoundaryFailure,
+    BoundaryFailure {
+        /// The same ordinary-tag boundary also terminates every enclosing
+        /// declaration, regardless of its current subset depth.
+        reusable: bool,
+    },
     EofFailure,
 }
 
@@ -898,7 +950,7 @@ fn generic_declaration_scan(
                 // A new top-level tag cannot belong to an unclosed declaration
                 // literal. Bound recovery here so a later quote and `>` cannot
                 // make the following node look like the declaration's suffix.
-                return GenericDeclarationScan::BoundaryFailure;
+                return GenericDeclarationScan::BoundaryFailure { reusable: false };
             }
             pos += 1;
             continue;
@@ -948,7 +1000,10 @@ fn generic_declaration_scan(
                     GenericDeclarationScan::EofFailure => {
                         return GenericDeclarationScan::EofFailure;
                     }
-                    GenericDeclarationScan::BoundaryFailure
+                    GenericDeclarationScan::BoundaryFailure { reusable: true } => {
+                        return GenericDeclarationScan::BoundaryFailure { reusable: true };
+                    }
+                    GenericDeclarationScan::BoundaryFailure { reusable: false }
                     | GenericDeclarationScan::Complete {
                         independently_balanced: false,
                         ..
@@ -968,7 +1023,7 @@ fn generic_declaration_scan(
             b'\'' | b'"' => quote = Some(bytes[pos]),
             b'[' => {
                 let Some(next_depth) = bracket_depth.checked_add(1) else {
-                    return GenericDeclarationScan::BoundaryFailure;
+                    return GenericDeclarationScan::BoundaryFailure { reusable: false };
                 };
                 bracket_depth = next_depth;
             }
@@ -978,8 +1033,11 @@ fn generic_declaration_scan(
                 // Internal subsets contain nested declarations and processing
                 // instructions. An ordinary tag is instead the recovery
                 // boundary for an incomplete outer declaration.
-                if bracket_depth == 0 || !matches!(bytes.get(pos + 1), Some(b'!' | b'?')) {
-                    return GenericDeclarationScan::BoundaryFailure;
+                if !matches!(bytes.get(pos + 1), Some(b'!' | b'?')) {
+                    return GenericDeclarationScan::BoundaryFailure { reusable: true };
+                }
+                if bracket_depth == 0 {
+                    return GenericDeclarationScan::BoundaryFailure { reusable: false };
                 }
             }
             b'>' if bracket_depth == 0 => {
@@ -1000,7 +1058,7 @@ fn generic_declaration_scan(
 fn generic_declaration_end_uncached(bytes: &[u8], start: usize) -> Option<usize> {
     match generic_declaration_scan(bytes, start, None, &mut DeclarationScanWork::default()) {
         GenericDeclarationScan::Complete { end, .. } => Some(end),
-        GenericDeclarationScan::BoundaryFailure | GenericDeclarationScan::EofFailure => None,
+        GenericDeclarationScan::BoundaryFailure { .. } | GenericDeclarationScan::EofFailure => None,
     }
 }
 
@@ -1969,6 +2027,79 @@ Content
     }
 
     #[test]
+    fn repeated_unterminated_subsets_before_a_tag_have_a_linear_work_bound() {
+        const REPEATS: usize = 4_096;
+        let unit = "<!DOCTYPE [";
+        let body = format!("{}<p>after</p>", unit.repeat(REPEATS));
+        let mut cached = GenericDeclarationEnds::new(body.as_bytes(), 0);
+
+        assert_eq!(cached.entry_count(), REPEATS);
+        for start in (0..unit.len() * REPEATS).step_by(unit.len()) {
+            assert_eq!(cached.end_at(start), None);
+        }
+        assert!(
+            cached.scanned_bytes() <= body.len() * 4,
+            "{} scan visits for {} input bytes",
+            cached.scanned_bytes(),
+            body.len()
+        );
+    }
+
+    #[test]
+    fn repeated_unterminated_pi_and_cdata_have_a_linear_work_bound() {
+        const REPEATS: usize = 4_096;
+
+        for unit in ["<?", "<![CDATA["] {
+            let body = format!("{}<p>after</p>", unit.repeat(REPEATS));
+            let mut declaration_ends = DeclarationEnds::default();
+            let mut work = DeclarationScanWork::default();
+
+            for start in (0..unit.len() * REPEATS).step_by(unit.len()) {
+                assert_eq!(
+                    declaration_end(body.as_bytes(), start, &mut declaration_ends, &mut work),
+                    None,
+                );
+            }
+            assert!(
+                work.scanned_bytes <= body.len() * 3,
+                "{} scan visits for {} input bytes ({unit:?})",
+                work.scanned_bytes,
+                body.len()
+            );
+        }
+    }
+
+    #[test]
+    fn declaration_terminator_cache_matches_sequential_searches() {
+        let body = "<?outer <?inner?> tail <?unterminated <![CDATA[first <![CDATA[second]]> tail <![CDATA[unterminated";
+        let bytes = body.as_bytes();
+        let mut declaration_ends = DeclarationEnds::default();
+        let mut work = DeclarationScanWork::default();
+
+        for start in (0..bytes.len()).filter(|&start| bytes[start..].starts_with(b"<?")) {
+            let expected = bytes[start + 2..]
+                .windows(2)
+                .position(|window| window == b"?>")
+                .map(|offset| start + 2 + offset + 2);
+            assert_eq!(
+                declaration_end(bytes, start, &mut declaration_ends, &mut work),
+                expected,
+            );
+        }
+
+        for start in (0..bytes.len()).filter(|&start| bytes[start..].starts_with(b"<![CDATA[")) {
+            let expected = bytes[start + 9..]
+                .windows(3)
+                .position(|window| window == b"]]>")
+                .map(|offset| start + 9 + offset + 3);
+            assert_eq!(
+                declaration_end(bytes, start, &mut declaration_ends, &mut work),
+                expected,
+            );
+        }
+    }
+
+    #[test]
     fn repeated_unterminated_subsets_keep_public_output_and_strict_parity() {
         let input = "<!DOCTYPE [".repeat(1_024);
         let output = render(&input);
@@ -1980,6 +2111,23 @@ Content
             crate::mdx::segment_strict(&input).unwrap(),
             crate::mdx::segment_spanned(&input)
         );
+    }
+
+    #[test]
+    fn repeated_unterminated_declarations_before_a_tag_keep_public_output_and_strict_parity() {
+        for unit in ["<!DOCTYPE [", "<?", "<![CDATA["] {
+            let input = format!("{}<p>after</p>", unit.repeat(256));
+            let output = render(&input);
+            let component = output.to_component("Page").unwrap();
+
+            assert_eq!(component.matches("&lt;").count(), 256, "{unit:?}");
+            assert!(component.contains("<p>after</p>"), "{unit:?}: {component}");
+            assert_eq!(
+                crate::mdx::segment_strict(&input).unwrap(),
+                crate::mdx::segment_spanned(&input),
+                "{unit:?}",
+            );
+        }
     }
 
     #[test]

--- a/src/mdx/render.rs
+++ b/src/mdx/render.rs
@@ -364,14 +364,8 @@ fn write_component_tag<'a>(
             return;
         }
 
-        if let Some(index) = html_void_element_index(tag.name) {
+        if let Some((index, _)) = html_void_element(tag.name) {
             void_openings[index] = void_openings[index].saturating_sub(1);
-            return;
-        }
-        if let Some(index) = html_void_element_index_ignore_ascii_case(tag.name)
-            && void_openings[index] > 0
-        {
-            void_openings[index] -= 1;
             return;
         }
 
@@ -379,21 +373,9 @@ fn write_component_tag<'a>(
         return;
     }
 
-    if let Some(index) = html_void_element_index(tag.name) {
+    if let Some((index, canonical_name)) = html_void_element(tag.name) {
         void_openings[index] += 1;
-        if tag.is_self_closing {
-            out.push_str(source);
-            return;
-        }
-
-        let before_close = &source[..source.len() - 1];
-        out.push_str(before_close);
-        if before_close.ends_with(char::is_whitespace) {
-            out.push('/');
-        } else {
-            out.push_str(" /");
-        }
-        out.push('>');
+        write_html_void_opening_tag(out, source, tag.name, canonical_name, tag.is_self_closing);
         return;
     }
 
@@ -403,10 +385,44 @@ fn write_component_tag<'a>(
     out.push_str(source);
 }
 
-fn html_void_element_index(name: &str) -> Option<usize> {
+fn write_html_void_opening_tag(
+    out: &mut String,
+    source: &str,
+    original_name: &str,
+    canonical_name: &str,
+    is_self_closing: bool,
+) {
+    debug_assert!(source.starts_with('<'));
+    debug_assert!(source.len() > original_name.len());
+    out.push('<');
+    out.push_str(canonical_name);
+
+    let after_name = &source[original_name.len() + 1..];
+    if is_self_closing {
+        out.push_str(after_name);
+        return;
+    }
+
+    let before_close = &after_name[..after_name.len() - 1];
+    out.push_str(before_close);
+    if before_close.ends_with(char::is_whitespace) {
+        out.push('/');
+    } else {
+        out.push_str(" /");
+    }
+    out.push('>');
+}
+
+fn html_void_element(name: &str) -> Option<(usize, &'static str)> {
+    if !uses_html_intrinsic_syntax(name) {
+        return None;
+    }
+
     HTML_VOID_ELEMENTS
         .iter()
-        .position(|element| *element == name)
+        .enumerate()
+        .find(|(_, element)| element.eq_ignore_ascii_case(name))
+        .map(|(index, element)| (index, *element))
 }
 
 fn html_void_element_index_ignore_ascii_case(name: &str) -> Option<usize> {
@@ -416,13 +432,7 @@ fn html_void_element_index_ignore_ascii_case(name: &str) -> Option<usize> {
 }
 
 fn html_text_element(name: &str) -> Option<(HtmlTextKind, &'static str)> {
-    // Lowercase-leading and all-uppercase names use HTML intrinsic semantics in
-    // JSX. Preserve PascalCase/mixed-leading-uppercase names as MDX components.
-    let html_syntax = name.as_bytes().first().is_some_and(u8::is_ascii_lowercase)
-        || name
-            .bytes()
-            .all(|byte| !byte.is_ascii_alphabetic() || byte.is_ascii_uppercase());
-    if !html_syntax {
+    if !uses_html_intrinsic_syntax(name) {
         return None;
     }
 
@@ -442,6 +452,16 @@ fn html_text_element(name: &str) -> Option<(HtmlTextKind, &'static str)> {
     }
 
     None
+}
+
+fn uses_html_intrinsic_syntax(name: &str) -> bool {
+    // Lowercase-leading and all-uppercase HTML names are emitted as JSX
+    // intrinsics. Preserve PascalCase/mixed-leading-uppercase names as MDX
+    // components.
+    name.as_bytes().first().is_some_and(u8::is_ascii_lowercase)
+        || name
+            .bytes()
+            .all(|byte| !byte.is_ascii_alphabetic() || byte.is_ascii_uppercase())
 }
 
 fn indent_component_line(out: &mut String, at_line_start: bool, pre_depth: u32) {
@@ -968,6 +988,99 @@ Content
             "{component}"
         );
         assert!(component.contains("line<br />\n"), "{component}");
+    }
+
+    #[test]
+    fn to_component_canonicalizes_all_uppercase_html_void_elements() {
+        let body = "<AREA data-kind=\"upper\"></area><BASE ></BASE><BR></br><COL span={2}></COL><EMBED type=\"example/test\"></EMBED><HR></hr><IMG src=\"image.png\"></img><INPUT disabled></INPUT><LINK rel=\"help\"></LINK><META name=\"kind\"></META><PARAM name=\"example\"></PARAM><SOURCE src=\"media.mp4\"></SOURCE><TRACK kind=\"captions\"></TRACK><WBR/></wbr>";
+        let out = MdxOutput {
+            body: body.to_owned(),
+            esm: vec![],
+            front_matter: None,
+        };
+        let component = out.to_component("Page").unwrap();
+
+        assert_eq!(out.body, body);
+        for expected in [
+            "<area data-kind=\"upper\" />",
+            "<base />",
+            "<br />",
+            "<col span={2} />",
+            "<embed type=\"example/test\" />",
+            "<hr />",
+            "<img src=\"image.png\" />",
+            "<input disabled />",
+            "<link rel=\"help\" />",
+            "<meta name=\"kind\" />",
+            "<param name=\"example\" />",
+            "<source src=\"media.mp4\" />",
+            "<track kind=\"captions\" />",
+            "<wbr/>",
+        ] {
+            assert!(
+                component.contains(expected),
+                "missing {expected:?}: {component}"
+            );
+        }
+        for omitted in HTML_VOID_ELEMENTS.map(str::to_ascii_uppercase) {
+            assert!(
+                !component.contains(&format!("<{omitted}")),
+                "retained uppercase opener {omitted:?}: {component}"
+            );
+            assert!(
+                !component.contains(&format!("</{omitted}")),
+                "retained void closer {omitted:?}: {component}"
+            );
+        }
+    }
+
+    #[test]
+    fn to_component_distinguishes_html_void_names_from_pascal_case_components() {
+        let body = "<bR data-kind=\"mixed\"></BR><iMg src=\"mixed.png\"></IMG><Br data-kind=\"component\"></Br><Img src=\"component.png\"></Img><BRAVO></BRAVO><BR-X></BR-X><custom-img></custom-img>";
+        let out = MdxOutput {
+            body: body.to_owned(),
+            esm: vec![],
+            front_matter: None,
+        };
+        let component = out.to_component("Page").unwrap();
+
+        assert!(
+            component.contains("<br data-kind=\"mixed\" />"),
+            "{component}"
+        );
+        assert!(
+            component.contains("<img src=\"mixed.png\" />"),
+            "{component}"
+        );
+        assert!(
+            component.contains("<Br data-kind=\"component\"></Br>"),
+            "{component}"
+        );
+        assert!(
+            component.contains("<Img src=\"component.png\"></Img>"),
+            "{component}"
+        );
+        assert!(component.contains("<BRAVO></BRAVO>"), "{component}");
+        assert!(component.contains("<BR-X></BR-X>"), "{component}");
+        assert!(
+            component.contains("<custom-img></custom-img>"),
+            "{component}"
+        );
+    }
+
+    #[test]
+    fn to_component_canonicalizes_uppercase_void_tags_from_rendered_markdown() {
+        let out = render("a<BR>b\n\n<IMG src=\"image.png\">\n\nAfter.");
+        assert!(out.body.contains("<p>a<BR>b</p>"), "{}", out.body);
+        assert!(out.body.contains("<IMG src=\"image.png\">"), "{}", out.body);
+
+        let component = out.to_component("Page").unwrap();
+        assert!(component.contains("<p>a<br />b</p>"), "{component}");
+        assert!(
+            component.contains("<img src=\"image.png\" />"),
+            "{component}"
+        );
+        assert!(component.contains("<p>After.</p>"), "{component}");
     }
 
     #[test]

--- a/src/mdx/render.rs
+++ b/src/mdx/render.rs
@@ -239,28 +239,47 @@ fn write_component_body(out: &mut String, body: &str) {
         }
 
         if bytes[pos] == b'<' && matches!(bytes.get(pos + 1), Some(b'!' | b'?')) {
-            pos = declaration_end(bytes, pos).unwrap_or(bytes.len());
+            if let Some(end) = declaration_end(bytes, pos) {
+                pos = end;
+                continue;
+            }
+
+            // An incomplete or declaration-like near-match is not an HTML node.
+            // Escape only its opening delimiter so later real JSX/HTML nodes are
+            // still processed instead of truncating the rest of the component.
+            indent_component_line(out, at_line_start, pre_depth);
+            out.push_str("&lt;");
+            at_line_start = false;
+            pos += 1;
             continue;
         }
 
         if bytes[pos] == b'<'
             && let Some(tag) = parse_jsx_tag(&bytes[pos..])
         {
-            indent_component_line(out, at_line_start, pre_depth);
-            write_component_tag(
-                out,
-                &body[pos..pos + tag.end_offset],
-                &tag,
-                &mut void_openings,
-                &mut void_named_component_openings,
-            );
-            at_line_start = false;
-
-            let text_kind = if !tag.is_closing && !tag.is_self_closing {
-                html_text_kind(tag.name)
+            let text_element = if !tag.is_closing && !tag.is_self_closing {
+                html_text_element(tag.name)
             } else {
                 None
             };
+            indent_component_line(out, at_line_start, pre_depth);
+            if let Some((_, canonical_name)) = text_element {
+                write_html_text_opening_tag(
+                    out,
+                    &body[pos..pos + tag.end_offset],
+                    tag.name,
+                    canonical_name,
+                );
+            } else {
+                write_component_tag(
+                    out,
+                    &body[pos..pos + tag.end_offset],
+                    &tag,
+                    &mut void_openings,
+                    &mut void_named_component_openings,
+                );
+            }
+            at_line_start = false;
 
             if tag.name == "pre" && !tag.is_self_closing {
                 if tag.is_closing {
@@ -271,14 +290,14 @@ fn write_component_body(out: &mut String, body: &str) {
             }
 
             pos += tag.end_offset;
-            if let Some(text_kind) = text_kind {
+            if let Some((text_kind, canonical_name)) = text_element {
                 if let Some((text_end, tag_end)) = raw_text_end(bytes, pos, tag.name) {
                     write_jsx_string_child(
                         out,
                         &body[pos..text_end],
                         matches!(text_kind, HtmlTextKind::Rcdata),
                     );
-                    write_html_text_closing_tag(out, &body[text_end..tag_end], tag.name);
+                    write_html_text_closing_tag(out, &body[text_end..tag_end], canonical_name);
                     pos = tag_end;
                 } else {
                     write_jsx_string_child(
@@ -396,12 +415,33 @@ fn html_void_element_index_ignore_ascii_case(name: &str) -> Option<usize> {
         .position(|element| element.eq_ignore_ascii_case(name))
 }
 
-fn html_text_kind(name: &str) -> Option<HtmlTextKind> {
-    match name {
-        "script" | "style" | "xmp" | "iframe" | "noembed" | "noframes" => Some(HtmlTextKind::Raw),
-        "textarea" | "title" => Some(HtmlTextKind::Rcdata),
-        _ => None,
+fn html_text_element(name: &str) -> Option<(HtmlTextKind, &'static str)> {
+    // Lowercase-leading and all-uppercase names use HTML intrinsic semantics in
+    // JSX. Preserve PascalCase/mixed-leading-uppercase names as MDX components.
+    let html_syntax = name.as_bytes().first().is_some_and(u8::is_ascii_lowercase)
+        || name
+            .bytes()
+            .all(|byte| !byte.is_ascii_alphabetic() || byte.is_ascii_uppercase());
+    if !html_syntax {
+        return None;
     }
+
+    for (canonical, kind) in [
+        ("script", HtmlTextKind::Raw),
+        ("style", HtmlTextKind::Raw),
+        ("xmp", HtmlTextKind::Raw),
+        ("iframe", HtmlTextKind::Raw),
+        ("noembed", HtmlTextKind::Raw),
+        ("noframes", HtmlTextKind::Raw),
+        ("textarea", HtmlTextKind::Rcdata),
+        ("title", HtmlTextKind::Rcdata),
+    ] {
+        if name.eq_ignore_ascii_case(canonical) {
+            return Some((kind, canonical));
+        }
+    }
+
+    None
 }
 
 fn indent_component_line(out: &mut String, at_line_start: bool, pre_depth: u32) {
@@ -451,6 +491,19 @@ fn write_html_text_closing_tag(out: &mut String, source: &str, opening_name: &st
     out.push_str(&source[opening_name.len() + 2..]);
 }
 
+fn write_html_text_opening_tag(
+    out: &mut String,
+    source: &str,
+    original_name: &str,
+    canonical_name: &str,
+) {
+    debug_assert!(source.starts_with('<'));
+    debug_assert!(source.len() > original_name.len());
+    out.push('<');
+    out.push_str(canonical_name);
+    out.push_str(&source[original_name.len() + 1..]);
+}
+
 fn raw_text_end(bytes: &[u8], start: usize, tag_name: &str) -> Option<(usize, usize)> {
     let mut pos = start;
 
@@ -492,20 +545,24 @@ fn declaration_end(bytes: &[u8], start: usize) -> Option<usize> {
             .map(|offset| start + 9 + offset + 3);
     }
 
-    let mut pos = start + 2;
-    let mut quote = None;
-    while pos < bytes.len() {
-        match (quote, bytes[pos]) {
-            (Some(expected), current) if current == expected => quote = None,
-            (Some(_), _) => {}
-            (None, b'"' | b'\'') => quote = Some(bytes[pos]),
-            (None, b'>') => return Some(pos + 1),
-            (None, _) => {}
-        }
-        pos += 1;
+    if bytes[start..].starts_with(b"<?") {
+        return bytes[start + 2..]
+            .windows(2)
+            .position(|window| window == b"?>")
+            .map(|offset| start + 2 + offset + 2);
     }
 
-    None
+    if bytes
+        .get(start + 2)
+        .is_none_or(|byte| !byte.is_ascii_alphabetic())
+    {
+        return None;
+    }
+
+    bytes[start + 2..]
+        .iter()
+        .position(|byte| *byte == b'>')
+        .map(|offset| start + 2 + offset + 1)
 }
 
 fn standalone_expression_end(bytes: &[u8], start: usize) -> Option<usize> {
@@ -1006,6 +1063,66 @@ Content
     }
 
     #[test]
+    fn to_component_uses_html_declaration_boundaries_without_truncation() {
+        let body = "<!DOCTYPE html data='unterminated><p>after doctype</p><?pi data='unterminated?><p>after pi</p><![CDATA[ignored > text]]><p>after cdata</p>";
+        let out = MdxOutput {
+            body: body.to_owned(),
+            esm: vec![],
+            front_matter: None,
+        };
+        let component = out.to_component("Page").unwrap();
+
+        assert_eq!(out.body, body);
+        assert!(!component.contains("DOCTYPE"), "{component}");
+        assert!(!component.contains("<?pi"), "{component}");
+        assert!(!component.contains("CDATA"), "{component}");
+        for trailing in ["after doctype", "after pi", "after cdata"] {
+            assert!(
+                component.contains(trailing),
+                "missing {trailing:?}: {component}"
+            );
+        }
+
+        let rendered = render(
+            "before <!DOCTYPE html data='unterminated> after declaration\n\n<p>after node</p>",
+        );
+        assert!(
+            rendered.body.contains("after declaration"),
+            "{}",
+            rendered.body
+        );
+        let rendered_component = rendered.to_component("Page").unwrap();
+        assert!(
+            rendered_component.contains("after declaration"),
+            "{rendered_component}"
+        );
+        assert!(
+            rendered_component.contains("<p>after node</p>"),
+            "{rendered_component}"
+        );
+    }
+
+    #[test]
+    fn to_component_bounds_incomplete_declarations_and_near_matches() {
+        for body in [
+            "<![CDATA[unterminated<p>after cdata</p>",
+            "<?unterminated<p>after pi</p>",
+            "<![near-match><p>after bracket near-match</p>",
+            "<!-near-match><p>after punctuation near-match</p>",
+        ] {
+            let out = MdxOutput {
+                body: body.to_owned(),
+                esm: vec![],
+                front_matter: None,
+            };
+            let component = out.to_component("Page").unwrap();
+
+            assert!(component.contains("&lt;"), "{component}");
+            assert!(component.contains("<p>after"), "{component}");
+        }
+    }
+
+    #[test]
     fn to_component_preserves_textarea_and_title_text() {
         let out = MdxOutput {
             body: "<textarea data-kind=\"example\">first\r\n  second {value}&amp;\r\n</textarea>\r\n<title>first\n  second {value}&amp;\n</title>"
@@ -1055,6 +1172,40 @@ Content
     }
 
     #[test]
+    fn to_component_preserves_case_variant_html_text_semantics() {
+        let body = "<TEXTAREA data-kind=\"upper\">first\r\n  second {value}&amp;\r\n</textAREA><p>after textarea</p>\n<textAREA data-kind=\"mixed\">third\n  fourth &amp; {value}\n</TEXTAREA><TITLE>heading\n  continuation &amp; {value}</title><SCRIPT>if (left < right) { run(); }</script><stYLE>.x { color: red }</STYLE>";
+        let out = MdxOutput {
+            body: body.to_owned(),
+            esm: vec![],
+            front_matter: None,
+        };
+        let component = out.to_component("Page").unwrap();
+
+        assert_eq!(out.body, body);
+        assert!(component.contains(
+            "<textarea data-kind=\"upper\">{\"first\\r\\n  second {value}&\\r\\n\"}</textarea><p>after textarea</p>"
+        ), "{component}");
+        assert!(
+            component.contains(
+                "<textarea data-kind=\"mixed\">{\"third\\n  fourth & {value}\\n\"}</textarea>"
+            ),
+            "{component}"
+        );
+        assert!(
+            component.contains("<title>{\"heading\\n  continuation & {value}\"}</title>"),
+            "{component}"
+        );
+        assert!(
+            component.contains("<script>{\"if (left < right) { run(); }\"}</script>"),
+            "{component}"
+        );
+        assert!(
+            component.contains("<style>{\".x { color: red }\"}</style>"),
+            "{component}"
+        );
+    }
+
+    #[test]
     fn to_component_ignores_raw_text_closing_tag_near_matches() {
         let out = MdxOutput {
             body: "<textarea>before</TEXTAREAX>middle</textarea extra>still</TeXtArEa><p>after</p>\n<script>before</SCRIPTS>middle</ScRiPt><p>after script</p>"
@@ -1078,7 +1229,9 @@ Content
 
     #[test]
     fn to_component_does_not_treat_component_names_as_html_text_elements() {
-        let out = render("<Pre>\n\n{value}\n\n</Pre>\n\n<Style>\n\n{text}\n\n</Style>\n");
+        let out = render(
+            "<Pre>\n\n{value}\n\n</Pre>\n\n<Style>\n\n{text}\n\n</Style>\n\n<Textarea>\n\n{value}\n\n</Textarea>\n\n<Title>\n\n{text}\n\n</Title>\n",
+        );
         let component = out.to_component("Page").unwrap();
 
         assert!(
@@ -1087,6 +1240,14 @@ Content
         );
         assert!(
             component.contains("      <Style>\n      {text}\n      </Style>"),
+            "{component}"
+        );
+        assert!(
+            component.contains("      <Textarea>\n      {value}\n      </Textarea>"),
+            "{component}"
+        );
+        assert!(
+            component.contains("      <Title>\n      {text}\n      </Title>"),
             "{component}"
         );
     }

--- a/src/mdx/render.rs
+++ b/src/mdx/render.rs
@@ -578,9 +578,59 @@ fn declaration_end(bytes: &[u8], start: usize) -> Option<usize> {
         return None;
     }
 
-    let tail = &bytes[start + 2..];
-    let boundary = tail.iter().position(|byte| matches!(byte, b'<' | b'>'))?;
-    (tail[boundary] == b'>').then_some(start + 2 + boundary + 1)
+    generic_declaration_end(bytes, start)
+}
+
+fn generic_declaration_end(bytes: &[u8], start: usize) -> Option<usize> {
+    let mut pos = start + 2;
+    let mut bracket_depth = 0_u32;
+    let mut quote = None;
+
+    while pos < bytes.len() {
+        if let Some(delimiter) = quote {
+            if bytes[pos] == delimiter {
+                quote = None;
+            } else if bytes[pos] == b'<' && bracket_depth == 0 {
+                // A new top-level tag cannot belong to an unclosed declaration
+                // literal. Bound recovery here so a later quote and `>` cannot
+                // make the following node look like the declaration's suffix.
+                return None;
+            }
+            pos += 1;
+            continue;
+        }
+
+        if bracket_depth > 0 && bytes[pos..].starts_with(b"<!--") {
+            pos = comment_end(bytes, pos)?;
+            continue;
+        }
+        if bracket_depth > 0 && bytes[pos..].starts_with(b"<?") {
+            pos = bytes[pos + 2..]
+                .windows(2)
+                .position(|window| window == b"?>")
+                .map(|offset| pos + 2 + offset + 2)?;
+            continue;
+        }
+
+        match bytes[pos] {
+            b'\'' | b'"' => quote = Some(bytes[pos]),
+            b'[' => bracket_depth = bracket_depth.checked_add(1)?,
+            b']' if bracket_depth > 0 => bracket_depth -= 1,
+            b'<' => {
+                // Internal subsets contain nested declarations and processing
+                // instructions. An ordinary tag is instead the recovery
+                // boundary for an incomplete outer declaration.
+                if bracket_depth == 0 || !matches!(bytes.get(pos + 1), Some(b'!' | b'?')) {
+                    return None;
+                }
+            }
+            b'>' if bracket_depth == 0 => return Some(pos + 1),
+            _ => {}
+        }
+        pos += 1;
+    }
+
+    None
 }
 
 fn standalone_expression_end(bytes: &[u8], start: usize) -> Option<usize> {
@@ -1231,7 +1281,7 @@ Content
         let component = out.to_component("Page").unwrap();
 
         assert_eq!(out.body, body);
-        assert!(!component.contains("DOCTYPE"), "{component}");
+        assert!(component.contains("&lt;!DOCTYPE"), "{component}");
         assert!(!component.contains("<?pi"), "{component}");
         assert!(!component.contains("CDATA"), "{component}");
         for trailing in ["after doctype", "after pi", "after cdata"] {
@@ -1306,6 +1356,68 @@ Content
             "<p>after cdata</p>",
         ] {
             assert!(component.contains(paragraph), "{component}");
+        }
+    }
+
+    #[test]
+    fn to_component_omits_complete_doctype_internal_subsets() {
+        for line_break in ["\n", "\r\n"] {
+            let body = format!(
+                "<!DOCTYPE html [{line_break}<!ENTITY example \"value>still\">{line_break}<!ENTITY markup '<p data-kind=\"literal\">text</p>'>{line_break}<!-- subset ] > comment -->{line_break}<?subset ] > data?>{line_break}]>{line_break}<p>after subset</p>{line_break}<!DOCTYPE root [<![INCLUDE[<!ENTITY nested \"[value]>\">]]>]><p>after nested subset</p>{line_break}<!DOCTYPE html SYSTEM \"value>still\"><p>after system literal</p>"
+            );
+            let out = MdxOutput {
+                body: body.clone(),
+                esm: vec![],
+                front_matter: None,
+            };
+            let component = out.to_component("Page").unwrap();
+
+            assert_eq!(out.body, body);
+            for omitted in [
+                "DOCTYPE",
+                "ENTITY",
+                "data-kind=\"literal\"",
+                "subset ] > comment",
+                "subset ] > data",
+                "INCLUDE",
+                "value>still",
+            ] {
+                assert!(!component.contains(omitted), "{component}");
+            }
+            for paragraph in [
+                "<p>after subset</p>",
+                "<p>after nested subset</p>",
+                "<p>after system literal</p>",
+            ] {
+                assert!(component.contains(paragraph), "{component}");
+            }
+        }
+    }
+
+    #[test]
+    fn to_component_bounds_incomplete_doctype_internal_subsets() {
+        for body in [
+            "<!DOCTYPE html [<!ENTITY example \"value\">\n<p>after missing subset close</p>",
+            "<!DOCTYPE html [<!ENTITY example \"unterminated\n<p>after unterminated entity</p>",
+            "<!DOCTYPE html SYSTEM \"unterminated\n<p data-kind='next'>after system literal</p>",
+            "<!DOCTYPE html [\r\n<section>after CRLF subset</section>",
+        ] {
+            let out = MdxOutput {
+                body: body.to_owned(),
+                esm: vec![],
+                front_matter: None,
+            };
+            let component = out.to_component("Page").unwrap();
+
+            assert!(component.contains("&lt;!DOCTYPE"), "{component}");
+            assert!(
+                component.contains("after ") || component.contains("after CRLF"),
+                "{component}"
+            );
+            assert!(
+                component.contains("<p") || component.contains("<section>"),
+                "{component}"
+            );
         }
     }
 

--- a/src/mdx/render.rs
+++ b/src/mdx/render.rs
@@ -2,7 +2,13 @@ use std::fmt::Write;
 
 use crate::{Options, RenderPolicy};
 
-use super::Segment;
+use super::{
+    Segment,
+    expr::find_expression_end,
+    jsx_tag::{TagInfo, parse_jsx_tag},
+};
+
+const COMPONENT_BODY_INDENT: &str = "      ";
 
 /// Error returned when a component name cannot be used as a JavaScript binding.
 ///
@@ -153,6 +159,11 @@ impl MdxOutput<'_> {
     ///   );
     /// }
     /// ```
+    ///
+    /// Literal braces in rendered Markdown are emitted as HTML character
+    /// references so they cannot be interpreted as JSX expressions. MDX flow
+    /// expressions remain executable, HTML comments are omitted, and whitespace
+    /// inside `<pre>` elements is preserved.
     pub fn to_component(&self, name: &str) -> Result<String, ComponentNameError> {
         validate_component_name(name)?;
         let mut out = String::with_capacity(self.body.len() + self.esm.len() * 40 + 80);
@@ -170,20 +181,239 @@ impl MdxOutput<'_> {
 
         let body = self.body.trim();
         if !body.is_empty() {
-            for line in body.lines() {
-                if line.is_empty() {
-                    out.push('\n');
-                } else {
-                    out.push_str("      ");
-                    out.push_str(line);
-                    out.push('\n');
-                }
-            }
+            write_component_body(&mut out, body);
+            out.push('\n');
         }
 
         out.push_str("    </>\n  );\n}\n");
         Ok(out)
     }
+}
+
+/// Write an HTML/MDX body as JSX without changing its rendered text semantics.
+///
+/// This deliberately operates on tokens instead of applying global replacements:
+/// tags and MDX flow expressions must remain executable, while braces in HTML text
+/// nodes are literal characters. The emitter also tracks `<pre>` ownership so its
+/// presentation indentation never becomes part of preformatted content.
+fn write_component_body(out: &mut String, body: &str) {
+    let bytes = body.as_bytes();
+    let mut pos = 0;
+    let mut at_line_start = true;
+    let mut pre_depth = 0_u32;
+
+    while pos < bytes.len() {
+        if pre_depth > 0 && bytes[pos] != b'<' {
+            let end = bytes[pos..]
+                .iter()
+                .position(|byte| *byte == b'<')
+                .map_or(bytes.len(), |offset| pos + offset);
+            write_preformatted_text(out, &body[pos..end]);
+            at_line_start = body[pos..end].ends_with(['\n', '\r']);
+            pos = end;
+            continue;
+        }
+
+        if let Some(line_break_len) = line_break_len(bytes, pos) {
+            out.push_str(&body[pos..pos + line_break_len]);
+            pos += line_break_len;
+            at_line_start = true;
+            continue;
+        }
+
+        if bytes[pos..].starts_with(b"<!--") {
+            pos = comment_end(bytes, pos).unwrap_or(bytes.len());
+            continue;
+        }
+
+        if bytes[pos] == b'<'
+            && let Some(tag) = parse_jsx_tag(&bytes[pos..])
+        {
+            indent_component_line(out, at_line_start, pre_depth);
+            write_component_tag(out, &body[pos..pos + tag.end_offset], &tag);
+            at_line_start = false;
+
+            let is_raw_text_open = !tag.is_closing
+                && !tag.is_self_closing
+                && (tag.name.eq_ignore_ascii_case("script")
+                    || tag.name.eq_ignore_ascii_case("style"));
+
+            if tag.name.eq_ignore_ascii_case("pre") && !tag.is_self_closing {
+                if tag.is_closing {
+                    pre_depth = pre_depth.saturating_sub(1);
+                } else {
+                    pre_depth = pre_depth.saturating_add(1);
+                }
+            }
+
+            pos += tag.end_offset;
+            if is_raw_text_open {
+                let end = raw_text_end(bytes, pos, tag.name).unwrap_or(bytes.len());
+                write_jsx_string_child(out, &body[pos..end], false);
+                // The raw text's line breaks are escaped inside the string child,
+                // so the generated JSX source is still on the opening tag's line.
+                at_line_start = false;
+                pos = end;
+            }
+            continue;
+        }
+
+        if at_line_start
+            && pre_depth == 0
+            && bytes[pos] == b'{'
+            && let Some(end) = standalone_expression_end(bytes, pos)
+        {
+            indent_component_line(out, true, pre_depth);
+            out.push_str(&body[pos..end]);
+            at_line_start = body[pos..end].ends_with(['\n', '\r']);
+            pos = end;
+            continue;
+        }
+
+        indent_component_line(out, at_line_start, pre_depth);
+        at_line_start = false;
+
+        match bytes[pos] {
+            b'{' => {
+                out.push_str("&#123;");
+                pos += 1;
+            }
+            b'}' => {
+                out.push_str("&#125;");
+                pos += 1;
+            }
+            _ => {
+                let ch = body[pos..]
+                    .chars()
+                    .next()
+                    .expect("position is inside the body");
+                out.push(ch);
+                pos += ch.len_utf8();
+            }
+        }
+    }
+}
+
+fn write_component_tag(out: &mut String, source: &str, tag: &TagInfo<'_>) {
+    if !tag.is_closing && !tag.is_self_closing && is_html_void_element(tag.name) {
+        let before_close = &source[..source.len() - 1];
+        out.push_str(before_close);
+        if before_close.ends_with(char::is_whitespace) {
+            out.push('/');
+        } else {
+            out.push_str(" /");
+        }
+        out.push('>');
+    } else {
+        out.push_str(source);
+    }
+}
+
+fn is_html_void_element(name: &str) -> bool {
+    matches!(
+        name,
+        "area"
+            | "base"
+            | "br"
+            | "col"
+            | "embed"
+            | "hr"
+            | "img"
+            | "input"
+            | "link"
+            | "meta"
+            | "param"
+            | "source"
+            | "track"
+            | "wbr"
+    )
+}
+
+fn indent_component_line(out: &mut String, at_line_start: bool, pre_depth: u32) {
+    if at_line_start && pre_depth == 0 {
+        out.push_str(COMPONENT_BODY_INDENT);
+    }
+}
+
+fn write_preformatted_text(out: &mut String, text: &str) {
+    write_jsx_string_child(out, text, true);
+}
+
+fn write_jsx_string_child(out: &mut String, text: &str, decode_entities: bool) {
+    let decoded = if decode_entities {
+        crate::render::decode_entities_commonmark(text)
+    } else {
+        std::borrow::Cow::Borrowed(text)
+    };
+    out.push_str("{\"");
+
+    for ch in decoded.chars() {
+        match ch {
+            '\\' => out.push_str("\\\\"),
+            '"' => out.push_str("\\\""),
+            '\n' => out.push_str("\\n"),
+            '\r' => out.push_str("\\r"),
+            '\t' => out.push_str("\\t"),
+            '\u{0008}' => out.push_str("\\b"),
+            '\u{000c}' => out.push_str("\\f"),
+            '\u{2028}' => out.push_str("\\u2028"),
+            '\u{2029}' => out.push_str("\\u2029"),
+            ch if ch.is_control() => {
+                let _ = write!(out, "\\u{:04x}", ch as u32);
+            }
+            _ => out.push(ch),
+        }
+    }
+
+    out.push_str("\"}");
+}
+
+fn raw_text_end(bytes: &[u8], start: usize, tag_name: &str) -> Option<usize> {
+    let mut pos = start;
+
+    while let Some(offset) = bytes[pos..].iter().position(|byte| *byte == b'<') {
+        pos += offset;
+        if let Some(tag) = parse_jsx_tag(&bytes[pos..])
+            && tag.is_closing
+            && tag.name.eq_ignore_ascii_case(tag_name)
+        {
+            return Some(pos);
+        }
+        pos += 1;
+    }
+
+    None
+}
+
+fn line_break_len(bytes: &[u8], pos: usize) -> Option<usize> {
+    match bytes[pos] {
+        b'\n' => Some(1),
+        b'\r' if bytes.get(pos + 1) == Some(&b'\n') => Some(2),
+        b'\r' => Some(1),
+        _ => None,
+    }
+}
+
+fn comment_end(bytes: &[u8], start: usize) -> Option<usize> {
+    bytes[start + 4..]
+        .windows(3)
+        .position(|window| window == b"-->")
+        .map(|offset| start + 4 + offset + 3)
+}
+
+fn standalone_expression_end(bytes: &[u8], start: usize) -> Option<usize> {
+    let relative_end = find_expression_end(&bytes[start..])?;
+    let end = start + relative_end;
+    let mut pos = end;
+
+    while pos < bytes.len() && bytes[pos] != b'\n' && bytes[pos] != b'\r' {
+        if !bytes[pos].is_ascii_whitespace() {
+            return None;
+        }
+        pos += 1;
+    }
+
+    Some(end)
 }
 
 /// Render MDX to HTML body with default options.
@@ -454,6 +684,126 @@ Content
 
         assert!(comp.contains("import A from 'a'"));
         assert!(comp.contains("<>\n    </>"));
+    }
+
+    #[test]
+    fn to_component_escapes_markdown_braces_but_preserves_mdx_expressions() {
+        let out = render(
+            "Use {braces}, `code {braces}`, and `{'{'}literal}`.\n\n{value ?? { nested: true }}\n",
+        );
+        let component = out.to_component("Page").unwrap();
+
+        assert!(component.contains(
+            "<p>Use &#123;braces&#125;, <code>code &#123;braces&#125;</code>, and <code>&#123;'&#123;'&#125;literal&#125;</code>.</p>"
+        ));
+        assert!(component.contains("      {value ?? { nested: true }}\n"));
+    }
+
+    #[test]
+    fn to_component_escapes_fenced_code_braces() {
+        let out = render("```rust\nfn main() { println!(\"hi\"); }\n```\n");
+        let component = out.to_component("Page").unwrap();
+
+        assert!(component.contains("{\"fn main() { println!(\\\"hi\\\"); }\\n\"}"));
+        assert!(!component.contains("fn main() { println!(\"hi\"); }"));
+    }
+
+    #[test]
+    fn to_component_drops_html_comments() {
+        let out = render("Before.\n\n<!-- comment with */ and {brace} -->\n\nAfter.\n");
+        assert!(out.body.contains("<!-- comment with */ and {brace} -->"));
+
+        let component = out.to_component("Page").unwrap();
+
+        assert!(!component.contains("<!--"));
+        assert!(!component.contains("comment with"));
+        assert!(component.contains("<p>Before.</p>"));
+        assert!(component.contains("<p>After.</p>"));
+    }
+
+    #[test]
+    fn to_component_preserves_preformatted_whitespace_and_crlf() {
+        let out = MdxOutput {
+            body: "<pre data-kind=\"example\"><code>first\r\n  second {value}\r\n</code></pre>\r\n<p>After</p>"
+                .to_owned(),
+            esm: vec![],
+            front_matter: None,
+        };
+        let component = out.to_component("Page").unwrap();
+
+        assert!(component.contains(
+            "      <pre data-kind=\"example\"><code>{\"first\\r\\n  second {value}\\r\\n\"}</code></pre>\r\n      <p>After</p>"
+        ));
+    }
+
+    #[test]
+    fn to_component_keeps_existing_entities_and_jsx_flow() {
+        let out = render(
+            "<Card value={{ nested: true }}>\n\nLiteral &#123; and {'{'}text}.\n\n</Card>\n",
+        );
+        let component = out.to_component("Page").unwrap();
+
+        assert!(component.contains("      <Card value={{ nested: true }}>"));
+        assert!(component.contains("Literal &#123; and &#123;'&#123;'&#125;text&#125;."));
+        assert!(component.contains("      </Card>"));
+    }
+
+    #[test]
+    fn to_component_keeps_escaped_comments_visible() {
+        let options = Options {
+            allow_html: false,
+            ..Options::default()
+        };
+        let out = render_with_options("<!-- visible -->\n", &options);
+        let component = out.to_component("Page").unwrap();
+
+        assert!(component.contains("&lt;!-- visible --&gt;"));
+    }
+
+    #[test]
+    fn to_component_preserves_entities_in_preformatted_text() {
+        let out = MdxOutput {
+            body: "<pre><code>&lt;&amp;&quot;&#123;&#125;&ngE;&#0;\n</code></pre>".to_owned(),
+            esm: vec![],
+            front_matter: None,
+        };
+        let component = out.to_component("Page").unwrap();
+
+        assert!(component.contains("<pre><code>{\"<&\\\"{}≧̸�\\n\"}</code></pre>"));
+    }
+
+    #[test]
+    fn to_component_preserves_raw_script_and_style_text() {
+        let out = MdxOutput {
+            body: "<script>const value = { text: \"<!-- &amp;\" };\n</script>\n<style>.x { color: red } /* <!-- */</style>"
+                .to_owned(),
+            esm: vec![],
+            front_matter: None,
+        };
+        let component = out.to_component("Page").unwrap();
+
+        assert!(
+            component
+                .contains("<script>{\"const value = { text: \\\"<!-- &amp;\\\" };\\n\"}</script>"),
+            "{component}"
+        );
+        assert!(
+            component.contains("<style>{\".x { color: red } /* <!-- */\"}</style>"),
+            "{component}"
+        );
+    }
+
+    #[test]
+    fn to_component_self_closes_html_void_elements() {
+        let out = render("Before.\n\n---\n\n![alt](image.png)\n\nline  \nbreak\n");
+        let component = out.to_component("Page").unwrap();
+
+        assert!(component.contains("<hr />"), "{component}");
+        assert!(
+            component.contains("<img src=\"image.png\" alt=\"alt\" />"),
+            "{component}"
+        );
+        assert!(component.contains("line<br />\n"), "{component}");
     }
 
     #[test]

--- a/src/mdx/render.rs
+++ b/src/mdx/render.rs
@@ -211,8 +211,7 @@ fn write_component_body(out: &mut String, body: &str) {
     let mut pos = 0;
     let mut at_line_start = true;
     let mut pre_depth = 0_u32;
-    let mut void_openings = [0_usize; HTML_VOID_ELEMENTS.len()];
-    let mut void_named_component_openings = Vec::new();
+    let mut void_component_openings = Vec::new();
 
     while pos < bytes.len() {
         if pre_depth > 0 && bytes[pos] != b'<' {
@@ -275,8 +274,7 @@ fn write_component_body(out: &mut String, body: &str) {
                     out,
                     &body[pos..pos + tag.end_offset],
                     &tag,
-                    &mut void_openings,
-                    &mut void_named_component_openings,
+                    &mut void_component_openings,
                 );
             }
             at_line_start = false;
@@ -297,7 +295,7 @@ fn write_component_body(out: &mut String, body: &str) {
                         &body[pos..text_end],
                         matches!(text_kind, HtmlTextKind::Rcdata),
                     );
-                    write_html_text_closing_tag(out, &body[text_end..tag_end], canonical_name);
+                    write_closing_tag(out, &body[text_end..tag_end], canonical_name);
                     pos = tag_end;
                 } else {
                     write_jsx_string_child(
@@ -354,33 +352,34 @@ fn write_component_tag<'a>(
     out: &mut String,
     source: &str,
     tag: &TagInfo<'a>,
-    void_openings: &mut [usize; HTML_VOID_ELEMENTS.len()],
-    void_named_component_openings: &mut Vec<&'a str>,
+    void_component_openings: &mut Vec<(usize, &'a str)>,
 ) {
     if tag.is_closing {
-        if void_named_component_openings.last() == Some(&tag.name) {
-            void_named_component_openings.pop();
-            out.push_str(source);
+        if let Some(index) = html_void_element_index_ignore_ascii_case(tag.name) {
+            if void_component_openings
+                .last()
+                .is_some_and(|(opening_index, _)| *opening_index == index)
+            {
+                let (_, opening_name) = void_component_openings
+                    .pop()
+                    .expect("last component opening was just checked");
+                write_closing_tag(out, source, opening_name);
+            }
             return;
         }
-
-        if let Some((index, _)) = html_void_element(tag.name) {
-            void_openings[index] = void_openings[index].saturating_sub(1);
-            return;
-        }
-
         out.push_str(source);
         return;
     }
 
-    if let Some((index, canonical_name)) = html_void_element(tag.name) {
-        void_openings[index] += 1;
+    if let Some((_, canonical_name)) = html_void_element(tag.name) {
         write_html_void_opening_tag(out, source, tag.name, canonical_name, tag.is_self_closing);
         return;
     }
 
-    if !tag.is_self_closing && html_void_element_index_ignore_ascii_case(tag.name).is_some() {
-        void_named_component_openings.push(tag.name);
+    if !tag.is_self_closing
+        && let Some(index) = html_void_element_index_ignore_ascii_case(tag.name)
+    {
+        void_component_openings.push((index, tag.name));
     }
     out.push_str(source);
 }
@@ -503,7 +502,7 @@ fn write_jsx_string_child(out: &mut String, text: &str, decode_entities: bool) {
     out.push_str("\"}");
 }
 
-fn write_html_text_closing_tag(out: &mut String, source: &str, opening_name: &str) {
+fn write_closing_tag(out: &mut String, source: &str, opening_name: &str) {
     debug_assert!(source.starts_with("</"));
     debug_assert!(source.len() >= opening_name.len() + 2);
     out.push_str("</");
@@ -579,10 +578,9 @@ fn declaration_end(bytes: &[u8], start: usize) -> Option<usize> {
         return None;
     }
 
-    bytes[start + 2..]
-        .iter()
-        .position(|byte| *byte == b'>')
-        .map(|offset| start + 2 + offset + 1)
+    let tail = &bytes[start + 2..];
+    let boundary = tail.iter().position(|byte| matches!(byte, b'<' | b'>'))?;
+    (tail[boundary] == b'>').then_some(start + 2 + boundary + 1)
 }
 
 fn standalone_expression_end(bytes: &[u8], start: usize) -> Option<usize> {
@@ -1035,6 +1033,53 @@ Content
     }
 
     #[test]
+    fn to_component_pairs_void_named_components_across_closing_case() {
+        let mut body = String::new();
+        for name in HTML_VOID_ELEMENTS {
+            let pascal = format!("{}{}", name[..1].to_ascii_uppercase(), &name[1..]);
+            let upper = name.to_ascii_uppercase();
+            let _ = write!(
+                body,
+                "<{pascal} data-kind=\"component\" ></{upper}   ><{upper} data-kind=\"intrinsic\"></{pascal}>"
+            );
+        }
+        let out = MdxOutput {
+            body: body.clone(),
+            esm: vec![],
+            front_matter: None,
+        };
+        let component = out.to_component("Page").unwrap();
+
+        assert_eq!(out.body, body);
+        for name in HTML_VOID_ELEMENTS {
+            let pascal = format!("{}{}", name[..1].to_ascii_uppercase(), &name[1..]);
+            assert!(
+                component.contains(&format!(
+                    "<{pascal} data-kind=\"component\" ></{pascal}   >"
+                )),
+                "component pair for {name:?} was not retained: {component}"
+            );
+            assert!(
+                component.contains(&format!("<{name} data-kind=\"intrinsic\" />")),
+                "intrinsic pair for {name:?} was not normalized: {component}"
+            );
+        }
+    }
+
+    #[test]
+    fn to_component_leaves_void_near_matches_and_custom_elements_unchanged() {
+        let body = "<Brave data-kind=\"component\"></Brave><BR-X></BR-X><br-x></br-x><brr></BRR><ImgExtra></ImgExtra>";
+        let out = MdxOutput {
+            body: body.to_owned(),
+            esm: vec![],
+            front_matter: None,
+        };
+        let component = out.to_component("Page").unwrap();
+
+        assert!(component.contains(body), "{component}");
+    }
+
+    #[test]
     fn to_component_distinguishes_html_void_names_from_pascal_case_components() {
         let body = "<bR data-kind=\"mixed\"></BR><iMg src=\"mixed.png\"></IMG><Br data-kind=\"component\"></Br><Img src=\"component.png\"></Img><BRAVO></BRAVO><BR-X></BR-X><custom-img></custom-img>";
         let out = MdxOutput {
@@ -1213,6 +1258,55 @@ Content
             rendered_component.contains("<p>after node</p>"),
             "{rendered_component}"
         );
+    }
+
+    #[test]
+    fn to_component_does_not_extend_incomplete_declarations_into_following_tags() {
+        for line_break in ["\n", "\r\n"] {
+            let body = format!(
+                "<!DOCTYPE html{line_break}<p>after doctype</p>{line_break}<?pi incomplete{line_break}<p>after pi</p>{line_break}<![CDATA[incomplete{line_break}<p>after cdata</p>"
+            );
+            let out = MdxOutput {
+                body: body.clone(),
+                esm: vec![],
+                front_matter: None,
+            };
+            let component = out.to_component("Page").unwrap();
+
+            assert_eq!(out.body, body);
+            for declaration in ["&lt;!DOCTYPE html", "&lt;?pi incomplete", "&lt;![CDATA["] {
+                assert!(component.contains(declaration), "{component}");
+            }
+            for paragraph in [
+                "<p>after doctype</p>",
+                "<p>after pi</p>",
+                "<p>after cdata</p>",
+            ] {
+                assert!(component.contains(paragraph), "{component}");
+            }
+        }
+    }
+
+    #[test]
+    fn to_component_omits_closed_multiline_declarations_at_their_own_boundary() {
+        let body = "<!DOCTYPE\nhtml>\n<p>after doctype</p>\n<?pi\nvalue?>\n<p>after pi</p>\n<![CDATA[ignored\n<p>inside cdata</p>]]>\n<p>after cdata</p>";
+        let out = MdxOutput {
+            body: body.to_owned(),
+            esm: vec![],
+            front_matter: None,
+        };
+        let component = out.to_component("Page").unwrap();
+
+        for omitted in ["DOCTYPE", "<?pi", "inside cdata", "CDATA"] {
+            assert!(!component.contains(omitted), "{component}");
+        }
+        for paragraph in [
+            "<p>after doctype</p>",
+            "<p>after pi</p>",
+            "<p>after cdata</p>",
+        ] {
+            assert!(component.contains(paragraph), "{component}");
+        }
     }
 
     #[test]

--- a/src/mdx/render.rs
+++ b/src/mdx/render.rs
@@ -329,7 +329,7 @@ fn write_component_body(out: &mut String, body: &str) {
                         &body[pos..text_end],
                         matches!(text_kind, HtmlTextKind::Rcdata),
                     );
-                    write_closing_tag(out, &body[text_end..tag_end], canonical_name);
+                    write_synthetic_closing_tag(out, canonical_name);
                     pos = tag_end;
                 } else {
                     write_jsx_string_child(
@@ -337,6 +337,7 @@ fn write_component_body(out: &mut String, body: &str) {
                         &body[pos..],
                         matches!(text_kind, HtmlTextKind::Rcdata),
                     );
+                    write_synthetic_closing_tag(out, canonical_name);
                     pos = bytes.len();
                 }
                 // The raw text's line breaks are escaped inside the string child,
@@ -457,6 +458,9 @@ fn write_component_tag<'a>(
                 *count -= 1;
                 return ComponentTagEffect::None;
             }
+            if html_text_element_ignore_ascii_case(tag.name).is_some() {
+                return ComponentTagEffect::None;
+            }
             if HTML_VOID_ELEMENTS.contains(&canonical_name) {
                 return ComponentTagEffect::None;
             }
@@ -555,6 +559,10 @@ fn html_text_element(name: &str) -> Option<(HtmlTextKind, &'static str)> {
         return None;
     }
 
+    html_text_element_ignore_ascii_case(name)
+}
+
+fn html_text_element_ignore_ascii_case(name: &str) -> Option<(HtmlTextKind, &'static str)> {
     for (canonical, kind) in [
         ("script", HtmlTextKind::Raw),
         ("style", HtmlTextKind::Raw),
@@ -656,11 +664,48 @@ fn raw_text_end(bytes: &[u8], start: usize, tag_name: &str) -> Option<(usize, us
 
     while let Some(offset) = bytes[pos..].iter().position(|byte| *byte == b'<') {
         pos += offset;
-        if let Some(tag) = parse_jsx_tag(&bytes[pos..])
-            && tag.is_closing
-            && tag.name.eq_ignore_ascii_case(tag_name)
-        {
-            return Some((pos, pos + tag.end_offset));
+        if let Some(end) = html_text_closing_tag_end(bytes, pos, tag_name) {
+            return Some((pos, end));
+        }
+        pos += 1;
+    }
+
+    None
+}
+
+/// Locate an HTML raw-text/RCDATA end tag, including parse-error forms that
+/// HTML still closes but JSX rejects, such as `</textarea/>` or end-tag attrs.
+fn html_text_closing_tag_end(bytes: &[u8], start: usize, tag_name: &str) -> Option<usize> {
+    let name_start = start.checked_add(2)?;
+    let name_end = name_start.checked_add(tag_name.len())?;
+    if !bytes.get(start..name_start)?.eq(b"</")
+        || !bytes
+            .get(name_start..name_end)?
+            .eq_ignore_ascii_case(tag_name.as_bytes())
+    {
+        return None;
+    }
+
+    match bytes.get(name_end) {
+        Some(b'>') => return Some(name_end + 1),
+        Some(byte) if byte.is_ascii_whitespace() || *byte == b'/' => {}
+        _ => return None,
+    }
+
+    let mut pos = name_end + 1;
+    let mut quote = None;
+    while pos < bytes.len() {
+        if let Some(delimiter) = quote {
+            if bytes[pos] == delimiter {
+                quote = None;
+            }
+        } else {
+            match bytes[pos] {
+                b'\'' | b'"' => quote = Some(bytes[pos]),
+                b'>' => return Some(pos + 1),
+                b'<' => return None,
+                _ => {}
+            }
         }
         pos += 1;
     }
@@ -1755,7 +1800,7 @@ Content
         let component = out.to_component("Page").unwrap();
 
         assert!(component.contains(
-            "<textarea data-kind=\"example\">{\"first\\r\\n  second {value}&\\r\\n\"}</textarea   ><p>after textarea</p>"
+            "<textarea data-kind=\"example\">{\"first\\r\\n  second {value}&\\r\\n\"}</textarea><p>after textarea</p>"
         ), "{component}");
         assert!(
             component.contains(
@@ -1770,6 +1815,70 @@ Content
         );
         assert!(
             component.contains("<style>{\".x { color: red }\"}</style><p>after style</p>"),
+            "{component}"
+        );
+    }
+
+    #[test]
+    fn to_component_normalizes_html_text_closers_to_valid_jsx() {
+        let cases = [
+            ("textarea", "</textarea/>"),
+            ("title", "</TiTlE / >"),
+            ("script", "</SCRIPT data-kind='ignored'>"),
+            ("style", "</stYLE data-kind=\"value>still\">"),
+            ("xmp", "</XMP/>"),
+            ("iframe", "</IFRAME / >"),
+            ("noembed", "</NOEMBED data-kind='ignored'>"),
+            ("noframes", "</noFrames data-kind=\"value>still\">"),
+        ];
+
+        for (name, closer) in cases {
+            let body = format!("<{name}>a {{value}}&amp;{closer}b<p>after</p>");
+            let out = MdxOutput {
+                body,
+                esm: vec![],
+                front_matter: None,
+            };
+            let component = out.to_component("Page").unwrap();
+
+            assert!(
+                component.contains(&format!("</{name}>b<p>after</p>")),
+                "{component}"
+            );
+            assert!(!component.contains(closer), "{component}");
+        }
+
+        let public_component = render("<textarea>a</textarea/>b")
+            .to_component("Page")
+            .unwrap();
+        assert!(
+            public_component.contains("<textarea>{\"a\"}</textarea>b"),
+            "{public_component}"
+        );
+    }
+
+    #[test]
+    fn to_component_keeps_html_text_closer_near_matches_as_text() {
+        let body = "<textarea>a</textareax>b</textarea><p>after name</p><title>c</title?>d</title><p>after punctuation</p><script>e</script data='unterminated<p>inside raw text</p>";
+        let out = MdxOutput {
+            body: body.to_owned(),
+            esm: vec![],
+            front_matter: None,
+        };
+        let component = out.to_component("Page").unwrap();
+
+        assert!(
+            component.contains("<textarea>{\"a</textareax>b\"}</textarea><p>after name</p>"),
+            "{component}"
+        );
+        assert!(
+            component.contains("<title>{\"c</title?>d\"}</title><p>after punctuation</p>"),
+            "{component}"
+        );
+        assert!(
+            component.contains(
+                "<script>{\"e</script data='unterminated<p>inside raw text</p>\"}</script>"
+            ),
             "{component}"
         );
     }
@@ -1809,7 +1918,7 @@ Content
     }
 
     #[test]
-    fn to_component_ignores_raw_text_closing_tag_near_matches() {
+    fn to_component_uses_html_text_end_tag_name_boundaries() {
         let out = MdxOutput {
             body: "<textarea>before</TEXTAREAX>middle</textarea extra>still</TeXtArEa><p>after</p>\n<script>before</SCRIPTS>middle</ScRiPt><p>after script</p>"
                 .to_owned(),
@@ -1819,9 +1928,8 @@ Content
         let component = out.to_component("Page").unwrap();
 
         assert!(
-            component.contains(
-                "<textarea>{\"before</TEXTAREAX>middle</textarea extra>still\"}</textarea><p>after</p>"
-            ),
+            component
+                .contains("<textarea>{\"before</TEXTAREAX>middle\"}</textarea>still<p>after</p>"),
             "{component}"
         );
         assert!(

--- a/src/mdx/render.rs
+++ b/src/mdx/render.rs
@@ -9,6 +9,10 @@ use super::{
 };
 
 const COMPONENT_BODY_INDENT: &str = "      ";
+const HTML_VOID_ELEMENTS: [&str; 14] = [
+    "area", "base", "br", "col", "embed", "hr", "img", "input", "link", "meta", "param", "source",
+    "track", "wbr",
+];
 
 #[derive(Clone, Copy)]
 enum HtmlTextKind {
@@ -207,6 +211,8 @@ fn write_component_body(out: &mut String, body: &str) {
     let mut pos = 0;
     let mut at_line_start = true;
     let mut pre_depth = 0_u32;
+    let mut void_openings = [0_usize; HTML_VOID_ELEMENTS.len()];
+    let mut void_named_component_openings = Vec::new();
 
     while pos < bytes.len() {
         if pre_depth > 0 && bytes[pos] != b'<' {
@@ -241,7 +247,13 @@ fn write_component_body(out: &mut String, body: &str) {
             && let Some(tag) = parse_jsx_tag(&bytes[pos..])
         {
             indent_component_line(out, at_line_start, pre_depth);
-            write_component_tag(out, &body[pos..pos + tag.end_offset], &tag);
+            write_component_tag(
+                out,
+                &body[pos..pos + tag.end_offset],
+                &tag,
+                &mut void_openings,
+                &mut void_named_component_openings,
+            );
             at_line_start = false;
 
             let text_kind = if !tag.is_closing && !tag.is_self_closing {
@@ -319,8 +331,42 @@ fn write_component_body(out: &mut String, body: &str) {
     }
 }
 
-fn write_component_tag(out: &mut String, source: &str, tag: &TagInfo<'_>) {
-    if !tag.is_closing && !tag.is_self_closing && is_html_void_element(tag.name) {
+fn write_component_tag<'a>(
+    out: &mut String,
+    source: &str,
+    tag: &TagInfo<'a>,
+    void_openings: &mut [usize; HTML_VOID_ELEMENTS.len()],
+    void_named_component_openings: &mut Vec<&'a str>,
+) {
+    if tag.is_closing {
+        if void_named_component_openings.last() == Some(&tag.name) {
+            void_named_component_openings.pop();
+            out.push_str(source);
+            return;
+        }
+
+        if let Some(index) = html_void_element_index(tag.name) {
+            void_openings[index] = void_openings[index].saturating_sub(1);
+            return;
+        }
+        if let Some(index) = html_void_element_index_ignore_ascii_case(tag.name)
+            && void_openings[index] > 0
+        {
+            void_openings[index] -= 1;
+            return;
+        }
+
+        out.push_str(source);
+        return;
+    }
+
+    if let Some(index) = html_void_element_index(tag.name) {
+        void_openings[index] += 1;
+        if tag.is_self_closing {
+            out.push_str(source);
+            return;
+        }
+
         let before_close = &source[..source.len() - 1];
         out.push_str(before_close);
         if before_close.ends_with(char::is_whitespace) {
@@ -329,29 +375,25 @@ fn write_component_tag(out: &mut String, source: &str, tag: &TagInfo<'_>) {
             out.push_str(" /");
         }
         out.push('>');
-    } else {
-        out.push_str(source);
+        return;
     }
+
+    if !tag.is_self_closing && html_void_element_index_ignore_ascii_case(tag.name).is_some() {
+        void_named_component_openings.push(tag.name);
+    }
+    out.push_str(source);
 }
 
-fn is_html_void_element(name: &str) -> bool {
-    matches!(
-        name,
-        "area"
-            | "base"
-            | "br"
-            | "col"
-            | "embed"
-            | "hr"
-            | "img"
-            | "input"
-            | "link"
-            | "meta"
-            | "param"
-            | "source"
-            | "track"
-            | "wbr"
-    )
+fn html_void_element_index(name: &str) -> Option<usize> {
+    HTML_VOID_ELEMENTS
+        .iter()
+        .position(|element| *element == name)
+}
+
+fn html_void_element_index_ignore_ascii_case(name: &str) -> Option<usize> {
+    HTML_VOID_ELEMENTS
+        .iter()
+        .position(|element| element.eq_ignore_ascii_case(name))
 }
 
 fn html_text_kind(name: &str) -> Option<HtmlTextKind> {
@@ -869,6 +911,81 @@ Content
             "{component}"
         );
         assert!(component.contains("line<br />\n"), "{component}");
+    }
+
+    #[test]
+    fn to_component_omits_html_void_element_closing_tags() {
+        let body = "<area data-kind=\"example\"></AREA   ><base ></base><br></BR><col></col><embed></embed><hr></hr><img src=\"image.png\"></IMG><input></input><link></link><meta></meta><param></param><source></source><track></track><wbr></wBr>";
+        let out = MdxOutput {
+            body: body.to_owned(),
+            esm: vec![],
+            front_matter: None,
+        };
+        let component = out.to_component("Page").unwrap();
+
+        assert_eq!(out.body, body);
+        for expected in [
+            "<area data-kind=\"example\" />",
+            "<base />",
+            "<br />",
+            "<col />",
+            "<embed />",
+            "<hr />",
+            "<img src=\"image.png\" />",
+            "<input />",
+            "<link />",
+            "<meta />",
+            "<param />",
+            "<source />",
+            "<track />",
+            "<wbr />",
+        ] {
+            assert!(
+                component.contains(expected),
+                "missing {expected:?}: {component}"
+            );
+        }
+        for omitted in [
+            "</AREA", "</base", "</BR", "</col", "</embed", "</hr", "</IMG", "</input", "</link",
+            "</meta", "</param", "</source", "</track", "</wBr",
+        ] {
+            assert!(
+                !component.contains(omitted),
+                "retained {omitted:?}: {component}"
+            );
+        }
+    }
+
+    #[test]
+    fn to_component_omits_void_closing_tag_from_rendered_markdown() {
+        let out = render("a<br></br>z");
+        assert!(out.body.contains("<p>a<br></br>z</p>"), "{}", out.body);
+
+        let component = out.to_component("Page").unwrap();
+        assert!(component.contains("<p>a<br />z</p>"), "{component}");
+        assert!(!component.contains("</br>"), "{component}");
+    }
+
+    #[test]
+    fn to_component_preserves_non_void_and_component_tag_pairs() {
+        let body = "<div data-kind=\"normal\"></div><bravo></bravo><custom-br></custom-br><br><Br></Br></BR><Img></Img><br></bravo>";
+        let out = MdxOutput {
+            body: body.to_owned(),
+            esm: vec![],
+            front_matter: None,
+        };
+        let component = out.to_component("Page").unwrap();
+
+        assert!(
+            component.contains("<div data-kind=\"normal\"></div>"),
+            "{component}"
+        );
+        assert!(component.contains("<bravo></bravo>"), "{component}");
+        assert!(component.contains("<custom-br></custom-br>"), "{component}");
+        assert!(component.contains("<br /><Br></Br>"), "{component}");
+        assert!(!component.contains("</BR>"), "{component}");
+        assert!(component.contains("<Img></Img>"), "{component}");
+        assert!(component.contains("<br /></bravo>"), "{component}");
     }
 
     #[test]

--- a/src/mdx/render.rs
+++ b/src/mdx/render.rs
@@ -228,7 +228,7 @@ fn write_component_body(out: &mut String, body: &str) {
     let mut pos = 0;
     let mut at_line_start = true;
     let mut pre_depth = 0_u32;
-    let mut html_component_openings = Vec::new();
+    let mut html_openings = Vec::new();
 
     while pos < bytes.len() {
         if pre_depth > 0 && bytes[pos] != b'<' {
@@ -302,7 +302,7 @@ fn write_component_body(out: &mut String, body: &str) {
                     out,
                     &body[pos..pos + tag.end_offset],
                     &tag,
-                    &mut html_component_openings,
+                    &mut html_openings,
                 )
             };
             at_line_start = false;
@@ -378,19 +378,23 @@ fn write_component_tag<'a>(
     out: &mut String,
     source: &str,
     tag: &TagInfo<'a>,
-    html_component_openings: &mut Vec<(&'static str, &'a str)>,
+    html_openings: &mut Vec<(&'static str, Option<&'a str>)>,
 ) -> ComponentTagEffect {
     if tag.is_closing {
         if let Some(canonical_name) = html_element_ignore_ascii_case(tag.name) {
-            if html_component_openings
+            if html_openings
                 .last()
                 .is_some_and(|(opening_canonical, _)| *opening_canonical == canonical_name)
             {
-                let (_, opening_name) = html_component_openings
+                let (_, component_name) = html_openings
                     .pop()
-                    .expect("last component opening was just checked");
-                write_closing_tag(out, source, opening_name);
-                return ComponentTagEffect::None;
+                    .expect("last HTML opening was just checked");
+                write_closing_tag(out, source, component_name.unwrap_or(canonical_name));
+                return if component_name.is_none() && canonical_name == "pre" {
+                    ComponentTagEffect::PreClose
+                } else {
+                    ComponentTagEffect::None
+                };
             }
             if HTML_VOID_ELEMENTS.contains(&canonical_name) {
                 return ComponentTagEffect::None;
@@ -415,6 +419,9 @@ fn write_component_tag<'a>(
 
     if let Some(canonical_name) = html_element(tag.name) {
         write_html_opening_tag(out, source, tag.name, canonical_name);
+        if !tag.is_self_closing {
+            html_openings.push((canonical_name, None));
+        }
         return if canonical_name == "pre" && !tag.is_self_closing {
             ComponentTagEffect::PreOpen
         } else {
@@ -425,7 +432,7 @@ fn write_component_tag<'a>(
     if !tag.is_self_closing
         && let Some(canonical_name) = html_element_ignore_ascii_case(tag.name)
     {
-        html_component_openings.push((canonical_name, tag.name));
+        html_openings.push((canonical_name, Some(tag.name)));
     }
     out.push_str(source);
     ComponentTagEffect::None
@@ -1795,6 +1802,31 @@ Content
         assert!(component.contains("      {value}"), "{component}");
         assert!(component.contains("      </Code>"), "{component}");
         assert!(component.contains("      </Pre>"), "{component}");
+    }
+
+    #[test]
+    fn to_component_keeps_nested_intrinsic_and_component_owners_distinct() {
+        let body = "<Div><div>inner</div></Div><div><Div>component</DIV></DIV><Pre><PRE><CODE>first\n  second {value}\n</code></pre></PRE>";
+        let out = MdxOutput {
+            body: body.to_owned(),
+            esm: vec![],
+            front_matter: None,
+        };
+        let component = out.to_component("Page").unwrap();
+
+        assert!(
+            component.contains("<Div><div>inner</div></Div>"),
+            "{component}"
+        );
+        assert!(
+            component.contains("<div><Div>component</Div></div>"),
+            "{component}"
+        );
+        assert!(
+            component
+                .contains("<Pre><pre><code>{\"first\\n  second {value}\\n\"}</code></pre></Pre>"),
+            "{component}"
+        );
     }
 
     #[test]

--- a/src/mdx/render.rs
+++ b/src/mdx/render.rs
@@ -34,7 +34,7 @@ enum HtmlTextKind {
 enum ComponentTagEffect {
     None,
     PreOpen,
-    PreClose,
+    PreClose(u32),
 }
 
 /// Error returned when a component name cannot be used as a JavaScript binding.
@@ -309,7 +309,9 @@ fn write_component_body(out: &mut String, body: &str) {
 
             match tag_effect {
                 ComponentTagEffect::PreOpen => pre_depth = pre_depth.saturating_add(1),
-                ComponentTagEffect::PreClose => pre_depth = pre_depth.saturating_sub(1),
+                ComponentTagEffect::PreClose(count) => {
+                    pre_depth = pre_depth.saturating_sub(count);
+                }
                 ComponentTagEffect::None => {}
             }
 
@@ -382,16 +384,42 @@ fn write_component_tag<'a>(
 ) -> ComponentTagEffect {
     if tag.is_closing {
         if let Some(canonical_name) = html_element_ignore_ascii_case(tag.name) {
-            if html_openings
+            let component_syntax = !uses_html_intrinsic_syntax(tag.name);
+            let top_matches = html_openings
                 .last()
-                .is_some_and(|(opening_canonical, _)| *opening_canonical == canonical_name)
-            {
+                .is_some_and(|(opening_canonical, _)| *opening_canonical == canonical_name);
+            let matching_index = if top_matches && is_all_uppercase_html_name(tag.name) {
+                Some(html_openings.len() - 1)
+            } else {
+                html_openings
+                    .iter()
+                    .rposition(|(opening_canonical, component_name)| {
+                        *opening_canonical == canonical_name
+                            && component_name.is_some() == component_syntax
+                    })
+                    .or_else(|| {
+                        html_openings.iter().rposition(|(opening_canonical, _)| {
+                            *opening_canonical == canonical_name
+                        })
+                    })
+            };
+            if let Some(matching_index) = matching_index {
+                let mut closed_pre_count = 0;
+                while html_openings.len() > matching_index + 1 {
+                    let (intervening_name, component_name) = html_openings
+                        .pop()
+                        .expect("an intervening HTML opening was just counted");
+                    write_synthetic_closing_tag(out, component_name.unwrap_or(intervening_name));
+                    closed_pre_count +=
+                        u32::from(component_name.is_none() && intervening_name == "pre");
+                }
                 let (_, component_name) = html_openings
                     .pop()
-                    .expect("last HTML opening was just checked");
+                    .expect("matching HTML opening was just located");
                 write_closing_tag(out, source, component_name.unwrap_or(canonical_name));
-                return if component_name.is_none() && canonical_name == "pre" {
-                    ComponentTagEffect::PreClose
+                closed_pre_count += u32::from(component_name.is_none() && canonical_name == "pre");
+                return if closed_pre_count > 0 {
+                    ComponentTagEffect::PreClose(closed_pre_count)
                 } else {
                     ComponentTagEffect::None
                 };
@@ -402,7 +430,7 @@ fn write_component_tag<'a>(
             if uses_html_intrinsic_syntax(tag.name) {
                 write_closing_tag(out, source, canonical_name);
                 return if canonical_name == "pre" {
-                    ComponentTagEffect::PreClose
+                    ComponentTagEffect::PreClose(1)
                 } else {
                     ComponentTagEffect::None
                 };
@@ -516,10 +544,12 @@ fn uses_html_intrinsic_syntax(name: &str) -> bool {
     // Lowercase-leading and all-uppercase HTML names are emitted as JSX
     // intrinsics. Preserve PascalCase/mixed-leading-uppercase names as MDX
     // components.
-    name.as_bytes().first().is_some_and(u8::is_ascii_lowercase)
-        || name
-            .bytes()
-            .all(|byte| !byte.is_ascii_alphabetic() || byte.is_ascii_uppercase())
+    name.as_bytes().first().is_some_and(u8::is_ascii_lowercase) || is_all_uppercase_html_name(name)
+}
+
+fn is_all_uppercase_html_name(name: &str) -> bool {
+    name.bytes()
+        .all(|byte| !byte.is_ascii_alphabetic() || byte.is_ascii_uppercase())
 }
 
 fn indent_component_line(out: &mut String, at_line_start: bool, pre_depth: u32) {
@@ -567,6 +597,12 @@ fn write_closing_tag(out: &mut String, source: &str, opening_name: &str) {
     out.push_str("</");
     out.push_str(opening_name);
     out.push_str(&source[opening_name.len() + 2..]);
+}
+
+fn write_synthetic_closing_tag(out: &mut String, opening_name: &str) {
+    out.push_str("</");
+    out.push_str(opening_name);
+    out.push('>');
 }
 
 fn write_html_opening_tag(
@@ -1806,7 +1842,7 @@ Content
 
     #[test]
     fn to_component_keeps_nested_intrinsic_and_component_owners_distinct() {
-        let body = "<Div><div>inner</div></Div><div><Div>component</DIV></DIV><Pre><PRE><CODE>first\n  second {value}\n</code></pre></PRE>";
+        let body = "<Div><div>inner</div></Div><div><Div>component</DIV></DIV><Div><div>component first</Div><div><Div>intrinsic first</div><Pre><pre>first\n  second {value}\n</Pre>";
         let out = MdxOutput {
             body: body.to_owned(),
             esm: vec![],
@@ -1823,8 +1859,15 @@ Content
             "{component}"
         );
         assert!(
-            component
-                .contains("<Pre><pre><code>{\"first\\n  second {value}\\n\"}</code></pre></Pre>"),
+            component.contains("<Div><div>component first</div></Div>"),
+            "{component}"
+        );
+        assert!(
+            component.contains("<div><Div>intrinsic first</Div></div>"),
+            "{component}"
+        );
+        assert!(
+            component.contains("<Pre><pre>{\"first\\n  second {value}\\n\"}</pre></Pre>"),
             "{component}"
         );
     }

--- a/src/mdx/render.rs
+++ b/src/mdx/render.rs
@@ -260,16 +260,25 @@ fn write_component_body(out: &mut String, body: &str) {
 
             pos += tag.end_offset;
             if let Some(text_kind) = text_kind {
-                let end = raw_text_end(bytes, pos, tag.name).unwrap_or(bytes.len());
-                write_jsx_string_child(
-                    out,
-                    &body[pos..end],
-                    matches!(text_kind, HtmlTextKind::Rcdata),
-                );
+                if let Some((text_end, tag_end)) = raw_text_end(bytes, pos, tag.name) {
+                    write_jsx_string_child(
+                        out,
+                        &body[pos..text_end],
+                        matches!(text_kind, HtmlTextKind::Rcdata),
+                    );
+                    write_html_text_closing_tag(out, &body[text_end..tag_end], tag.name);
+                    pos = tag_end;
+                } else {
+                    write_jsx_string_child(
+                        out,
+                        &body[pos..],
+                        matches!(text_kind, HtmlTextKind::Rcdata),
+                    );
+                    pos = bytes.len();
+                }
                 // The raw text's line breaks are escaped inside the string child,
                 // so the generated JSX source is still on the opening tag's line.
                 at_line_start = false;
-                pos = end;
             }
             continue;
         }
@@ -392,16 +401,24 @@ fn write_jsx_string_child(out: &mut String, text: &str, decode_entities: bool) {
     out.push_str("\"}");
 }
 
-fn raw_text_end(bytes: &[u8], start: usize, tag_name: &str) -> Option<usize> {
+fn write_html_text_closing_tag(out: &mut String, source: &str, opening_name: &str) {
+    debug_assert!(source.starts_with("</"));
+    debug_assert!(source.len() >= opening_name.len() + 2);
+    out.push_str("</");
+    out.push_str(opening_name);
+    out.push_str(&source[opening_name.len() + 2..]);
+}
+
+fn raw_text_end(bytes: &[u8], start: usize, tag_name: &str) -> Option<(usize, usize)> {
     let mut pos = start;
 
     while let Some(offset) = bytes[pos..].iter().position(|byte| *byte == b'<') {
         pos += offset;
         if let Some(tag) = parse_jsx_tag(&bytes[pos..])
             && tag.is_closing
-            && tag.name == tag_name
+            && tag.name.eq_ignore_ascii_case(tag_name)
         {
-            return Some(pos);
+            return Some((pos, pos + tag.end_offset));
         }
         pos += 1;
     }
@@ -886,6 +903,58 @@ Content
         ), "{component}");
         assert!(
             component.contains("<title>{\"first\\n  second {value}&\\n\"}</title>"),
+            "{component}"
+        );
+    }
+
+    #[test]
+    fn to_component_matches_html_text_end_tags_ascii_case_insensitively() {
+        let out = MdxOutput {
+            body: "<textarea data-kind=\"example\">first\r\n  second {value}&amp;\r\n</TEXTAREA   ><p>after textarea</p>\n<title data-kind=\"example\">heading &amp; {value}</TiTlE><p>after title</p>\n<script>if (left < right) { run(); }</SCRIPT><p>after script</p>\n<style>.x { color: red }</StYlE><p>after style</p>"
+                .to_owned(),
+            esm: vec![],
+            front_matter: None,
+        };
+        let component = out.to_component("Page").unwrap();
+
+        assert!(component.contains(
+            "<textarea data-kind=\"example\">{\"first\\r\\n  second {value}&\\r\\n\"}</textarea   ><p>after textarea</p>"
+        ), "{component}");
+        assert!(
+            component.contains(
+                "<title data-kind=\"example\">{\"heading & {value}\"}</title><p>after title</p>"
+            ),
+            "{component}"
+        );
+        assert!(
+            component
+                .contains("<script>{\"if (left < right) { run(); }\"}</script><p>after script</p>"),
+            "{component}"
+        );
+        assert!(
+            component.contains("<style>{\".x { color: red }\"}</style><p>after style</p>"),
+            "{component}"
+        );
+    }
+
+    #[test]
+    fn to_component_ignores_raw_text_closing_tag_near_matches() {
+        let out = MdxOutput {
+            body: "<textarea>before</TEXTAREAX>middle</textarea extra>still</TeXtArEa><p>after</p>\n<script>before</SCRIPTS>middle</ScRiPt><p>after script</p>"
+                .to_owned(),
+            esm: vec![],
+            front_matter: None,
+        };
+        let component = out.to_component("Page").unwrap();
+
+        assert!(
+            component.contains(
+                "<textarea>{\"before</TEXTAREAX>middle</textarea extra>still\"}</textarea><p>after</p>"
+            ),
+            "{component}"
+        );
+        assert!(
+            component.contains("<script>{\"before</SCRIPTS>middle\"}</script><p>after script</p>"),
             "{component}"
         );
     }

--- a/src/render.rs
+++ b/src/render.rs
@@ -9,7 +9,7 @@ use memchr::memchr;
 /// Decode HTML entities with CommonMark compliance.
 /// - Replaces null bytes (from &#0;) with U+FFFD replacement character
 /// - Handles multi-codepoint entities that html_escape doesn't support
-fn decode_entities_commonmark(input: &str) -> std::borrow::Cow<'_, str> {
+pub(crate) fn decode_entities_commonmark(input: &str) -> std::borrow::Cow<'_, str> {
     let decoded = html_escape::decode_html_entities(input);
 
     // Check if we need to fix null bytes or missing multi-codepoint entities


### PR DESCRIPTION
Fixes #150

## Summary

- emit Markdown text braces as literal JSX text while preserving MDX flow expressions and JSX tags
- omit HTML comments, self-close HTML void elements, and preserve raw script/style content
- preserve exact preformatted text and line endings through escaped JSX string children
- keep the public rendered HTML body unchanged

## Validation

- cargo test --locked
- cargo test --locked --all-features
- cargo clippy --locked --all-targets --all-features -- -D warnings
- cargo fmt --all -- --check
- cargo doc --locked --all-features --no-deps
- workflow pin contract checks
- TypeScript 5.9 JSX parse/transpile of the generated module
- React 19 server-render semantic probe for literal braces, comments, and preformatted trailing whitespace

🔧 Emily Carter · Implementation Agent