### PR TITLE
docs: add migration guide for 0.4 to 0.7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,6 +56,7 @@ jobs:
       - run: ruby ./scripts/test-contributing-ci-contract.rb --self-test
       - run: ruby ./scripts/test-docs-rs-metadata.rb --self-test
       - run: RUSTDOCFLAGS='-D warnings' cargo doc --locked --no-deps --no-default-features --features mdx
+      - run: ruby ./scripts/test-migration-guide-contract.rb --self-test
       - run: ./scripts/check-workflow-pins.sh
 
   rustsec:

--- a/README.md
+++ b/README.md
@@ -299,6 +299,8 @@ let html = ferromark::to_html_with_options(trusted_markdown, &options);
 
 Upgrading from an older release? See the [0.8 migration guide](docs/migration-0.8.md)
 for the `Options` and event-match migration, the
+[0.4–0.7 migration guide](docs/migration-0.4.md) for `Profile`, inline-parser,
+fenced-renderer, Rust, and Node.js changes, the
 [0.2 migration guide](docs/migration-0.2.md) for the rendering default and the
 fallible UTF-8 and MDX APIs, and the
 [0.3 migration guide](docs/migration-0.3.md) for removed Cargo features and the

--- a/docs/migration-0.4.md
+++ b/docs/migration-0.4.md
@@ -1,0 +1,212 @@
+# Migrating from ferromark 0.3 to 0.7
+
+This guide covers the breaking release boundaries from 0.3.3 through 0.7.0:
+0.4 removes `Profile`, 0.5 extends the configurable inline-parser API, 0.6
+changes several Rust integration types, and 0.7 raises the Rust and Node.js
+runtime floors. Apply the sections in order when upgrading across more than
+one release.
+
+If you are upgrading from 0.2 or earlier, read the [0.2 migration
+guide](migration-0.2.md) and the [0.3 migration guide](migration-0.3.md)
+first. If you also adopt the upcoming 0.8 API changes, continue with the [0.8
+migration guide](migration-0.8.md).
+
+## Before you start
+
+Update the Rust toolchain and, for the npm package, Node.js before changing
+source code. Then run `cargo check --all-features`; this also checks the
+opt-in `mdx` feature. Keep `features = ["mdx"]` in a Cargo dependency
+declaration when your application uses the Rust MDX APIs: this feature remains
+opt-in throughout these releases.
+
+## 0.4: replace `Profile`
+
+`Profile` and `Options::from(Profile)` were added in 0.3.1 and removed in
+0.4. Choose the syntax surface explicitly with `Options::minimal()`,
+`Options::commonmark()`, `Options::gfm()`, or `Options::default()`, then
+change the public fields your application needs. The render policy remains
+separate from those syntax choices.
+
+For the former `Profile::Extended`, `Options::default()` preserves the 0.3
+profile's default option set:
+
+```rust
+// Before (0.3.1–0.3.3)
+use ferromark::{Options, Profile};
+
+let options = Options::from(Profile::Extended);
+```
+
+<!-- migration-example: profile-extended -->
+```rust
+// After (0.4+)
+use ferromark::Options;
+
+let options = Options::default();
+assert!(options.allow_html);
+assert!(options.tables);
+```
+
+Do not assume that another `Profile` has a one-to-one preset replacement.
+Start from the closest preset and set the required fields explicitly. For
+example, a GFM-oriented configuration starts with `Options::gfm()`; select
+`RenderPolicy::Trusted` separately only for Markdown you trust.
+
+## 0.5: update configurable inline parsing
+
+`Options` gained `inline_footnotes`, which enables Pandoc-style `^[note]`
+syntax. Code that constructed an `Options` literal for 0.4 must set the new
+field (normally `false` to preserve the prior behavior).
+
+The public `InlineParser::parse_with_options` method also gained the
+`inline_footnotes: bool` positional argument between `math` and
+`footnote_store`. Insert `false` when retaining the 0.4 behavior, or `true`
+when handling inline-footnote syntax:
+
+```rust,ignore
+// Before (0.4): `false` is the `math` argument, then the footnote store.
+parser.parse_with_options(
+    text, refs, true, true, false, false, false, true, false, None, &mut events,
+);
+```
+
+<!-- migration-example: inline-parser-argument -->
+```rust
+// After (0.5+): the new `false` follows the `math` argument.
+use ferromark::{InlineEvent, InlineParser};
+
+let mut parser = InlineParser::new();
+let mut events = Vec::<InlineEvent>::new();
+parser.parse_with_options(
+    b"plain text",
+    None,
+    true,
+    true,
+    false,
+    false,
+    false,
+    true,
+    false, // math
+    false, // inline_footnotes
+    None,
+    &mut events,
+);
+assert!(!events.is_empty());
+```
+
+`InlineEvent` also gained `InlineFootnote(Range)`. Add handling for that
+variant to exhaustive `InlineEvent` matches. Its range covers the note content
+without the surrounding `^[` and `]`.
+
+## 0.6: clone options and make integration matches forward-compatible
+
+`Options` no longer implements `Copy` because it now owns the optional
+`link_base_path`. Clone an `Options` value at a former implicit-copy site when
+you need to retain it. `link_base_path` itself prefixes internal absolute link
+destinations; it does not rewrite image sources or autolinks.
+
+```rust,ignore
+// Before (0.5): this copied `options`.
+let options_for_second_use = options;
+```
+
+<!-- migration-example: options-clone -->
+```rust
+// After (0.6+): clone when both values are needed.
+use ferromark::Options;
+
+let options = Options::default();
+let options_for_second_use = options.clone();
+assert_eq!(options, options_for_second_use);
+```
+
+`FencedCodeBlock` gained a decoded `meta` field and is now
+`#[non_exhaustive]`. Custom fenced-code renderers must use `..` in patterns so
+future fields do not break their build. Read `meta` when a highlighter supports
+info-string metadata such as `{1-3}`.
+
+```rust,ignore
+// Before (0.5): this pattern named every field.
+fn render(block: ferromark::FencedCodeBlock<'_>) {
+    let ferromark::FencedCodeBlock { language, code } = block;
+    let _ = (language, code);
+}
+```
+
+<!-- migration-example: fenced-code-pattern -->
+```rust
+// After (0.6+)
+use ferromark::{FencedCodeBlock, FencedCodeRenderer, TrustedHtml};
+
+struct Highlighter;
+
+impl FencedCodeRenderer for Highlighter {
+    fn render(&mut self, block: FencedCodeBlock<'_>) -> Option<TrustedHtml> {
+        let FencedCodeBlock {
+            language,
+            meta,
+            code,
+            ..
+        } = block;
+        let _ = (language, meta, code);
+        None
+    }
+}
+```
+
+`parse`, `parse_with_options`, and `parse_with_renderer` now return document
+headings alongside HTML and front matter. If your code constructs or
+destructures `ParseResult`, account for `headings`:
+
+```rust,ignore
+// Before (0.5)
+let ferromark::ParseResult { html, front_matter } = ferromark::parse(input);
+```
+
+<!-- migration-example: parse-result-headings -->
+```rust
+// After (0.6+)
+use ferromark::{ParseResult, parse};
+
+let ParseResult {
+    html,
+    front_matter,
+    headings,
+} = parse("# Guide");
+assert!(front_matter.is_none());
+assert!(html.contains("Guide"));
+assert_eq!(headings[0].text, "Guide");
+```
+
+The Node package did not remove a callable API in 0.6. It added `transform()`
+and `transformWithHighlighter()` for the same HTML, heading, and front-matter
+metadata; use those functions when the extra metadata is needed.
+
+## 0.7: raise runtime prerequisites
+
+ferromark 0.7 requires Rust 1.88 or newer. Update the compiler used by local
+builds and CI before updating the crate version:
+
+```sh
+rustup toolchain install 1.88
+cargo +1.88 check --all-features
+```
+
+The published `ferromark` npm package requires Node.js 22.0.0 or newer. Update
+the runtime before running `npm install ferromark` or loading the native
+module. Repository contributors who run the `node/` workspace also need its
+pinned pnpm 11.17.0 toolchain and Node.js 22.13.0 or newer.
+
+## Validate the completed upgrade
+
+Run the checks that match the surfaces your project uses:
+
+```sh
+cargo check --all-features
+# For npm consumers, verify that `node --version` is 22.0.0 or newer.
+```
+
+For custom renderers, include a fenced block with an info string in a local
+test and verify that unknown future fields are ignored by the `..` pattern.
+For inline-parser users, exercise both the `inline_footnotes: false` path and,
+when enabled, a `^[note]` input.

--- a/scripts/test-migration-guide-contract.rb
+++ b/scripts/test-migration-guide-contract.rb
@@ -1,0 +1,188 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require 'fileutils'
+require 'open3'
+require 'tmpdir'
+
+class ContractError < StandardError; end
+
+GUIDE_PATH = 'docs/migration-0.4.md'
+EXAMPLES = %w[
+  profile-extended
+  inline-parser-argument
+  options-clone
+  fenced-code-pattern
+  parse-result-headings
+].freeze
+
+def fail_contract(message)
+  raise ContractError, "migration guide contract: #{message}"
+end
+
+def extract_example(document, name)
+  marker = "<!-- migration-example: #{name} -->"
+  start = document.index(marker)
+  fail_contract("must contain #{marker}") unless start
+
+  block = document[(start + marker.length)..]
+  match = block.match(/\A[ \t\r\n]*```rust\r?\n(?<code>.*?)^```[ \t]*\r?$/m)
+  fail_contract("#{name} must be followed by a Rust code block") unless match
+
+  match[:code]
+end
+
+def assert_contains(document, needle, message)
+  fail_contract(message) unless document.include?(needle)
+end
+
+def validate_document(document, readme, cargo_toml, node_package, node_workspace, changelog)
+  assert_contains(document, '# Migrating from ferromark 0.3 to 0.7', 'must name its supported upgrade range')
+  [
+    '## Before you start',
+    '## 0.4: replace `Profile`',
+    '## 0.5: update configurable inline parsing',
+    '## 0.6: clone options and make integration matches forward-compatible',
+    '## 0.7: raise runtime prerequisites',
+    '## Validate the completed upgrade'
+  ].each { |heading| assert_contains(document, heading, "must contain #{heading}") }
+
+  assert_contains(readme, "[0.4–0.7 migration guide](#{GUIDE_PATH})", 'README must link the 0.4–0.7 guide')
+  assert_contains(document, 'Options::from(Profile)', 'must explain the removed Profile conversion')
+  assert_contains(document, 'inline_footnotes: bool', 'must name the inserted inline-parser argument')
+  assert_contains(document, 'InlineFootnote(Range)', 'must name the added inline event')
+  assert_contains(document, 'Options` no longer implements `Copy`', 'must explain the Options Copy removal')
+  assert_contains(document, '`#[non_exhaustive]`', 'must explain the fenced-code forward-compatibility contract')
+  assert_contains(document, '`headings`', 'must explain the ParseResult metadata field')
+  [
+    'remove Profile and Options::from(Profile)',
+    'a positional parse_with_options argument',
+    'Options no longer implements Copy',
+    'FencedCodeBlock gained the meta field and is now non_exhaustive',
+    'ferromark now requires Rust 1.88 or newer',
+    'ferromark npm package now requires Node.js 22 or newer'
+  ].each { |change| assert_contains(changelog, change, "CHANGELOG must record #{change.inspect}") }
+
+  rust_version = cargo_toml[/^rust-version\s*=\s*"([^"]+)"\s*$/, 1]
+  fail_contract('Cargo.toml must declare rust-version') unless rust_version
+  assert_contains(document, "requires Rust #{rust_version} or newer", 'must state Cargo.toml Rust requirement')
+
+  node_version = node_package[/"node"\s*:\s*">=([0-9]+(?:\.[0-9]+){0,2})"/, 1]
+  fail_contract('node package must declare a minimum Node version') unless node_version
+  assert_contains(document, "Node.js #{node_version} or newer", 'must state npm package Node requirement')
+
+  workspace_node = node_workspace[/"node"\s*:\s*">=([0-9]+(?:\.[0-9]+){0,2})"/, 1]
+  workspace_pnpm = node_workspace[/"packageManager"\s*:\s*"pnpm@([^"]+)"/, 1]
+  fail_contract('node workspace must declare a minimum Node version') unless workspace_node
+  fail_contract('node workspace must pin pnpm') unless workspace_pnpm
+  assert_contains(document, "pnpm #{workspace_pnpm}", 'must state the node workspace pnpm version')
+  assert_contains(document, "Node.js #{workspace_node} or newer", 'must state the node workspace Node requirement')
+
+  EXAMPLES.each { |name| extract_example(document, name) }
+  assert_contains(
+    extract_example(document, 'inline-parser-argument'),
+    'false, // inline_footnotes',
+    'inline parser example must preserve the new argument position'
+  )
+  assert_contains(
+    extract_example(document, 'fenced-code-pattern'),
+    '..',
+    'fenced-code example must ignore future fields'
+  )
+end
+
+def compile_examples(repository_root, document)
+  examples = EXAMPLES.map { |name| [name, extract_example(document, name)] }
+
+  Dir.mktmpdir('ferromark-migration-guide.') do |directory|
+    File.write(File.join(directory, 'Cargo.toml'), <<~TOML)
+      [package]
+      name = "ferromark-migration-guide-contract"
+      version = "0.0.0"
+      edition = "2024"
+
+      [dependencies]
+      ferromark = { path = #{repository_root.inspect}, features = ["mdx"] }
+    TOML
+    FileUtils.mkdir_p(File.join(directory, 'src'))
+    functions = examples.map do |name, code|
+      "fn #{name.tr('-', '_')}() {\n#{code.lines.map { |line| "  #{line}" }.join}\n}\n"
+    end.join("\n")
+    File.write(File.join(directory, 'src/main.rs'), "#![allow(dead_code)]\n\n#{functions}\nfn main() {}\n")
+
+    stdout, stderr, status = Open3.capture3(
+      'cargo', 'check', '--quiet', '--manifest-path', File.join(directory, 'Cargo.toml')
+    )
+    next if status.success?
+
+    fail_contract("documented Rust examples must compile:\n#{stdout}#{stderr}")
+  end
+end
+
+def validate(repository_root)
+  guide = File.read(File.join(repository_root, GUIDE_PATH))
+  readme = File.read(File.join(repository_root, 'README.md'))
+  cargo_toml = File.read(File.join(repository_root, 'Cargo.toml'))
+  node_package = File.read(File.join(repository_root, 'node/ferromark/package.json'))
+  node_workspace = File.read(File.join(repository_root, 'node/package.json'))
+  changelog = File.read(File.join(repository_root, 'CHANGELOG.md'))
+  validate_document(guide, readme, cargo_toml, node_package, node_workspace, changelog)
+  compile_examples(repository_root, guide)
+end
+
+def assert_rejected(label)
+  yield
+  raise "#{label} mutation unexpectedly passed"
+rescue ContractError
+  # Expected: this mutation must be rejected by the contract.
+end
+
+def self_test(repository_root)
+  validate(repository_root)
+
+  guide = File.read(File.join(repository_root, GUIDE_PATH))
+  readme = File.read(File.join(repository_root, 'README.md'))
+  cargo_toml = File.read(File.join(repository_root, 'Cargo.toml'))
+  node_package = File.read(File.join(repository_root, 'node/ferromark/package.json'))
+  node_workspace = File.read(File.join(repository_root, 'node/package.json'))
+  changelog = File.read(File.join(repository_root, 'CHANGELOG.md'))
+
+  assert_rejected('README guide link') do
+    validate_document(
+      guide,
+      readme.sub("[0.4–0.7 migration guide](#{GUIDE_PATH})", 'migration guide'),
+      cargo_toml,
+      node_package,
+      node_workspace,
+      changelog
+    )
+  end
+  assert_rejected('inline parser argument') do
+    validate_document(guide.sub('false, // inline_footnotes', 'None, // footnote_store'), readme, cargo_toml, node_package, node_workspace, changelog)
+  end
+  assert_rejected('fenced-code fallback pattern') do
+    validate_document(guide.sub("            ..\n", ''), readme, cargo_toml, node_package, node_workspace, changelog)
+  end
+  assert_rejected('Rust version') do
+    validate_document(guide.sub('requires Rust 1.88 or newer', 'requires Rust 1.85 or newer'), readme, cargo_toml, node_package, node_workspace, changelog)
+  end
+  assert_rejected('Node version') do
+    validate_document(guide.sub('Node.js 22.0.0 or newer', 'Node.js 20.0.0 or newer'), readme, cargo_toml, node_package, node_workspace, changelog)
+  end
+end
+
+repository_root = File.expand_path('..', __dir__)
+
+begin
+  if ARGV == ['--self-test']
+    self_test(repository_root)
+  elsif ARGV.empty?
+    validate(repository_root)
+  else
+    abort 'usage: test-migration-guide-contract.rb [--self-test]'
+  end
+rescue ContractError => error
+  abort error.message
+end
+
+puts 'Migration guide contract checks passed'


### PR DESCRIPTION
Fixes #158

## Summary

- Add a release- and tag-verified migration guide covering the 0.3-to-0.7 path, including Profile removal, inline parser/events, Options, FencedCodeBlock, ParseResult, and the Rust/Node version floors.
- Link the guide from the README.
- Add a CI migration contract that validates manifest/changelog/navigation facts, exercises negative mutations, and compiles the post-migration Rust snippets.

## Validation

- migration contract self-test
- Node README contract
- `cargo test --workspace --locked --all-features`
- Rust 1.88 workspace all-feature tests
- `RUSTDOCFLAGS='-D warnings' cargo doc --workspace --locked --all-features --no-deps`
- `cargo clippy --all-targets --all-features --locked -- -D warnings`
- `cargo fmt --check`
- contributing and Node CI contracts
- workflow pin test
- `git diff --check`

🔧 Emily Carter · Implementation Agent
