### PR TITLE
docs(node): complete npm package guidance

### DIFF
--- a/node/ferromark/README.md
+++ b/node/ferromark/README.md
@@ -40,7 +40,7 @@ untrusted user content.
 toHtml('<span class="note">Internal note</span>', {
   renderPolicy: 'trusted',
 })
-// '<span class="note">Internal note</span>'
+// '<p><span class="note">Internal note</span></p>\n'
 ```
 
 See [`Options`](./index.d.mts) for the complete optional syntax and rendering

--- a/node/ferromark/README.md
+++ b/node/ferromark/README.md
@@ -2,11 +2,50 @@
 
 Native Node.js bindings for the [ferromark](https://github.com/sebastian-software/ferromark) Markdown-to-HTML compiler.
 
+## Install
+
+```sh
+npm install ferromark
+# or: pnpm add ferromark
+```
+
+The package requires Node.js 22 or newer. It ships native binaries for glibc
+Linux, macOS, and Windows on x64 and arm64; there is no WASM fallback.
+
 ```js
 import { toHtml } from 'ferromark'
 
 const html = toHtml('# Hello')
 ```
+
+## Untrusted by default
+
+`toHtml()` and `transform()` default to `renderPolicy: 'untrusted'`. Raw HTML
+is escaped, and unsafe link and image URL schemes (such as `javascript:`) are
+removed from the rendered attributes. Use this default for Markdown from users
+or other untrusted sources.
+
+```js
+toHtml('<img src=x onerror=alert(1)>')
+// '&lt;img src=x onerror=alert(1)&gt;'
+```
+
+Set `renderPolicy: 'trusted'` only when the Markdown source is trusted. Trusted
+mode permits arbitrary URL schemes and ordinary raw HTML. The default
+`disallowedRawHtml` filter still removes GFM-disallowed tags; set it to `false`
+only when trusted content needs those tags. Trusted mode is not appropriate for
+untrusted user content.
+
+```js
+toHtml('<span class="note">Internal note</span>', {
+  renderPolicy: 'trusted',
+})
+// '<span class="note">Internal note</span>'
+```
+
+See [`Options`](./index.d.mts) for the complete optional syntax and rendering
+configuration. `transform()` also returns headings and optional front matter;
+the highlighter helpers below accept trusted highlighter HTML.
 
 ## Input size limit
 
@@ -61,7 +100,20 @@ toHtml('[guide](/guide)', { linkBasePath: '/docs' })
 
 Image sources and autolinks are not rewritten.
 
-The package supports Node.js 22 or newer on glibc Linux, macOS, and Windows for x64 and arm64. It does not include a WASM fallback.
+## Troubleshooting native loading
+
+The native binding loads on the first call to `toHtml()`, `transform()`, or a
+highlighter helper, not when this package is imported. If that call fails:
+
+| Message or environment | Resolution |
+| --- | --- |
+| Node.js below 22 | Upgrade to Node.js 22 or newer; this is the package's declared engine requirement. |
+| Alpine or another musl Linux environment | Use a glibc Linux environment. musl binaries are not published. |
+| Unsupported platform or architecture | Use macOS, Windows, or glibc Linux on x64 or arm64. |
+| `does not include a native binary` | Reinstall the published package and verify that installation did not omit its platform binary. |
+
+This package does not include a WASM fallback, so unsupported environments need
+one of the supported native runtimes rather than a JavaScript fallback.
 
 ## Native build profile
 

--- a/node/ferromark/package.json
+++ b/node/ferromark/package.json
@@ -46,7 +46,7 @@
   "scripts": {
     "build": "node ./scripts/build-native.mjs && node ./scripts/verify-package.mjs",
     "build:native": "node ./scripts/build-native.mjs",
-    "lint": "node --check index.mjs && node --check scripts/build-native.mjs && node --check scripts/verify-package.mjs && node --check scripts/verify-panic-unwind.mjs",
+    "lint": "node --check index.mjs && node --check scripts/build-native.mjs && node --check scripts/verify-package.mjs && node --check scripts/verify-panic-unwind.mjs && node scripts/test-readme-contract.mjs",
     "test": "node --test test/*.test.mjs && node ./scripts/verify-panic-unwind.mjs"
   },
   "publishConfig": {

--- a/node/ferromark/scripts/test-readme-contract.mjs
+++ b/node/ferromark/scripts/test-readme-contract.mjs
@@ -41,6 +41,11 @@ function assertReadmeContract(candidate) {
   assert.match(candidate, /unsafe link and image URL schemes/i, 'README must describe URL filtering')
   assert.match(candidate, /renderPolicy: 'trusted'/, 'README must show the trusted opt-in')
   assert.match(candidate, /only when the Markdown source is trusted/i, 'README must scope trusted mode')
+  assert.match(
+    candidate,
+    /'<p><span class="note">Internal note<\/span><\/p>\\n'/,
+    'README must show the actual trusted inline HTML output',
+  )
   assert.match(candidate, /\[`Options`\]\(\.\/index\.d\.mts\)/, 'README must link the typed options')
 
   assert.match(candidate, /^## Troubleshooting native loading$/m, 'README must explain lazy loader failures')
@@ -91,6 +96,11 @@ assert.throws(
   () => assertReadmeContract(readme.replace("renderPolicy: 'untrusted'", "renderPolicy: 'trusted'")),
   /default render policy/,
   'security documentation contract must reject a missing untrusted default',
+)
+assert.throws(
+  () => assertReadmeContract(readme.replace('<p><span class="note">Internal note</span></p>\\n', '<span class="note">Internal note</span>')),
+  /actual trusted inline HTML output/,
+  'security documentation contract must reject incorrect trusted output',
 )
 assert.throws(
   () => assertReadmeContract(readme.replace('Alpine or another musl Linux environment', 'Linux environment')),

--- a/node/ferromark/scripts/test-readme-contract.mjs
+++ b/node/ferromark/scripts/test-readme-contract.mjs
@@ -1,0 +1,101 @@
+import assert from 'node:assert/strict'
+import { readFile } from 'node:fs/promises'
+
+const readmeUrl = new URL('../README.md', import.meta.url)
+const packageUrl = new URL('../package.json', import.meta.url)
+const loaderUrl = new URL('../index.mjs', import.meta.url)
+const declarationUrl = new URL('../index.d.mts', import.meta.url)
+const nativeOptionsUrl = new URL('../../native/src/lib.rs', import.meta.url)
+const coreOptionsUrl = new URL('../../../src/lib.rs', import.meta.url)
+
+const [readme, packageJson, loader, declarations, nativeOptions, coreOptions] = await Promise.all([
+  readFile(readmeUrl, 'utf8'),
+  readFile(packageUrl, 'utf8').then(JSON.parse),
+  readFile(loaderUrl, 'utf8'),
+  readFile(declarationUrl, 'utf8'),
+  readFile(nativeOptionsUrl, 'utf8'),
+  readFile(coreOptionsUrl, 'utf8'),
+])
+
+function assertReadmeContract(candidate) {
+  assert.match(candidate, /^## Install$/m, 'README must have an install section')
+  assert.match(candidate, new RegExp(`npm install ${packageJson.name}`), 'README must show npm install')
+  assert.match(candidate, new RegExp(`pnpm add ${packageJson.name}`), 'README must show pnpm add')
+
+  const minimumNode = packageJson.engines.node.match(/^>=(\d+)/)?.[1]
+  assert.ok(minimumNode, 'package.json must declare a minimum Node major version')
+  assert.match(
+    candidate,
+    new RegExp(`Node\\.js ${minimumNode} or newer`),
+    'README must state the package Node.js requirement',
+  )
+
+  assert.match(candidate, /^## Untrusted by default$/m, 'README must explain the default trust boundary')
+  assert.match(declarations, /export type RenderPolicy = 'untrusted' \| 'trusted'/, 'declarations must expose both render policies')
+  assert.match(nativeOptions, /let mut options = CoreOptions::default\(\)/, 'Node options must start from core defaults')
+  const coreDefaultOptions = coreOptions.match(/impl Default for Options \{.*?\n\}/s)?.[0]
+  assert.ok(coreDefaultOptions, 'core must define default options')
+  assert.match(coreDefaultOptions, /render_policy: RenderPolicy::Untrusted/, 'core default policy must be untrusted')
+  assert.match(candidate, /renderPolicy: 'untrusted'/, 'README must name the default render policy')
+  assert.match(candidate, /raw HTML\s+is escaped/i, 'README must describe raw HTML escaping')
+  assert.match(candidate, /unsafe link and image URL schemes/i, 'README must describe URL filtering')
+  assert.match(candidate, /renderPolicy: 'trusted'/, 'README must show the trusted opt-in')
+  assert.match(candidate, /only when the Markdown source is trusted/i, 'README must scope trusted mode')
+  assert.match(candidate, /\[`Options`\]\(\.\/index\.d\.mts\)/, 'README must link the typed options')
+
+  assert.match(candidate, /^## Troubleshooting native loading$/m, 'README must explain lazy loader failures')
+  assert.match(candidate, /first call to `toHtml\(\)`, `transform\(\)`, or a\s+highlighter helper/i)
+
+  assert.match(loader, /musl is not supported/, 'loader must retain its musl diagnostic')
+  assert.match(candidate, /Alpine or another musl Linux environment/, 'README must cover the musl loader error')
+  assert.match(loader, /does not support \$\{process\.platform\}/, 'loader must retain unsupported-target diagnostics')
+  assert.match(candidate, /Unsupported platform or architecture/, 'README must cover unsupported targets')
+  assert.match(loader, /does not include a native binary/, 'loader must retain missing-binary diagnostics')
+  assert.match(candidate, /`does not include a native binary`/, 'README must cover missing binaries')
+
+  const loaderTargets = [...loader.matchAll(/'([a-z0-9]+-(?:arm64|x64))': '([a-z0-9-]+)'/g)]
+    .map(([, host, target]) => ({ host, target }))
+  const packageTargets = packageJson.napi.targets.map(packageTargetToBindingTarget)
+  assert.deepEqual(
+    loaderTargets.map(({ target }) => target).sort(),
+    packageTargets.slice().sort(),
+    'loader targets and published native targets must stay aligned',
+  )
+  assert.match(candidate, /glibc\s+Linux, macOS, and Windows on x64 and arm64/, 'README must state published platforms')
+  assert.match(candidate, /no WASM fallback/, 'README must state the missing fallback')
+}
+
+function packageTargetToBindingTarget(target) {
+  const match = target.match(/^(aarch64|x86_64)-(apple|unknown-linux|pc-windows)-(darwin|gnu|msvc)$/)
+  assert.ok(match, `unsupported napi target format: ${target}`)
+
+  const [, architecture, platform, abi] = match
+  const hostPlatform = {
+    apple: 'darwin',
+    'unknown-linux': 'linux',
+    'pc-windows': 'win32',
+  }[platform]
+  const hostArchitecture = architecture === 'aarch64' ? 'arm64' : 'x64'
+  const binding = `${hostPlatform}-${hostArchitecture}`
+  return abi === 'darwin' ? binding : `${binding}-${abi}`
+}
+
+assertReadmeContract(readme)
+
+assert.throws(
+  () => assertReadmeContract(readme.replace(`npm install ${packageJson.name}`, 'npm install')),
+  /npm install/,
+  'install documentation contract must reject a missing package name',
+)
+assert.throws(
+  () => assertReadmeContract(readme.replace("renderPolicy: 'untrusted'", "renderPolicy: 'trusted'")),
+  /default render policy/,
+  'security documentation contract must reject a missing untrusted default',
+)
+assert.throws(
+  () => assertReadmeContract(readme.replace('Alpine or another musl Linux environment', 'Linux environment')),
+  /musl loader error/,
+  'loader troubleshooting contract must reject missing musl guidance',
+)
+
+console.log('Node README package, security, and loader contract checks passed')


### PR DESCRIPTION
Fixes #161

## Summary

- add npm and pnpm installation guidance and the exact Node/native platform support boundary
- document untrusted-by-default rendering, the trusted opt-in, typed options, and the highlighter trust boundary
- add first-call native-loader troubleshooting for Node, musl/Alpine, unsupported targets, and missing binaries
- enforce those public claims with a package, loader, declaration, and core-default README contract with negative mutations

## Validation

- Node frozen install, build, test, typecheck, lint, pack check, and clean-install smoke test
- Rust workspace all-features tests and doctests on stable and Rust 1.88
- strict Clippy, Rustdoc, formatting, workflow-pin, native-matrix, publish-verification, and diff checks

The npm audit remains red only for the unchanged transitive `@napi-rs/cli > js-yaml` advisory.

🔧 Emily Carter · Implementation Agent
