### PR TITLE
docs(contributing): align checks with CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,7 @@ jobs:
       - run: ./scripts/test-check-workflow-pins.sh
       - run: node ./scripts/test-publish-verification.mjs
       - run: ruby ./scripts/test-node-ci-matrix.rb
+      - run: ruby ./scripts/test-contributing-ci-contract.rb
       - run: ./scripts/check-workflow-pins.sh
 
   rustsec:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
       - run: ./scripts/test-check-workflow-pins.sh
       - run: node ./scripts/test-publish-verification.mjs
       - run: ruby ./scripts/test-node-ci-matrix.rb
-      - run: ruby ./scripts/test-contributing-ci-contract.rb
+      - run: ruby ./scripts/test-contributing-ci-contract.rb --self-test
       - run: ./scripts/check-workflow-pins.sh
 
   rustsec:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,8 +5,23 @@
 ```bash
 git clone https://github.com/sebastian-software/ferromark.git
 cd ferromark
-cargo test
+cargo test --locked --all-features
 ```
+
+The minimum supported Rust version (MSRV) is Rust 1.88.
+
+## Required local checks
+
+Run these commands from the repository root before opening a pull request:
+
+```bash
+cargo test --locked --all-features
+cargo clippy --all-targets --all-features --locked -- -D warnings
+cargo fmt --check
+```
+
+Changes to the Node workspace or release process have additional package checks;
+follow the [releasing guide](docs/releasing.md) for those commands.
 
 ## Running benchmarks
 
@@ -49,5 +64,5 @@ Breaking changes: add `!` after the type (e.g., `feat!:`) or include `BREAKING C
 ## Pull requests
 
 1. Fork the repo and create a branch from `main`
-2. Run `cargo test` and `cargo clippy` before submitting
+2. Run the required local checks before submitting
 3. Keep PRs focused -- one change per PR

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,10 +5,11 @@
 ```bash
 git clone https://github.com/sebastian-software/ferromark.git
 cd ferromark
-cargo test --locked --all-features
 ```
 
 The minimum supported Rust version (MSRV) is Rust 1.88.
+
+Run the [required local checks](#required-local-checks) below.
 
 ## Required local checks
 

--- a/scripts/test-contributing-ci-contract.rb
+++ b/scripts/test-contributing-ci-contract.rb
@@ -49,6 +49,13 @@ def validate(repository_root)
   unless getting_started.include?(expected_msrv)
     fail_contract("Getting started must state #{expected_msrv.inspect}")
   end
+  unless getting_started.include?('Run the [required local checks](#required-local-checks) below.')
+    fail_contract('Getting started must point contributors to Required local checks')
+  end
+  bootstrap_commands = fenced_bash_commands(getting_started, 'Getting started')
+  if bootstrap_commands.any? { |command| command.start_with?('cargo ') }
+    fail_contract('Getting started must not duplicate cargo commands from Required local checks')
+  end
 
   jobs = workflow.fetch('jobs')
   test_job = jobs.fetch('test')
@@ -97,9 +104,9 @@ def with_fixture(source_root)
   end
 end
 
-def mutate_required_command(document, original, replacement)
-  section_start = document.index("## Required local checks\n")
-  fail 'test fixture is missing Required local checks' unless section_start
+def mutate_section_command(document, heading, original, replacement)
+  section_start = document.index("## #{heading}\n")
+  fail "test fixture is missing #{heading.inspect}" unless section_start
 
   prefix = document[0...section_start]
   section = document[section_start..]
@@ -149,24 +156,25 @@ def self_test(source_root)
       if label == 'required MSRV statement'
         document.sub!(original, replacement) || raise("test fixture is missing #{original.inspect}")
       else
-        document = mutate_required_command(document, original, replacement)
+        document = mutate_section_command(document, 'Required local checks', original, replacement)
       end
       File.write(path, document)
       assert_rejected(label) { validate(fixture_root) }
     end
   end
 
-  # The bootstrap command intentionally duplicates the required test command.
-  # Mutating only the Required local checks occurrence must still fail.
+  # The bootstrap section deliberately contains no cargo command, leaving
+  # Required local checks as the single source for CI-equivalent commands.
   with_fixture(source_root) do |fixture_root|
     path = File.join(fixture_root, 'CONTRIBUTING.md')
-    document = mutate_required_command(
+    document = mutate_section_command(
       File.read(path),
-      required_test,
-      'cargo test --locked'
+      'Getting started',
+      'cd ferromark',
+      "cd ferromark\ncargo test --locked"
     )
     File.write(path, document)
-    assert_rejected('duplicate bootstrap command') { validate(fixture_root) }
+    assert_rejected('bootstrap cargo command') { validate(fixture_root) }
   end
 end
 

--- a/scripts/test-contributing-ci-contract.rb
+++ b/scripts/test-contributing-ci-contract.rb
@@ -1,0 +1,55 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require 'yaml'
+
+repository_root = File.expand_path('..', __dir__)
+contributing = File.read(File.join(repository_root, 'CONTRIBUTING.md'))
+cargo_toml = File.read(File.join(repository_root, 'Cargo.toml'))
+workflow = YAML.safe_load(File.read(File.join(repository_root, '.github/workflows/ci.yml')), aliases: false)
+
+def fail_contract(message)
+  abort "CONTRIBUTING CI contract: #{message}"
+end
+
+rust_version = cargo_toml[/^rust-version\s*=\s*"([^"]+)"\s*$/, 1]
+fail_contract('Cargo.toml must declare rust-version') unless rust_version
+
+expected_msrv = "The minimum supported Rust version (MSRV) is Rust #{rust_version}."
+fail_contract("must state #{expected_msrv.inspect}") unless contributing.include?(expected_msrv)
+
+jobs = workflow.fetch('jobs')
+test_job = jobs.fetch('test')
+test_command = test_job.fetch('steps').map { |step| step['run'] }.compact.find do |command|
+  command.include?('${{ matrix.args }}') && command.start_with?('cargo test ')
+end
+fail_contract('CI test job must use a matrix command') unless test_command
+
+test_matrix = test_job.fetch('strategy').fetch('matrix').fetch('include')
+all_feature_args = test_matrix.map do |entry|
+  entry['args'] if entry['args'] == '--all-features'
+end.compact
+fail_contract('CI test matrix must include --all-features') if all_feature_args.empty?
+
+msrv_entries = test_matrix.select { |entry| entry['rust'] == rust_version }
+fail_contract("CI test matrix must test Rust #{rust_version}") if msrv_entries.empty?
+msrv_args = msrv_entries.map { |entry| entry['args'] }
+unless msrv_args.include?('') && msrv_args.include?('--all-features')
+  fail_contract("CI Rust #{rust_version} entries must cover default and --all-features")
+end
+
+all_features_test_command = test_command.sub('${{ matrix.args }}', all_feature_args.first)
+unless contributing.include?(all_features_test_command)
+  fail_contract("must include CI all-features test command #{all_features_test_command.inspect}")
+end
+
+clippy_job = jobs.fetch('clippy')
+clippy_command = clippy_job.fetch('steps').map { |step| step['run'] }.compact.find do |command|
+  command.start_with?('cargo clippy ')
+end
+fail_contract('CI must define a cargo clippy command') unless clippy_command
+fail_contract("must include CI clippy command #{clippy_command.inspect}") unless contributing.include?(clippy_command)
+
+fail_contract('must link the Node workspace release checks') unless contributing.include?('[releasing guide](docs/releasing.md)')
+
+puts 'CONTRIBUTING CI contract checks passed'

--- a/scripts/test-contributing-ci-contract.rb
+++ b/scripts/test-contributing-ci-contract.rb
@@ -1,62 +1,187 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
+require 'fileutils'
+require 'tmpdir'
 require 'yaml'
 
-repository_root = File.expand_path('..', __dir__)
-contributing = File.read(File.join(repository_root, 'CONTRIBUTING.md'))
-cargo_toml = File.read(File.join(repository_root, 'Cargo.toml'))
-workflow = YAML.safe_load(File.read(File.join(repository_root, '.github/workflows/ci.yml')), aliases: false)
+class ContractError < StandardError; end
 
 def fail_contract(message)
-  abort "CONTRIBUTING CI contract: #{message}"
+  raise ContractError, "CONTRIBUTING CI contract: #{message}"
 end
 
-rust_version = cargo_toml[/^rust-version\s*=\s*"([^"]+)"\s*$/, 1]
-fail_contract('Cargo.toml must declare rust-version') unless rust_version
+def markdown_section(document, heading)
+  start = document.index("## #{heading}\n")
+  fail_contract("must contain a #{heading.inspect} section") unless start
 
-expected_msrv = "The minimum supported Rust version (MSRV) is Rust #{rust_version}."
-fail_contract("must state #{expected_msrv.inspect}") unless contributing.include?(expected_msrv)
-
-jobs = workflow.fetch('jobs')
-test_job = jobs.fetch('test')
-test_command = test_job.fetch('steps').map { |step| step['run'] }.compact.find do |command|
-  command.include?('${{ matrix.args }}') && command.start_with?('cargo test ')
-end
-fail_contract('CI test job must use a matrix command') unless test_command
-
-test_matrix = test_job.fetch('strategy').fetch('matrix').fetch('include')
-all_feature_args = test_matrix.map do |entry|
-  entry['args'] if entry['args'] == '--all-features'
-end.compact
-fail_contract('CI test matrix must include --all-features') if all_feature_args.empty?
-
-msrv_entries = test_matrix.select { |entry| entry['rust'] == rust_version }
-fail_contract("CI test matrix must test Rust #{rust_version}") if msrv_entries.empty?
-msrv_args = msrv_entries.map { |entry| entry['args'] }
-unless msrv_args.include?('') && msrv_args.include?('--all-features')
-  fail_contract("CI Rust #{rust_version} entries must cover default and --all-features")
+  content_start = start + heading.length + 4
+  next_heading = document.index(/^## /, content_start)
+  document[content_start...(next_heading || document.length)]
 end
 
-all_features_test_command = test_command.sub('${{ matrix.args }}', all_feature_args.first)
-unless contributing.include?(all_features_test_command)
-  fail_contract("must include CI all-features test command #{all_features_test_command.inspect}")
+def fenced_bash_commands(section, heading)
+  match = section.match(/```bash\n(?<commands>.*?)\n```/m)
+  fail_contract("#{heading.inspect} must contain a bash code block") unless match
+
+  match[:commands].lines.map(&:strip).reject(&:empty?)
 end
 
-clippy_job = jobs.fetch('clippy')
-clippy_command = clippy_job.fetch('steps').map { |step| step['run'] }.compact.find do |command|
-  command.start_with?('cargo clippy ')
-end
-fail_contract('CI must define a cargo clippy command') unless clippy_command
-fail_contract("must include CI clippy command #{clippy_command.inspect}") unless contributing.include?(clippy_command)
+def ci_command(job, prefix)
+  command = job.fetch('steps').map { |step| step['run'] }.compact.find do |candidate|
+    candidate.start_with?(prefix)
+  end
+  fail_contract("CI must define a #{prefix.strip} command") unless command
 
-fmt_job = jobs.fetch('fmt')
-fmt_command = fmt_job.fetch('steps').map { |step| step['run'] }.compact.find do |command|
-  command.start_with?('cargo fmt ')
+  command
 end
-fail_contract('CI must define a cargo fmt command') unless fmt_command
-fail_contract("must include CI fmt command #{fmt_command.inspect}") unless contributing.include?(fmt_command)
 
-fail_contract('must link the Node workspace release checks') unless contributing.include?('[releasing guide](docs/releasing.md)')
+def validate(repository_root)
+  contributing = File.read(File.join(repository_root, 'CONTRIBUTING.md'))
+  cargo_toml = File.read(File.join(repository_root, 'Cargo.toml'))
+  workflow = YAML.safe_load(File.read(File.join(repository_root, '.github/workflows/ci.yml')), aliases: false)
+
+  rust_version = cargo_toml[/^rust-version\s*=\s*"([^"]+)"\s*$/, 1]
+  fail_contract('Cargo.toml must declare rust-version') unless rust_version
+
+  getting_started = markdown_section(contributing, 'Getting started')
+  expected_msrv = "The minimum supported Rust version (MSRV) is Rust #{rust_version}."
+  unless getting_started.include?(expected_msrv)
+    fail_contract("Getting started must state #{expected_msrv.inspect}")
+  end
+
+  jobs = workflow.fetch('jobs')
+  test_job = jobs.fetch('test')
+  test_command = ci_command(test_job, 'cargo test ')
+  fail_contract('CI test job must use a matrix command') unless test_command.include?('${{ matrix.args }}')
+
+  test_matrix = test_job.fetch('strategy').fetch('matrix').fetch('include')
+  all_feature_args = test_matrix.map { |entry| entry['args'] if entry['args'] == '--all-features' }.compact
+  fail_contract('CI test matrix must include --all-features') if all_feature_args.empty?
+
+  msrv_entries = test_matrix.select { |entry| entry['rust'] == rust_version }
+  fail_contract("CI test matrix must test Rust #{rust_version}") if msrv_entries.empty?
+  msrv_args = msrv_entries.map { |entry| entry['args'] }
+  unless msrv_args.include?('') && msrv_args.include?('--all-features')
+    fail_contract("CI Rust #{rust_version} entries must cover default and --all-features")
+  end
+
+  expected_commands = [
+    test_command.sub('${{ matrix.args }}', all_feature_args.first),
+    ci_command(jobs.fetch('clippy'), 'cargo clippy '),
+    ci_command(jobs.fetch('fmt'), 'cargo fmt ')
+  ]
+  required_checks = markdown_section(contributing, 'Required local checks')
+  actual_commands = fenced_bash_commands(required_checks, 'Required local checks')
+  unless actual_commands == expected_commands
+    fail_contract(
+      "Required local checks commands must exactly match CI: expected #{expected_commands.inspect}, got #{actual_commands.inspect}"
+    )
+  end
+  unless required_checks.include?('[releasing guide](docs/releasing.md)')
+    fail_contract('Required local checks must link the Node workspace release checks')
+  end
+end
+
+def with_fixture(source_root)
+  Dir.mktmpdir('ferromark-contributing-contract.') do |fixture_root|
+    FileUtils.mkdir_p(File.join(fixture_root, '.github/workflows'))
+    %w[CONTRIBUTING.md Cargo.toml].each do |path|
+      FileUtils.cp(File.join(source_root, path), File.join(fixture_root, path))
+    end
+    FileUtils.cp(
+      File.join(source_root, '.github/workflows/ci.yml'),
+      File.join(fixture_root, '.github/workflows/ci.yml')
+    )
+    yield fixture_root
+  end
+end
+
+def mutate_required_command(document, original, replacement)
+  section_start = document.index("## Required local checks\n")
+  fail 'test fixture is missing Required local checks' unless section_start
+
+  prefix = document[0...section_start]
+  section = document[section_start..]
+  changed = section.sub!(original, replacement)
+  fail "test fixture is missing #{original.inspect}" unless changed
+
+  prefix + section
+end
+
+def assert_rejected(label)
+  yield
+  raise "#{label} mutation unexpectedly passed"
+rescue ContractError
+  # Expected: this mutation must be rejected by the contract.
+end
+
+def self_test(source_root)
+  validate(source_root)
+
+  source_document = File.read(File.join(source_root, 'CONTRIBUTING.md'))
+  required_commands = fenced_bash_commands(
+    markdown_section(source_document, 'Required local checks'),
+    'Required local checks'
+  )
+  required_test = required_commands.find { |command| command.start_with?('cargo test ') }
+  required_clippy = required_commands.find { |command| command.start_with?('cargo clippy ') }
+  required_fmt = required_commands.find { |command| command.start_with?('cargo fmt ') }
+  fail 'test fixture is missing a required cargo test command' unless required_test
+  fail 'test fixture is missing a required cargo clippy command' unless required_clippy
+  fail 'test fixture is missing a required cargo fmt command' unless required_fmt
+
+  rust_version = File.read(File.join(source_root, 'Cargo.toml'))[/^rust-version\s*=\s*"([^"]+)"\s*$/, 1]
+  fail 'test fixture is missing Cargo.toml rust-version' unless rust_version
+  required_msrv = "The minimum supported Rust version (MSRV) is Rust #{rust_version}."
+
+  mutations = {
+    'required all-features test' => [required_test, 'cargo test --locked'],
+    'required clippy command' => [required_clippy, 'cargo clippy'],
+    'required fmt command' => [required_fmt, 'cargo fmt'],
+    'required MSRV statement' => [required_msrv, 'The minimum supported Rust version (MSRV) is Rust unknown.']
+  }
+
+  mutations.each do |label, (original, replacement)|
+    with_fixture(source_root) do |fixture_root|
+      path = File.join(fixture_root, 'CONTRIBUTING.md')
+      document = File.read(path)
+      if label == 'required MSRV statement'
+        document.sub!(original, replacement) || raise("test fixture is missing #{original.inspect}")
+      else
+        document = mutate_required_command(document, original, replacement)
+      end
+      File.write(path, document)
+      assert_rejected(label) { validate(fixture_root) }
+    end
+  end
+
+  # The bootstrap command intentionally duplicates the required test command.
+  # Mutating only the Required local checks occurrence must still fail.
+  with_fixture(source_root) do |fixture_root|
+    path = File.join(fixture_root, 'CONTRIBUTING.md')
+    document = mutate_required_command(
+      File.read(path),
+      required_test,
+      'cargo test --locked'
+    )
+    File.write(path, document)
+    assert_rejected('duplicate bootstrap command') { validate(fixture_root) }
+  end
+end
+
+repository_root = File.expand_path('..', __dir__)
+
+begin
+  if ARGV == ['--self-test']
+    self_test(repository_root)
+  elsif ARGV.empty?
+    validate(repository_root)
+  else
+    abort 'usage: test-contributing-ci-contract.rb [--self-test]'
+  end
+rescue ContractError => error
+  abort error.message
+end
 
 puts 'CONTRIBUTING CI contract checks passed'

--- a/scripts/test-contributing-ci-contract.rb
+++ b/scripts/test-contributing-ci-contract.rb
@@ -50,6 +50,13 @@ end
 fail_contract('CI must define a cargo clippy command') unless clippy_command
 fail_contract("must include CI clippy command #{clippy_command.inspect}") unless contributing.include?(clippy_command)
 
+fmt_job = jobs.fetch('fmt')
+fmt_command = fmt_job.fetch('steps').map { |step| step['run'] }.compact.find do |command|
+  command.start_with?('cargo fmt ')
+end
+fail_contract('CI must define a cargo fmt command') unless fmt_command
+fail_contract("must include CI fmt command #{fmt_command.inspect}") unless contributing.include?(fmt_command)
+
 fail_contract('must link the Node workspace release checks') unless contributing.include?('[releasing guide](docs/releasing.md)')
 
 puts 'CONTRIBUTING CI contract checks passed'


### PR DESCRIPTION
Fixes #162

## Summary

- document the executable locked all-features test and strict CI-equivalent Clippy commands
- state the Rust 1.88 MSRV and point Node/release contributors to the release checks
- add a CI-run Ruby contract that derives the documented commands and MSRV coverage from Cargo.toml and ci.yml

## Validation

- ruby ./scripts/test-contributing-ci-contract.rb
- cargo test --workspace --locked --all-features
- cargo test --doc --locked --all-features
- cargo clippy --workspace --all-targets --all-features --locked -- -D warnings
- cargo fmt --all -- --check
- cargo doc --locked --all-features --no-deps
- ./scripts/test-check-workflow-pins.sh
- ./scripts/check-workflow-pins.sh
- node ./scripts/test-publish-verification.mjs
- ruby ./scripts/test-node-ci-matrix.rb
- git diff --check

🔧 Emily Carter · Implementation Agent