### PR TITLE
docs: refresh crate rustdoc

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2708,11 +2708,26 @@ More text."#;
 
 #[cfg(test)]
 mod crate_docs_tests {
-    use super::RenderPolicy;
+    use super::{Options, RenderPolicy};
+
+    fn documented_default_policy(crate_docs: &str) -> RenderPolicy {
+        const UNTRUSTED_DEFAULT: &str = "Its default\n//! [`RenderPolicy::Untrusted`] escapes raw HTML and restricts unsafe URL";
+        const TRUSTED_DEFAULT: &str =
+            "Its default\n//! [`RenderPolicy::Trusted`] preserves raw HTML and arbitrary URL";
+
+        match (
+            crate_docs.contains(UNTRUSTED_DEFAULT),
+            crate_docs.contains(TRUSTED_DEFAULT),
+        ) {
+            (true, false) => RenderPolicy::Untrusted,
+            (false, true) => RenderPolicy::Trusted,
+            _ => panic!("crate docs must identify exactly one default render policy"),
+        }
+    }
 
     #[test]
     fn crate_docs_describe_current_security_feature_and_simd_contracts() {
-        let source = include_str!("lib.rs");
+        let source = include_str!("lib.rs").replace("\r\n", "\n");
         let crate_docs = source
             .split_once("pub mod block;")
             .expect("crate docs must precede the public module declarations")
@@ -2720,8 +2735,11 @@ mod crate_docs_tests {
         let cargo_toml = include_str!("../Cargo.toml");
         let simd_source = include_str!("inline/simd.rs").replace("\r\n", "\n");
 
-        assert_eq!(RenderPolicy::default(), RenderPolicy::Untrusted);
-        assert!(crate_docs.contains("RenderPolicy::Untrusted"));
+        assert_eq!(
+            documented_default_policy(crate_docs),
+            Options::default().render_policy,
+            "crate docs must describe the policy used by default public render entry points",
+        );
         assert!(crate_docs.contains("`mdx` Cargo feature"));
         assert!(crate_docs.contains("AArch64 builds with NEON enabled"));
         assert!(crate_docs.contains("x86-64"));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2718,7 +2718,7 @@ mod crate_docs_tests {
             .expect("crate docs must precede the public module declarations")
             .0;
         let cargo_toml = include_str!("../Cargo.toml");
-        let simd_source = include_str!("inline/simd.rs");
+        let simd_source = include_str!("inline/simd.rs").replace("\r\n", "\n");
 
         assert_eq!(RenderPolicy::default(), RenderPolicy::Untrusted);
         assert!(crate_docs.contains("RenderPolicy::Untrusted"));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,18 +1,28 @@
-//! ferromark: Ultra-high-performance Markdown to HTML compiler
+//! Markdown to HTML with a secure rendering default.
 //!
-//! This crate provides a streaming Markdown parser optimized for speed,
-//! targeting 20-30% better throughput than existing Rust parsers.
+//! ferromark streams Markdown into HTML without building an AST. Its default
+//! [`RenderPolicy::Untrusted`] escapes raw HTML and restricts unsafe URL
+//! schemes. Use [`Options`] to select syntax extensions and rendering policy.
 //!
-//! # Design Principles
-//! - No AST: streaming events only
-//! - No regex: pure byte-level scanning
-//! - No backtracking: O(n) time on all inputs
-//! - Minimal allocations: ranges into input buffer
+//! # Quick start
 //!
-//! # Future Optimizations
-//! - `simdutf` / `simdutf8`: SIMD-accelerated UTF-8 validation for input
-//! - NEON intrinsics for ARM: inline marker scanning
-//! - Loop unrolling in hot paths (4x unroll like md4c)
+//! ```
+//! let html = ferromark::to_html("# Hello\n\n**World**");
+//!
+//! assert_eq!(html, "<h1 id=\"hello\">Hello</h1>\n<p><strong>World</strong></p>\n");
+//! ```
+//!
+//! # Optional MDX support
+//!
+//! Enable the `mdx` Cargo feature to segment and render MDX documents. The
+//! feature is opt-in and does not alter the default Markdown renderer.
+//!
+//! # Platform optimizations
+//!
+//! The inline-specials scanner uses NEON on AArch64 builds with NEON enabled
+//! and baseline SSE2 on x86-64. When neither path is available, it uses the
+//! scalar scanner. See the repository benchmark documentation for current,
+//! reproducible measurements.
 
 pub mod block;
 pub mod cursor;
@@ -2693,6 +2703,36 @@ More text."#;
             "Alt text should be plain: {html}"
         );
         assert!(!html.contains("<strong>"), "No <strong> tags in alt text");
+    }
+}
+
+#[cfg(test)]
+mod crate_docs_tests {
+    use super::RenderPolicy;
+
+    #[test]
+    fn crate_docs_describe_current_security_feature_and_simd_contracts() {
+        let source = include_str!("lib.rs");
+        let crate_docs = source
+            .split_once("pub mod block;")
+            .expect("crate docs must precede the public module declarations")
+            .0;
+        let cargo_toml = include_str!("../Cargo.toml");
+        let simd_source = include_str!("inline/simd.rs");
+
+        assert_eq!(RenderPolicy::default(), RenderPolicy::Untrusted);
+        assert!(crate_docs.contains("RenderPolicy::Untrusted"));
+        assert!(crate_docs.contains("`mdx` Cargo feature"));
+        assert!(crate_docs.contains("AArch64 builds with NEON enabled"));
+        assert!(crate_docs.contains("x86-64"));
+        assert!(!crate_docs.contains("targeting 20-30% better throughput"));
+        assert!(!crate_docs.contains("Future Optimizations"));
+        assert!(!crate_docs.contains("NEON intrinsics for ARM"));
+
+        assert!(cargo_toml.contains("mdx = []"));
+        assert!(simd_source.contains("target_arch = \"x86_64\""));
+        assert!(simd_source.contains("target_arch = \"aarch64\""));
+        assert!(simd_source.contains("target_feature = \"neon\""));
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2730,9 +2730,24 @@ mod crate_docs_tests {
         assert!(!crate_docs.contains("NEON intrinsics for ARM"));
 
         assert!(cargo_toml.contains("mdx = []"));
-        assert!(simd_source.contains("target_arch = \"x86_64\""));
-        assert!(simd_source.contains("target_arch = \"aarch64\""));
-        assert!(simd_source.contains("target_feature = \"neon\""));
+        assert!(simd_source.contains(
+            r#"#[cfg(all(target_arch = "aarch64", target_feature = "neon"))]
+#[target_feature(enable = "neon")]
+pub unsafe fn has_inline_specials_simd"#,
+        ));
+        assert!(simd_source.contains(
+            r#"#[cfg(target_arch = "x86_64")]
+#[inline]
+pub unsafe fn has_inline_specials_simd"#,
+        ));
+        assert!(simd_source.contains(
+            r#"#[cfg(not(any(
+    target_arch = "x86_64",
+    all(target_arch = "aarch64", target_feature = "neon")
+)))]
+#[allow(dead_code)]
+pub fn has_inline_specials_simd"#,
+        ));
     }
 }
 


### PR DESCRIPTION
Fixes #160

## Summary

- Replace stale crate-level throughput and “future NEON” claims with current, scoped documentation.
- Document the secure defaults, reusable options, MDX feature surface, and current AArch64 NEON/x86-64 SSE2 acceleration paths.
- Add an executable doctest and a drift contract tied to the actual default policy, feature declaration, and architecture-specific source paths.

## Validation

- `cargo test --workspace --locked --all-features`
- stable and Rust 1.88 all-feature doctests
- `RUSTDOCFLAGS='-D warnings' cargo doc --workspace --locked --all-features --no-deps`
- strict all-target/all-feature Clippy
- `cargo fmt --check`
- workflow pin, native-matrix, and publish-contract tests
- `git diff --check`

🔧 Emily Carter · Implementation Agent
