### PR TITLE
docs: add security and contribution templates

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @sebastian-software/maintainers

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,59 @@
+name: Bug report
+description: Report reproducible incorrect behavior in ferromark
+title: "bug: "
+body:
+  - type: markdown
+    attributes:
+      value: >-
+        Thanks for reporting a bug. For security vulnerabilities, follow
+        SECURITY.md instead of opening a public issue.
+  - type: input
+    id: version
+    attributes:
+      label: ferromark version
+      description: The crate or npm package version where the problem occurs.
+      placeholder: 0.7.0
+    validations:
+      required: true
+  - type: dropdown
+    id: interface
+    attributes:
+      label: Interface
+      options:
+        - Rust crate
+        - Node.js package
+        - CLI
+        - MDX
+        - Other
+    validations:
+      required: true
+  - type: textarea
+    id: input
+    attributes:
+      label: Minimal input and configuration
+      description: Include the smallest Markdown input and options that reproduce the issue.
+      render: markdown
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+      description: Include the rendered output or error and relevant environment details.
+    validations:
+      required: true
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Checks
+      options:
+        - label: I reproduced this with the latest published release.
+          required: true
+        - label: This report does not disclose a security vulnerability.
+          required: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,28 @@
+name: Feature request
+description: Propose a focused improvement to ferromark
+title: "feat: "
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: Describe the use case or limitation that motivates this request.
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: Explain the desired behavior and public API, if applicable.
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Describe current workarounds or other designs you considered.
+  - type: textarea
+    id: compatibility
+    attributes:
+      label: Compatibility considerations
+      description: Note relevant CommonMark, GFM, MDX, Rust, Node.js, or CLI behavior.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,14 @@
+## Summary
+
+<!-- Explain what changed and why. Link the issue with "Fixes #..." when applicable. -->
+
+## Testing
+
+<!-- List the commands or checks used to verify the change. -->
+
+## Checklist
+
+- [ ] The change is focused and preserves existing compatibility unless documented.
+- [ ] Tests cover behavior changes and regressions.
+- [ ] Public APIs and user-facing behavior are documented.
+- [ ] `cargo fmt --check` and relevant lint/test commands pass locally.

--- a/README.md
+++ b/README.md
@@ -863,3 +863,7 @@ This project is part of [Ferramenta](https://ferramenta.dev) — the family of R
   Copyright &copy; 2026 Sebastian Software GmbH
 </p>
 <!-- sebastian-software-branding:end -->
+
+## Security
+
+See [SECURITY.md](SECURITY.md) for vulnerability reporting.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,14 +2,21 @@
 
 ## Supported Versions
 
-Please prefer the latest release when reporting security issues.
+Security fixes are provided for the latest published release of ferromark.
+Older releases are not supported; users should upgrade before reporting an
+issue that is already fixed in the latest release.
 
 ## Reporting a Vulnerability
 
-If you discover a security vulnerability, please report it privately:
+Please email vulnerability reports to
+[info@sebastian-software.de](mailto:info@sebastian-software.de). This is the
+private contact address published by the repository's owning organization.
 
-1. Open a GitHub Security Advisory for this repository when available, or
-2. Contact the maintainers via the email listed in the repository profile or README.
+Do not open a public issue for a suspected vulnerability. Include the affected
+version, impact, reproduction steps or a proof of concept, and any suggested
+mitigation. Please allow the maintainers time to investigate before publishing
+details.
 
-Please include steps to reproduce, impact, and any suggested fix.
-Do not open a public issue for sensitive reports.
+You should receive an acknowledgement within three business days. The
+maintainers will coordinate status updates, remediation, and disclosure timing
+with you after validating the report.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,15 @@
+# Security Policy
+
+## Supported Versions
+
+Please prefer the latest release when reporting security issues.
+
+## Reporting a Vulnerability
+
+If you discover a security vulnerability, please report it privately:
+
+1. Open a GitHub Security Advisory for this repository when available, or
+2. Contact the maintainers via the email listed in the repository profile or README.
+
+Please include steps to reproduce, impact, and any suggested fix.
+Do not open a public issue for sensitive reports.


### PR DESCRIPTION
Fixes #177

Supersedes #213 because that fork branch cannot be updated by maintainers.

## Summary

- add a root security policy with a verified private contact and supported-version guidance
- add structured bug and feature issue forms
- add a pull request template
- assign the repository Maintainers team through CODEOWNERS

## Validation

- parsed both issue forms as YAML
- verified the Maintainers team has repository push access
- ran the README structure contract