### PR TITLE
feat(cli): add documented command interface

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,7 @@ jobs:
       - run: ruby ./scripts/test-docs-rs-metadata.rb --self-test
       - run: RUSTDOCFLAGS='-D warnings' cargo doc --locked --no-deps --no-default-features --features mdx
       - run: ruby ./scripts/test-migration-guide-contract.rb --self-test
+      - run: ruby ./scripts/test-readme-structure-contract.rb --self-test
       - run: ./scripts/check-workflow-pins.sh
 
   rustsec:

--- a/README.md
+++ b/README.md
@@ -209,6 +209,18 @@ blocks remain available.
 
 ## Markdown configuration
 
+## CLI
+
+`cargo install ferromark` installs `ferromark`, which reads Markdown from a file
+or standard input and writes HTML to standard output. Use `ferromark --help` for
+the complete interface. `--gfm`, `--commonmark`, and `--minimal` select syntax
+presets; output remains safely untrusted unless `--trusted` is explicitly set.
+
+```sh
+ferromark --gfm README.md -o README.html
+printf '# Hello\n' | ferromark --no-heading-ids
+```
+
 Start from the syntax contract you need, then enable individual extensions:
 
 - `Options::minimal()` keeps the smallest Markdown surface and disables raw

--- a/README.md
+++ b/README.md
@@ -215,6 +215,8 @@ blocks remain available.
 or standard input and writes HTML to standard output. Use `ferromark --help` for
 the complete interface. `--gfm`, `--commonmark`, and `--minimal` select syntax
 presets; output remains safely untrusted unless `--trusted` is explicitly set.
+`--trusted` also disables GFM's disallowed-raw-HTML filter, so raw HTML parsed
+by the selected syntax preset is preserved; use it only for Markdown you trust.
 
 ```sh
 ferromark --gfm README.md -o README.html

--- a/README.md
+++ b/README.md
@@ -207,8 +207,6 @@ Set `indented_code_blocks: false` for dialects that require fenced code blocks
 and interpret four-space indentation as ordinary paragraph content. Fenced code
 blocks remain available.
 
-## Markdown configuration
-
 ## CLI
 
 `cargo install ferromark` installs `ferromark`, which reads Markdown from a file
@@ -222,6 +220,8 @@ by the selected syntax preset is preserved; use it only for Markdown you trust.
 ferromark --gfm README.md -o README.html
 printf '# Hello\n' | ferromark --no-heading-ids
 ```
+
+## Markdown configuration
 
 Start from the syntax contract you need, then enable individual extensions:
 

--- a/scripts/test-readme-structure-contract.rb
+++ b/scripts/test-readme-structure-contract.rb
@@ -1,0 +1,90 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+class ContractError < StandardError; end
+
+README_PATH = 'README.md'
+MIGRATION_GUIDE = '[0.4–0.7 migration guide](docs/migration-0.4.md)'
+
+def fail_contract(message)
+  raise ContractError, "README structure contract: #{message}"
+end
+
+def section(document, heading)
+  start = document.index("## #{heading}\n")
+  fail_contract("must contain a #{heading.inspect} section") unless start
+
+  content_start = start + heading.length + 4
+  following_heading = document.index(/^## /, content_start)
+  document[content_start...(following_heading || document.length)]
+end
+
+def validate(document)
+  headings = document.scan(/^## (.+)$/).flatten
+  fail_contract('must not repeat top-level headings') unless headings.uniq.length == headings.length
+
+  headings.each do |heading|
+    fail_contract("#{heading.inspect} must not be empty") if section(document, heading).strip.empty?
+  end
+
+  cli_start = document.index("## CLI\n")
+  configuration_start = document.index("## Markdown configuration\n")
+  unless cli_start && configuration_start && cli_start < configuration_start
+    fail_contract('CLI must precede Markdown configuration so each section owns its content')
+  end
+
+  cli = section(document, 'CLI')
+  configuration = section(document, 'Markdown configuration')
+  fail_contract('CLI must document installation') unless cli.include?('cargo install ferromark')
+  fail_contract('CLI must document trusted mode') unless cli.include?('--trusted')
+  fail_contract('Markdown configuration must describe presets') unless configuration.include?('Options::minimal()')
+  unless configuration.include?('`Options` is non-exhaustive')
+    fail_contract('Markdown configuration must document Options construction')
+  end
+  fail_contract('README must preserve the migration guide link') unless document.include?(MIGRATION_GUIDE)
+end
+
+def assert_rejected(label)
+  yield
+  raise "#{label} mutation unexpectedly passed"
+rescue ContractError
+  # Expected: the contract must reject this mutation.
+end
+
+def self_test(document)
+  validate(document)
+
+  assert_rejected('empty Markdown configuration') do
+    validate(
+      document.sub(
+        "## Markdown configuration\n\nStart from",
+        "## Markdown configuration\n\n## Configuration details\n\nStart from"
+      )
+    )
+  end
+  assert_rejected('misowned Markdown configuration content') do
+    validate(document.sub("## Markdown configuration\n", ''))
+  end
+  assert_rejected('CLI trusted guidance') do
+    validate(document.gsub('--trusted', '--safe'))
+  end
+  assert_rejected('migration guide link') do
+    validate(document.sub(MIGRATION_GUIDE, 'migration guide'))
+  end
+end
+
+document = File.read(File.expand_path("../#{README_PATH}", __dir__))
+
+begin
+  if ARGV == ['--self-test']
+    self_test(document)
+  elsif ARGV.empty?
+    validate(document)
+  else
+    abort 'usage: test-readme-structure-contract.rb [--self-test]'
+  end
+rescue ContractError => error
+  abort error.message
+end
+
+puts 'README structure contract checks passed'

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,21 +1,104 @@
-//! ferromark CLI - Ultra-high-performance Markdown to HTML compiler
+//! Command-line interface for rendering Markdown as HTML.
 
+use std::error::Error;
 use std::io::{self, Read, Write};
+use std::path::PathBuf;
 
-fn main() -> io::Result<()> {
-    let args: Vec<String> = std::env::args().collect();
+use ferromark::{Options, RenderPolicy, to_html_with_options};
 
-    // Simple usage: read from stdin or file
-    let input = if args.len() > 1 && args[1] != "-" {
-        std::fs::read_to_string(&args[1])?
-    } else {
-        let mut buf = String::new();
-        io::stdin().read_to_string(&mut buf)?;
-        buf
+const USAGE: &str = "Usage: ferromark [OPTIONS] [INPUT]\n\nRender Markdown to HTML. INPUT is a file path or - for standard input.\n\nOptions:\n  -o, --output FILE       Write HTML to FILE\n      --minimal           Use the minimal Markdown preset\n      --commonmark        Use the CommonMark preset\n      --gfm               Use the GitHub Flavored Markdown preset\n      --trusted           Preserve raw HTML and unrestricted URL schemes\n      --front-matter      Strip leading front matter\n      --no-heading-ids    Do not generate heading ids\n  -h, --help              Print this help text\n  -V, --version           Print the version";
+
+struct Cli {
+    input: Option<PathBuf>,
+    output: Option<PathBuf>,
+    options: Options,
+    help: bool,
+    version: bool,
+}
+
+fn parse_args(args: impl IntoIterator<Item = String>) -> Result<Cli, String> {
+    let mut cli = Cli {
+        input: None,
+        output: None,
+        options: Options::default(),
+        help: false,
+        version: false,
     };
+    let mut args = args.into_iter();
+    while let Some(arg) = args.next() {
+        match arg.as_str() {
+            "-h" | "--help" => cli.help = true,
+            "-V" | "--version" => cli.version = true,
+            "--minimal" => cli.options = Options::minimal(),
+            "--commonmark" => cli.options = Options::commonmark(),
+            "--gfm" => cli.options = Options::gfm(),
+            "--trusted" => cli.options.render_policy = RenderPolicy::Trusted,
+            "--front-matter" => cli.options.front_matter = true,
+            "--no-heading-ids" => cli.options.heading_ids = false,
+            "-o" | "--output" => {
+                cli.output = Some(PathBuf::from(
+                    args.next()
+                        .ok_or_else(|| format!("{arg} requires a file path"))?,
+                ))
+            }
+            value if value.starts_with('-') && value != "-" => {
+                return Err(format!("unknown option: {value}"));
+            }
+            value => {
+                if cli.input.replace(PathBuf::from(value)).is_some() {
+                    return Err("only one input path is supported".into());
+                }
+            }
+        }
+    }
+    Ok(cli)
+}
 
-    let html = ferromark::to_html(&input);
-    io::stdout().write_all(html.as_bytes())?;
-
+fn run(cli: Cli) -> Result<(), Box<dyn Error>> {
+    if cli.help {
+        println!("{USAGE}");
+        return Ok(());
+    }
+    if cli.version {
+        println!("ferromark {}", env!("CARGO_PKG_VERSION"));
+        return Ok(());
+    }
+    let input = match cli.input.as_deref() {
+        Some(path) if path != std::path::Path::new("-") => std::fs::read_to_string(path)?,
+        _ => {
+            let mut input = String::new();
+            io::stdin().read_to_string(&mut input)?;
+            input
+        }
+    };
+    let html = to_html_with_options(&input, &cli.options);
+    match cli.output {
+        Some(path) => std::fs::write(path, html)?,
+        None => io::stdout().write_all(html.as_bytes())?,
+    }
     Ok(())
+}
+
+fn main() {
+    match parse_args(std::env::args().skip(1))
+        .and_then(|cli| run(cli).map_err(|error| error.to_string()))
+    {
+        Ok(()) => {}
+        Err(error) => {
+            eprintln!("ferromark: {error}\nTry 'ferromark --help' for usage.");
+            std::process::exit(2);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn parses_options() {
+        let cli = parse_args(["--gfm", "--trusted", "-o", "out", "in"].map(String::from)).unwrap();
+        assert_eq!(cli.options.render_policy, RenderPolicy::Trusted);
+        assert!(cli.options.tables);
+        assert_eq!(cli.output.unwrap(), PathBuf::from("out"));
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -24,17 +24,29 @@ fn parse_args(args: impl IntoIterator<Item = String>) -> Result<Cli, String> {
         help: false,
         version: false,
     };
+    let mut preset: Option<fn() -> Options> = None;
+    let mut trusted = false;
+    let mut front_matter = false;
+    let mut no_heading_ids = false;
+    let mut positional_only = false;
     let mut args = args.into_iter();
     while let Some(arg) = args.next() {
+        if positional_only {
+            if cli.input.replace(PathBuf::from(arg)).is_some() {
+                return Err("only one input path is supported".into());
+            }
+            continue;
+        }
         match arg.as_str() {
             "-h" | "--help" => cli.help = true,
             "-V" | "--version" => cli.version = true,
-            "--minimal" => cli.options = Options::minimal(),
-            "--commonmark" => cli.options = Options::commonmark(),
-            "--gfm" => cli.options = Options::gfm(),
-            "--trusted" => cli.options.render_policy = RenderPolicy::Trusted,
-            "--front-matter" => cli.options.front_matter = true,
-            "--no-heading-ids" => cli.options.heading_ids = false,
+            "--minimal" => preset = Some(Options::minimal),
+            "--commonmark" => preset = Some(Options::commonmark),
+            "--gfm" => preset = Some(Options::gfm),
+            "--trusted" => trusted = true,
+            "--front-matter" => front_matter = true,
+            "--no-heading-ids" => no_heading_ids = true,
+            "--" => positional_only = true,
             "-o" | "--output" => {
                 cli.output = Some(PathBuf::from(
                     args.next()
@@ -50,6 +62,18 @@ fn parse_args(args: impl IntoIterator<Item = String>) -> Result<Cli, String> {
                 }
             }
         }
+    }
+    if let Some(preset) = preset {
+        cli.options = preset();
+    }
+    if trusted {
+        cli.options.render_policy = RenderPolicy::Trusted;
+    }
+    if front_matter {
+        cli.options.front_matter = true;
+    }
+    if no_heading_ids {
+        cli.options.heading_ids = false;
     }
     Ok(cli)
 }
@@ -100,5 +124,20 @@ mod tests {
         assert_eq!(cli.options.render_policy, RenderPolicy::Trusted);
         assert!(cli.options.tables);
         assert_eq!(cli.output.unwrap(), PathBuf::from("out"));
+    }
+
+    #[test]
+    fn presets_do_not_override_explicit_flags_or_dash_paths() {
+        for args in [
+            ["--trusted", "--front-matter", "--no-heading-ids", "--gfm"],
+            ["--gfm", "--trusted", "--front-matter", "--no-heading-ids"],
+        ] {
+            let cli = parse_args(args.map(String::from)).unwrap();
+            assert_eq!(cli.options.render_policy, RenderPolicy::Trusted);
+            assert!(cli.options.front_matter);
+            assert!(!cli.options.heading_ids);
+        }
+        let cli = parse_args(["--", "-draft.md"].map(String::from)).unwrap();
+        assert_eq!(cli.input.unwrap(), PathBuf::from("-draft.md"));
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -68,6 +68,7 @@ fn parse_args(args: impl IntoIterator<Item = String>) -> Result<Cli, String> {
     }
     if trusted {
         cli.options.render_policy = RenderPolicy::Trusted;
+        cli.options.disallowed_raw_html = false;
     }
     if front_matter {
         cli.options.front_matter = true;
@@ -139,5 +140,31 @@ mod tests {
         }
         let cli = parse_args(["--", "-draft.md"].map(String::from)).unwrap();
         assert_eq!(cli.input.unwrap(), PathBuf::from("-draft.md"));
+    }
+
+    #[test]
+    fn trusted_mode_preserves_raw_html_independently_of_preset_order() {
+        for args in [
+            ["--trusted"].as_slice(),
+            ["--gfm", "--trusted"].as_slice(),
+            ["--trusted", "--gfm"].as_slice(),
+            ["--commonmark", "--trusted"].as_slice(),
+            ["--trusted", "--commonmark"].as_slice(),
+        ] {
+            let cli = parse_args(args.iter().map(|arg| (*arg).to_owned())).unwrap();
+            assert_eq!(cli.options.render_policy, RenderPolicy::Trusted);
+            assert!(!cli.options.disallowed_raw_html);
+            let html = to_html_with_options("<script>x()</script><style>p{}</style>", &cli.options);
+            assert_eq!(html, "<script>x()</script><style>p{}</style>");
+        }
+    }
+
+    #[test]
+    fn default_cli_mode_remains_untrusted() {
+        let cli = parse_args(std::iter::empty()).unwrap();
+        let html =
+            to_html_with_options("<script>x()</script>[x](javascript:alert(1))", &cli.options);
+        assert!(html.contains("&lt;script&gt;"), "{html}");
+        assert!(!html.contains("href=\"javascript:"), "{html}");
     }
 }


### PR DESCRIPTION
Fixes #157

## Summary

- Add help, version, preset, secure rendering, input, and output CLI options without a new dependency.
- Preserve stdin/file behavior and document explicit trusted-mode semantics.
- Add README CLI usage.

## Testing

- cargo test --workspace --locked --all-features
- cargo test --locked --bin ferromark
- cargo run -- --help and --version
- cargo fmt and clippy

🔧 Emily Carter · Implementation Agent