### PR TITLE
docs(mdx): fix render example front matter

### DIFF
--- a/README.md
+++ b/README.md
@@ -321,11 +321,11 @@ cargo add ferromark --features mdx
 ```rust
 use ferromark::mdx::render;
 
-let input = r#"import { Card } from './card'
-
----
+let input = r#"---
 title: Hello
 ---
+
+import { Card } from './card'
 
 # Hello World
 

--- a/src/mdx/render.rs
+++ b/src/mdx/render.rs
@@ -324,6 +324,35 @@ Paragraph.
     }
 
     #[test]
+    fn readme_render_example_extracts_front_matter_before_esm() {
+        let input = r#"---
+title: Hello
+---
+
+import { Card } from './card'
+
+# Hello World
+
+<Card title="Example">
+
+Markdown **inside** a component.
+
+</Card>
+
+{new Date().getFullYear()}
+"#;
+        let out = render(input);
+
+        assert_eq!(out.front_matter, Some("title: Hello\n"));
+        assert_eq!(out.esm, ["import { Card } from './card'\n"]);
+        assert!(out.body.contains("<h1 id=\"hello-world\">Hello World</h1>"));
+        assert!(out.body.contains("<Card title=\"Example\">"));
+        assert!(out.body.contains("<strong>inside</strong>"));
+        assert!(out.body.contains("{new Date().getFullYear()}"));
+        assert!(!out.body.contains("title: Hello"));
+    }
+
+    #[test]
     fn inline_html_passthrough() {
         let input = "Text with <sl-button>Click</sl-button> here.\n";
         let out = render(input);


### PR DESCRIPTION
Fixes #151

## Summary

- Move the README flagship MDX front matter to byte zero so `render()` extracts it as documented.
- Keep the documented ESM, Markdown body, and JSX expression output aligned with the actual renderer behavior.
- Add an executable regression that validates the complete example output and prevents the title from leaking into rendered content.

## Validation

- `cargo test --workspace --all-features --locked`
- `cargo clippy --all-targets --all-features --locked -- -D warnings`
- `cargo fmt --check`
- `git diff --check`

🔧 Emily Carter · Implementation Agent
