### PR TITLE
feat(parser): report resource limit fallbacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,7 +259,10 @@ underlying table columns, while a merged cell spans those columns.
 
 For documentation pipelines, `parse()` / `parse_with_options()` return the
 rendered HTML together with the raw front matter block and a list of headings
-(level, id, plain text) for table-of-contents rendering;
+(level, id, plain text) for table-of-contents rendering. Their
+`resource_limits` report identifies any bounded parser operation that fell
+back to literal or truncated output; an empty report means no such fallback
+was used.
 `parse_with_renderer()` adds the opt-in fenced-code renderer to the same pass.
 `link_base_path` prefixes internal absolute link destinations (`/…`) for sites
 deployed under a subpath; image sources and autolinks are not rewritten.

--- a/docs/migration-0.4.md
+++ b/docs/migration-0.4.md
@@ -155,8 +155,8 @@ impl FencedCodeRenderer for Highlighter {
 ```
 
 `parse`, `parse_with_options`, and `parse_with_renderer` now return document
-headings alongside HTML and front matter. If your code constructs or
-destructures `ParseResult`, account for `headings`:
+`headings` and a `resource_limits` report alongside HTML and front matter. If
+your code constructs or destructures `ParseResult`, account for those fields:
 
 ```rust,ignore
 // Before (0.5)
@@ -172,10 +172,12 @@ let ParseResult {
     html,
     front_matter,
     headings,
+    resource_limits,
 } = parse("# Guide");
 assert!(front_matter.is_none());
 assert!(html.contains("Guide"));
 assert_eq!(headings[0].text, "Guide");
+assert!(resource_limits.is_empty());
 ```
 
 The Node package did not remove a callable API in 0.6. It added `transform()`

--- a/src/block/parser.rs
+++ b/src/block/parser.rs
@@ -1,7 +1,7 @@
 //! Block parser implementation.
 
 use crate::cursor::Cursor;
-use crate::limits;
+use crate::limits::{self, ResourceLimit, ResourceLimitReport};
 use crate::range::offset_to_u32;
 use crate::{InputSizeError, Range, validate_input_size};
 use smallvec::SmallVec;
@@ -222,6 +222,8 @@ pub struct BlockParser<'a> {
     definition_blank_before_next: bool,
     /// Blank-line state captured for the physical line currently being parsed.
     definition_current_line_loose: bool,
+    /// Resource-limit fallbacks used while parsing this document.
+    resource_limits: ResourceLimitReport,
 }
 
 impl<'a> BlockParser<'a> {
@@ -293,6 +295,7 @@ impl<'a> BlockParser<'a> {
             pending_definition_term: None,
             definition_blank_before_next: false,
             definition_current_line_loose: false,
+            resource_limits: ResourceLimitReport::default(),
         }
     }
 
@@ -338,6 +341,12 @@ impl<'a> BlockParser<'a> {
         // Close all open containers
         self.close_all_containers(events);
         self.close_all_definition_lists(events);
+    }
+
+    /// Return resource-limit fallbacks used while parsing this document.
+    #[must_use]
+    pub const fn resource_limits(&self) -> ResourceLimitReport {
+        self.resource_limits
     }
 
     /// Parse blocks and return internal metadata for each fenced code start.
@@ -692,14 +701,17 @@ impl<'a> BlockParser<'a> {
             };
             let line = &self.input[save_pos..line_end];
 
-            if let Some(alignments) = Self::is_delimiter_row(line)
+            if let Some((alignments, delimiter_truncated)) = Self::is_delimiter_row(line)
                 && !self.paragraph_lines.is_empty()
             {
                 let last_para_line = self.paragraph_lines.last().unwrap();
                 let header_line = last_para_line.slice(self.input);
-                let header_cells = self.table_cells(header_line);
+                let (header_cells, header_truncated) = self.table_cells(header_line);
 
                 if Self::table_width(&header_cells) == alignments.len() {
+                    if delimiter_truncated || header_truncated {
+                        self.resource_limits.record(ResourceLimit::TableColumns);
+                    }
                     let dash_counts = self
                         .options
                         .table_column_widths
@@ -724,19 +736,23 @@ impl<'a> BlockParser<'a> {
         }
 
         // Check for new container starts (blockquote, list)
-        if indent < 4 && self.container_stack.len() < limits::MAX_BLOCK_NESTING {
-            // Check for blockquote
-            if self.try_blockquote(events) {
-                // Recursively parse the rest of the line
-                self.parse_line_content(events);
-                return;
-            }
+        if indent < 4 {
+            if self.container_stack.len() < limits::MAX_BLOCK_NESTING {
+                // Check for blockquote
+                if self.try_blockquote(events) {
+                    // Recursively parse the rest of the line
+                    self.parse_line_content(events);
+                    return;
+                }
 
-            // Check for list item - either continuing an existing list or starting new
-            // Pass the pre-marker indent so content_indent can be calculated correctly
-            if self.try_list_item(indent, events) {
-                self.parse_line_content(events);
-                return;
+                // Check for list item - either continuing an existing list or starting new
+                // Pass the pre-marker indent so content_indent can be calculated correctly
+                if self.try_list_item(indent, events) {
+                    self.parse_line_content(events);
+                    return;
+                }
+            } else {
+                self.record_block_nesting_limit_if_needed();
             }
         }
 
@@ -1083,14 +1099,17 @@ impl<'a> BlockParser<'a> {
                 };
                 let line = &self.input[save_pos..line_end];
 
-                if let Some(alignments) = Self::is_delimiter_row(line) {
+                if let Some((alignments, delimiter_truncated)) = Self::is_delimiter_row(line) {
                     // Check cell count of the last paragraph line matches
                     if !self.paragraph_lines.is_empty() {
                         let last_para_line = self.paragraph_lines.last().unwrap();
                         let header_line = last_para_line.slice(self.input);
-                        let header_cells = self.table_cells(header_line);
+                        let (header_cells, header_truncated) = self.table_cells(header_line);
 
                         if Self::table_width(&header_cells) == alignments.len() {
+                            if delimiter_truncated || header_truncated {
+                                self.resource_limits.record(ResourceLimit::TableColumns);
+                            }
                             let dash_counts = self
                                 .options
                                 .table_column_widths
@@ -1144,6 +1163,8 @@ impl<'a> BlockParser<'a> {
                     self.parse_line_content(events);
                     return;
                 }
+            } else {
+                self.record_block_nesting_limit_if_needed();
             }
 
             // Check for HTML block
@@ -1863,13 +1884,9 @@ impl<'a> BlockParser<'a> {
         // Parse digits
         while let Some(b) = self.cursor.peek() {
             if b.is_ascii_digit() {
-                if digits >= limits::MAX_LIST_MARKER_DIGITS {
-                    // Too many digits, reset and return
-                    self.cursor = Cursor::new_at(self.input, start);
-                    self.current_col = start_col;
-                    return None;
+                if digits < limits::MAX_LIST_MARKER_DIGITS {
+                    num = num * 10 + (b - b'0') as u32;
                 }
-                num = num * 10 + (b - b'0') as u32;
                 digits += 1;
                 parser_cursor_bump!(self.cursor);
                 self.current_col += 1;
@@ -1879,6 +1896,21 @@ impl<'a> BlockParser<'a> {
         }
 
         if digits == 0 {
+            return None;
+        }
+
+        if digits > limits::MAX_LIST_MARKER_DIGITS {
+            let is_marker = matches!(self.cursor.peek(), Some(b'.' | b')'))
+                && self
+                    .input
+                    .get(self.cursor.offset() + 1)
+                    .is_none_or(|byte| matches!(byte, b' ' | b'\t' | b'\n' | b'\r'));
+            if is_marker {
+                self.resource_limits
+                    .record(ResourceLimit::OrderedListMarkerDigits);
+            }
+            self.cursor = Cursor::new_at(self.input, start);
+            self.current_col = start_col;
             return None;
         }
 
@@ -1943,6 +1975,45 @@ impl<'a> BlockParser<'a> {
         // relative_content_indent = digits + delimiter(1) + cols_after_marker
         let relative_content_indent = digits + 1 + cols_after_marker;
         Some((num, relative_content_indent, delimiter))
+    }
+
+    /// Record a syntactically plausible container marker left literal because
+    /// the parser has already reached the block nesting cap.
+    fn record_block_nesting_limit_if_needed(&mut self) {
+        let start = self.cursor.offset();
+        let line_end = self.input[start..]
+            .iter()
+            .position(|&byte| byte == b'\n')
+            .map_or(self.input.len(), |offset| start + offset);
+        let line = &self.input[start..line_end];
+        let Some(&first) = line.first() else {
+            return;
+        };
+
+        let is_container = match first {
+            b'>' => true,
+            b'-' | b'+' | b'*' => line
+                .get(1)
+                .is_none_or(|byte| matches!(byte, b' ' | b'\t' | b'\r')),
+            b'0'..=b'9' => {
+                let digit_count = line.iter().take_while(|byte| byte.is_ascii_digit()).count();
+                let delimiter = line.get(digit_count);
+                let followed_by_space = line
+                    .get(digit_count + 1)
+                    .is_none_or(|byte| matches!(byte, b' ' | b'\t' | b'\r'));
+                let is_marker = matches!(delimiter, Some(b'.' | b')')) && followed_by_space;
+                if is_marker && digit_count > limits::MAX_LIST_MARKER_DIGITS {
+                    self.resource_limits
+                        .record(ResourceLimit::OrderedListMarkerDigits);
+                }
+                is_marker
+            }
+            _ => false,
+        };
+
+        if is_container {
+            self.resource_limits.record(ResourceLimit::BlockNesting);
+        }
     }
 
     /// Start a new list item.
@@ -3163,11 +3234,11 @@ impl<'a> BlockParser<'a> {
     /// Split a table line by unescaped `|` outside backtick code spans.
     /// Returns source-relative cells trimmed of whitespace. Leading and
     /// trailing pipes are stripped and every cell has a span of one.
-    fn split_table_cells(line: &[u8]) -> SmallVec<[TableCell; 8]> {
+    fn split_table_cells(line: &[u8]) -> (SmallVec<[TableCell; 8]>, bool) {
         let mut cells = SmallVec::new();
         let len = line.len();
         if len == 0 {
-            return cells;
+            return (cells, false);
         }
 
         // Strip trailing whitespace from the line
@@ -3198,10 +3269,11 @@ impl<'a> BlockParser<'a> {
         // A line that is just a bare pipe (e.g., "|") has no content between leading/trailing
         // pipes and should not produce any cells.
         if pos >= scan_end {
-            return cells;
+            return (cells, false);
         }
 
         let mut cell_start = pos;
+        let mut truncated = false;
         loop {
             // Jump straight to the next byte that can affect cell structure;
             // everything in between is plain cell content.
@@ -3228,6 +3300,7 @@ impl<'a> BlockParser<'a> {
                 pos += 1;
                 cell_start = pos;
                 if cells.len() >= limits::MAX_TABLE_COLUMNS {
+                    truncated = pos < scan_end;
                     break;
                 }
             } else {
@@ -3235,7 +3308,7 @@ impl<'a> BlockParser<'a> {
             }
         }
 
-        cells
+        (cells, truncated)
     }
 
     /// Split a table row into semantic cells, interpreting consecutive pipes
@@ -3244,11 +3317,11 @@ impl<'a> BlockParser<'a> {
     /// Unlike ordinary GFM splitting, the final pipe is significant here:
     /// one pipe closes a one-column cell, `||` closes a two-column cell, and
     /// so on. Whitespace between pipes preserves an explicit empty cell.
-    fn split_merged_table_cells(line: &[u8]) -> SmallVec<[TableCell; 8]> {
+    fn split_merged_table_cells(line: &[u8]) -> (SmallVec<[TableCell; 8]>, bool) {
         let mut cells = SmallVec::new();
         let len = line.len();
         if len == 0 {
-            return cells;
+            return (cells, false);
         }
 
         let mut line_end = len;
@@ -3264,7 +3337,7 @@ impl<'a> BlockParser<'a> {
             pos += 1;
         }
         if pos >= line_end {
-            return cells;
+            return (cells, false);
         }
 
         let mut cell_start = pos;
@@ -3286,7 +3359,9 @@ impl<'a> BlockParser<'a> {
                     colspan: pipe_count.min(u16::MAX as usize) as u16,
                 });
                 if cells.len() >= limits::MAX_TABLE_COLUMNS || pos == line_end {
-                    return cells;
+                    let truncated =
+                        pos < line_end || Self::table_width(&cells) > limits::MAX_TABLE_COLUMNS;
+                    return (cells, truncated);
                 }
                 cell_start = pos;
             } else {
@@ -3300,7 +3375,8 @@ impl<'a> BlockParser<'a> {
             end: offset_to_u32(end),
             colspan: 1,
         });
-        cells
+        let truncated = Self::table_width(&cells) > limits::MAX_TABLE_COLUMNS;
+        (cells, truncated)
     }
 
     /// Advance past one table-cell token, treating escapes and matching
@@ -3341,7 +3417,7 @@ impl<'a> BlockParser<'a> {
         next
     }
 
-    fn table_cells(&self, line: &[u8]) -> SmallVec<[TableCell; 8]> {
+    fn table_cells(&self, line: &[u8]) -> (SmallVec<[TableCell; 8]>, bool) {
         if self.options.merged_table_cells {
             Self::split_merged_table_cells(line)
         } else {
@@ -3385,11 +3461,11 @@ impl<'a> BlockParser<'a> {
 
     /// Check if a line is a valid GFM table delimiter row.
     /// Returns column alignments if valid.
-    fn is_delimiter_row(line: &[u8]) -> Option<SmallVec<[Alignment; 8]>> {
+    fn is_delimiter_row(line: &[u8]) -> Option<(SmallVec<[Alignment; 8]>, bool)> {
         if !Self::could_be_delimiter_row(line) {
             return None;
         }
-        let cells = Self::split_table_cells(line);
+        let (cells, truncated) = Self::split_table_cells(line);
         if cells.is_empty() {
             return None;
         }
@@ -3438,13 +3514,13 @@ impl<'a> BlockParser<'a> {
             }
         }
 
-        Some(alignments)
+        Some((alignments, truncated))
     }
 
     /// Collect dash counts from a delimiter row already validated by
     /// `is_delimiter_row`.
     fn delimiter_dash_counts(line: &[u8]) -> SmallVec<[u16; 8]> {
-        let cells = Self::split_table_cells(line);
+        let (cells, _) = Self::split_table_cells(line);
         let mut dash_counts = SmallVec::new();
         for cell in &cells {
             let cell = &line[cell.start as usize..cell.end as usize];
@@ -3626,7 +3702,10 @@ impl<'a> BlockParser<'a> {
         };
 
         let line = &self.input[line_start..line_end];
-        let cells = self.table_cells(line);
+        let (cells, truncated) = self.table_cells(line);
+        if truncated {
+            self.resource_limits.record(ResourceLimit::TableColumns);
+        }
         let col_count = self.table_alignments.len();
 
         if !self.table_has_body {

--- a/src/inline/links.rs
+++ b/src/inline/links.rs
@@ -94,6 +94,11 @@ impl ReferenceResolutionBudget {
         self.remaining = remaining;
         true
     }
+
+    #[inline]
+    pub(crate) const fn limit_exceeded(&self) -> bool {
+        self.exhausted
+    }
 }
 
 #[derive(Clone, Copy)]
@@ -137,6 +142,28 @@ pub fn resolve_links_into(
     inactive_opens: &mut Vec<bool>,
     used_closes: &mut Vec<bool>,
 ) {
+    let _ = resolve_links_into_with_limits(
+        text,
+        open_brackets,
+        close_brackets,
+        out_links,
+        formed_opens,
+        inactive_opens,
+        used_closes,
+    );
+}
+
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn resolve_links_into_with_limits(
+    text: &[u8],
+    open_brackets: &[(u32, bool)],
+    close_brackets: &[u32],
+    out_links: &mut Vec<Link>,
+    formed_opens: &mut Vec<bool>,
+    inactive_opens: &mut Vec<bool>,
+    used_closes: &mut Vec<bool>,
+) -> bool {
+    let mut destination_parentheses_limit_exceeded = false;
     out_links.clear();
     // Track opens that have formed links (consumed with their close)
     formed_opens.clear();
@@ -170,7 +197,11 @@ pub fn resolve_links_into(
             if after_close < text.len() && text[after_close] == b'(' {
                 // Try to parse link destination
                 if let Some((url_start, url_end, title_start, title_end, end)) =
-                    parse_link_destination(text, after_close + 1)
+                    parse_link_destination(
+                        text,
+                        after_close + 1,
+                        &mut destination_parentheses_limit_exceeded,
+                    )
                 {
                     out_links.push(Link {
                         start: if is_image { open_pos - 1 } else { open_pos },
@@ -219,6 +250,7 @@ pub fn resolve_links_into(
 
     // Sort by start position
     out_links.sort_by_key(|l| l.start);
+    destination_parentheses_limit_exceeded
 }
 
 /// Resolve reference-style links/images using link reference definitions.
@@ -293,6 +325,7 @@ pub fn resolve_reference_links_into(
     let mut candidate_limit = open_brackets.len();
     for (open_idx, &(open_pos, is_image)) in open_brackets.iter().enumerate() {
         if work_budget.remaining == 0 {
+            work_budget.exhausted = true;
             candidate_limit = open_idx;
             break;
         }
@@ -320,6 +353,9 @@ pub fn resolve_reference_links_into(
         let count = candidate_prefix[open_idx] + usize::from(!is_image && candidate.is_some());
         candidate_prefix.push(count);
         if work_budget.remaining == 0 {
+            if open_idx + 1 < open_brackets.len() {
+                work_budget.exhausted = true;
+            }
             candidate_limit = open_idx + 1;
             break;
         }
@@ -588,6 +624,7 @@ fn parse_ref_label_immediate(
 fn parse_link_destination(
     text: &[u8],
     start: usize,
+    destination_parentheses_limit_exceeded: &mut bool,
 ) -> Option<(usize, usize, Option<usize>, Option<usize>, usize)> {
     let mut pos = start;
     let len = text.len();
@@ -629,6 +666,7 @@ fn parse_link_destination(
                 b'(' => {
                     paren_depth += 1;
                     if paren_depth > limits::MAX_LINK_PAREN_DEPTH as u32 {
+                        *destination_parentheses_limit_exceeded = true;
                         return None;
                     }
                     pos += 1;

--- a/src/inline/marks.rs
+++ b/src/inline/marks.rs
@@ -140,6 +140,8 @@ impl Mark {
 #[derive(Debug)]
 pub struct MarkBuffer {
     marks: Vec<Mark>,
+    limit_exceeded: bool,
+    code_span_limit_exceeded: bool,
 }
 
 impl MarkBuffer {
@@ -147,6 +149,8 @@ impl MarkBuffer {
     pub fn new() -> Self {
         Self {
             marks: Vec::with_capacity(64),
+            limit_exceeded: false,
+            code_span_limit_exceeded: false,
         }
     }
 
@@ -154,6 +158,8 @@ impl MarkBuffer {
     #[inline]
     pub fn clear(&mut self) {
         self.marks.clear();
+        self.limit_exceeded = false;
+        self.code_span_limit_exceeded = false;
     }
 
     /// Reserve capacity based on input length.
@@ -170,7 +176,24 @@ impl MarkBuffer {
     pub fn push(&mut self, mark: Mark) {
         if self.marks.len() < limits::MAX_INLINE_MARKS {
             self.marks.push(mark);
+        } else {
+            self.limit_exceeded = true;
         }
+    }
+
+    #[inline]
+    pub(crate) const fn limit_exceeded(&self) -> bool {
+        self.limit_exceeded
+    }
+
+    #[inline]
+    pub(crate) const fn code_span_limit_exceeded(&self) -> bool {
+        self.code_span_limit_exceeded
+    }
+
+    #[inline]
+    fn record_code_span_limit(&mut self) {
+        self.code_span_limit_exceeded = true;
     }
 
     /// Get marks slice.
@@ -303,6 +326,8 @@ fn collect_marks_impl<const HIGHLIGHT: bool, const SUPERSCRIPT: bool>(
                         b'`',
                         flags::POTENTIAL_OPENER | flags::POTENTIAL_CLOSER,
                     ));
+                } else {
+                    buffer.record_code_span_limit();
                 }
             }
 

--- a/src/inline/mod.rs
+++ b/src/inline/mod.rs
@@ -21,6 +21,7 @@ pub use event::InlineEvent;
 pub use links::AutolinkLiteralKind;
 
 use crate::footnote::FootnoteStore;
+use crate::limits::{ResourceLimit, ResourceLimitReport};
 use crate::link_ref::LinkRefStore;
 use crate::range::assert_input_size;
 use crate::{InputSizeError, Range};
@@ -29,7 +30,7 @@ use emphasis::{EmphasisMatch, EmphasisStacks, resolve_emphasis_with_stacks_into}
 use highlight::{HighlightMatch, resolve_highlight_into};
 use links::{
     Autolink, AutolinkLiteral, Link, RefLink, ReferenceResolutionBudget,
-    find_autolink_literals_into, find_autolinks_into, resolve_links_into,
+    find_autolink_literals_into, find_autolinks_into, resolve_links_into_with_limits,
     resolve_reference_links_into,
 };
 use marks::{
@@ -86,6 +87,7 @@ pub struct InlineParser {
     inline_footnotes: Vec<InlineFootnote>,
     inline_footnote_brackets: Vec<(u32, Option<u32>)>,
     math_spans: Vec<MathSpan>,
+    resource_limits: ResourceLimitReport,
 }
 
 impl InlineParser {
@@ -133,6 +135,7 @@ impl InlineParser {
             inline_footnotes: Vec::new(),
             inline_footnote_brackets: Vec::new(),
             math_spans: Vec::new(),
+            resource_limits: ResourceLimitReport::default(),
         }
     }
 
@@ -217,6 +220,16 @@ impl InlineParser {
     /// so reference-resolution work remains bounded for the whole document.
     pub(crate) fn begin_document(&mut self) {
         self.ref_work_budget.reset();
+        self.resource_limits = ResourceLimitReport::default();
+    }
+
+    /// Return resource-limit fallbacks used in the current document.
+    ///
+    /// Public parse methods reset this report before parsing. Document
+    /// renderers accumulate limits across every paragraph in the document.
+    #[must_use]
+    pub const fn resource_limits(&self) -> ResourceLimitReport {
+        self.resource_limits
     }
 
     /// Parse inline Markdown with opt-in MDX expressions as part of an active
@@ -383,6 +396,14 @@ impl InlineParser {
             MarkSummary::default()
         };
 
+        if self.mark_buffer.limit_exceeded() {
+            self.resource_limits.record(ResourceLimit::InlineMarks);
+        }
+        if self.mark_buffer.code_span_limit_exceeded() {
+            self.resource_limits
+                .record(ResourceLimit::CodeSpanBackticks);
+        }
+
         if self.mark_buffer.is_empty() && !may_have_autolinks {
             // No special characters and no autolink candidates, emit as plain text
             if !text.is_empty() {
@@ -473,7 +494,7 @@ impl InlineParser {
         });
         let has_inline_link_candidate = has_brackets && has_inline_link_opener(text);
         if has_inline_link_candidate {
-            resolve_links_into(
+            if resolve_links_into_with_limits(
                 text,
                 &self.open_brackets,
                 &self.close_brackets,
@@ -481,7 +502,10 @@ impl InlineParser {
                 &mut self.link_formed_opens,
                 &mut self.link_inactive_opens,
                 &mut self.link_used_closes,
-            );
+            ) {
+                self.resource_limits
+                    .record(ResourceLimit::LinkDestinationParentheses);
+            }
         } else {
             self.resolved_links.clear();
         }
@@ -506,6 +530,10 @@ impl InlineParser {
                     &mut self.ref_candidate_prefix,
                     &mut self.ref_work_budget,
                 );
+                if self.ref_work_budget.limit_exceeded() {
+                    self.resource_limits
+                        .record(ResourceLimit::ReferenceResolutionWork);
+                }
             } else {
                 self.ref_links.clear();
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,6 +45,7 @@ use smallvec::SmallVec;
 pub use block::{Alignment, BlockEvent, BlockParser, CalloutType, CodeBlockKind, fixup_list_tight};
 pub use footnote::FootnoteStore;
 pub use inline::{InlineEvent, InlineParser};
+pub use limits::{ResourceLimit, ResourceLimitReport};
 pub use link_ref::{LinkRefDef, LinkRefStore};
 pub use range::{InputSizeError, MAX_INPUT_BYTES, Range, validate_input_size};
 pub use render::HtmlWriter;
@@ -373,6 +374,8 @@ pub struct ParseResult<'a> {
     pub front_matter: Option<&'a str>,
     /// Document headings in source order, for table-of-contents rendering.
     pub headings: Vec<Heading>,
+    /// Resource-limit fallbacks used while parsing the document.
+    pub resource_limits: ResourceLimitReport,
 }
 
 /// One document heading collected during rendering.
@@ -494,7 +497,8 @@ fn extract_front_matter(input: &str) -> Option<(&str, usize)> {
     None
 }
 
-/// Parse Markdown and return HTML, front matter, and headings.
+/// Parse Markdown and return HTML, front matter, headings, and resource-limit
+/// fallbacks.
 ///
 /// Uses default options with `front_matter: true`.
 ///
@@ -505,6 +509,7 @@ fn extract_front_matter(input: &str) -> Option<(&str, usize)> {
 /// assert!(result.html.contains("Content</h1>"));
 /// assert_eq!(result.headings[0].id.as_deref(), Some("content"));
 /// assert_eq!(result.headings[0].text, "Content");
+/// assert!(result.resource_limits.is_empty());
 /// ```
 ///
 /// # Panics
@@ -524,7 +529,8 @@ pub fn try_parse(input: &str) -> Result<ParseResult<'_>, InputSizeError> {
     try_parse_with_options(input, &options)
 }
 
-/// Parse Markdown with options and return HTML, front matter, and headings.
+/// Parse Markdown with options and return HTML, front matter, headings, and
+/// resource-limit fallbacks.
 ///
 /// Front matter is only extracted when `options.front_matter` is `true`.
 /// Heading IDs are only present when `options.heading_ids` is enabled.
@@ -547,7 +553,7 @@ pub fn try_parse_with_options<'a>(
 }
 
 /// Parse Markdown with options and an opt-in fenced-code renderer, returning
-/// HTML, front matter, and headings.
+/// HTML, front matter, headings, and resource-limit fallbacks.
 ///
 /// See [`FencedCodeRenderer`] for the escaping contract the renderer must
 /// uphold.
@@ -590,6 +596,7 @@ fn parse_impl<'a>(
     };
 
     let mut headings = Vec::new();
+    let mut resource_limits = ResourceLimitReport::default();
     let mut writer = HtmlWriter::with_capacity_for(markdown.len());
     render_to_writer_impl(
         markdown.as_bytes(),
@@ -597,6 +604,7 @@ fn parse_impl<'a>(
         options,
         renderer,
         Some(&mut headings),
+        Some(&mut resource_limits),
     );
     let html = writer
         .into_string()
@@ -605,6 +613,7 @@ fn parse_impl<'a>(
         html,
         front_matter,
         headings,
+        resource_limits,
     }
 }
 
@@ -1211,7 +1220,7 @@ impl<'a, 'r, R: FencedCodeRenderer + ?Sized> RenderContext<'a, 'r, R> {
 
 /// Render Markdown to an HtmlWriter.
 fn render_to_writer(input: &[u8], writer: &mut HtmlWriter, options: &Options) {
-    render_to_writer_impl::<DisabledFencedCodeRenderer>(input, writer, options, None, None);
+    render_to_writer_impl::<DisabledFencedCodeRenderer>(input, writer, options, None, None, None);
 }
 
 fn render_to_writer_with_renderer(
@@ -1220,7 +1229,7 @@ fn render_to_writer_with_renderer(
     options: &Options,
     fenced_code_renderer: Option<&mut dyn FencedCodeRenderer>,
 ) {
-    render_to_writer_impl(input, writer, options, fenced_code_renderer, None);
+    render_to_writer_impl(input, writer, options, fenced_code_renderer, None, None);
 }
 
 struct DisabledFencedCodeRenderer;
@@ -1237,11 +1246,15 @@ fn render_to_writer_impl<R: FencedCodeRenderer + ?Sized>(
     options: &Options,
     fenced_code_renderer: Option<&mut R>,
     headings: Option<&mut Vec<Heading>>,
+    mut resource_limits: Option<&mut ResourceLimitReport>,
 ) {
     // Parse blocks
     let mut parser = BlockParser::new_with_options(input, options.clone());
     let mut events = Vec::with_capacity((input.len() / 16).max(64));
     parser.parse(&mut events);
+    if let Some(report) = resource_limits.as_deref_mut() {
+        report.extend(parser.resource_limits());
+    }
     #[cfg(feature = "profiling")]
     profiling::record_block_events(&events, events.capacity());
     let link_refs = parser.take_link_refs();
@@ -1272,6 +1285,9 @@ fn render_to_writer_impl<R: FencedCodeRenderer + ?Sized>(
     // Render footnote section at document end
     if !context.footnote_numbers.is_empty() {
         context.render_footnote_section(input);
+    }
+    if let Some(report) = resource_limits {
+        report.extend(context.inline_parser.resource_limits());
     }
 }
 

--- a/src/limits.rs
+++ b/src/limits.rs
@@ -3,6 +3,94 @@
 //! Every constant in this module is consumed by a parser path and covered by
 //! black-box tests in `tests/resource_limits_tests.rs`.
 
+/// A bounded parser operation that fell back to literal or truncated output.
+///
+/// The limits keep adversarial input from causing excessive work or memory
+/// growth. Use [`ResourceLimitReport`] to distinguish fully processed output
+/// from the documented safe fallbacks.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[non_exhaustive]
+pub enum ResourceLimit {
+    /// Blockquote or list nesting exceeded [`MAX_BLOCK_NESTING`].
+    BlockNesting,
+    /// Inline delimiter collection exceeded [`MAX_INLINE_MARKS`].
+    InlineMarks,
+    /// Reference-link resolution exceeded [`MAX_REFERENCE_RESOLUTION_WORK`].
+    ReferenceResolutionWork,
+    /// A backtick run exceeded [`MAX_CODE_SPAN_BACKTICKS`].
+    CodeSpanBackticks,
+    /// Link destination nesting exceeded [`MAX_LINK_PAREN_DEPTH`].
+    LinkDestinationParentheses,
+    /// An ordered-list marker exceeded [`MAX_LIST_MARKER_DIGITS`].
+    OrderedListMarkerDigits,
+    /// A table row exceeded [`MAX_TABLE_COLUMNS`].
+    TableColumns,
+}
+
+impl ResourceLimit {
+    const fn bit(self) -> u8 {
+        match self {
+            Self::BlockNesting => 1 << 0,
+            Self::InlineMarks => 1 << 1,
+            Self::ReferenceResolutionWork => 1 << 2,
+            Self::CodeSpanBackticks => 1 << 3,
+            Self::LinkDestinationParentheses => 1 << 4,
+            Self::OrderedListMarkerDigits => 1 << 5,
+            Self::TableColumns => 1 << 6,
+        }
+    }
+}
+
+/// Set of resource limits exceeded while parsing one document.
+///
+/// A report is empty when the parser processed the document without taking a
+/// resource-limit fallback. Repeated hits of the same limit are intentionally
+/// coalesced; callers generally need to know which output guarantees changed,
+/// not how often adversarial syntax repeated.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct ResourceLimitReport(u8);
+
+impl ResourceLimitReport {
+    const ALL: [ResourceLimit; 7] = [
+        ResourceLimit::BlockNesting,
+        ResourceLimit::InlineMarks,
+        ResourceLimit::ReferenceResolutionWork,
+        ResourceLimit::CodeSpanBackticks,
+        ResourceLimit::LinkDestinationParentheses,
+        ResourceLimit::OrderedListMarkerDigits,
+        ResourceLimit::TableColumns,
+    ];
+
+    /// Return whether no resource-limit fallback was used.
+    #[must_use]
+    pub const fn is_empty(self) -> bool {
+        self.0 == 0
+    }
+
+    /// Return whether a specific resource limit was exceeded.
+    #[must_use]
+    pub const fn contains(self, limit: ResourceLimit) -> bool {
+        self.0 & limit.bit() != 0
+    }
+
+    /// Iterate over the exceeded limits in stable declaration order.
+    pub fn iter(self) -> impl Iterator<Item = ResourceLimit> {
+        Self::ALL
+            .into_iter()
+            .filter(move |limit| self.contains(*limit))
+    }
+
+    #[inline]
+    pub(crate) fn record(&mut self, limit: ResourceLimit) {
+        self.0 |= limit.bit();
+    }
+
+    #[inline]
+    pub(crate) fn extend(&mut self, other: Self) {
+        self.0 |= other.0;
+    }
+}
+
 /// Maximum nesting depth for block containers (lists, blockquotes)
 pub const MAX_BLOCK_NESTING: usize = 32;
 

--- a/tests/resource_limits_tests.rs
+++ b/tests/resource_limits_tests.rs
@@ -1,7 +1,116 @@
 use ferromark::{
-    InlineEvent, InlineParser, LinkRefDef, LinkRefStore, Options, limits, to_html,
-    to_html_with_options,
+    InlineEvent, InlineParser, LinkRefDef, LinkRefStore, Options, ResourceLimit, limits, parse,
+    parse_with_options, to_html, to_html_with_options,
 };
+
+#[test]
+fn parse_reports_each_silent_resource_limit() {
+    let nested = format!("{}content", "> ".repeat(limits::MAX_BLOCK_NESTING + 1));
+    assert!(
+        parse(&nested)
+            .resource_limits
+            .contains(ResourceLimit::BlockNesting)
+    );
+
+    let marks = "*x* ".repeat(limits::MAX_INLINE_MARKS);
+    assert!(
+        parse(&marks)
+            .resource_limits
+            .contains(ResourceLimit::InlineMarks)
+    );
+
+    let references = format!(
+        "[x]: /safe\n\n{}",
+        "[x]\n\n".repeat(limits::MAX_REFERENCE_RESOLUTION_WORK / 3 + 2)
+    );
+    assert!(
+        parse(&references)
+            .resource_limits
+            .contains(ResourceLimit::ReferenceResolutionWork)
+    );
+
+    let backticks = "`".repeat(limits::MAX_CODE_SPAN_BACKTICKS + 1);
+    assert!(
+        parse(&format!("{backticks}code{backticks}"))
+            .resource_limits
+            .contains(ResourceLimit::CodeSpanBackticks)
+    );
+
+    let parentheses = format!(
+        "[link](url{}{})",
+        "(".repeat(limits::MAX_LINK_PAREN_DEPTH + 1),
+        ")".repeat(limits::MAX_LINK_PAREN_DEPTH + 1)
+    );
+    assert!(
+        parse(&parentheses)
+            .resource_limits
+            .contains(ResourceLimit::LinkDestinationParentheses)
+    );
+
+    let marker = format!("{}. item", "1".repeat(limits::MAX_LIST_MARKER_DIGITS + 1));
+    assert!(
+        parse(&marker)
+            .resource_limits
+            .contains(ResourceLimit::OrderedListMarkerDigits)
+    );
+
+    let columns = limits::MAX_TABLE_COLUMNS + 1;
+    let header = std::iter::repeat_n("cell", columns)
+        .collect::<Vec<_>>()
+        .join(" | ");
+    let delimiter = std::iter::repeat_n("---", columns)
+        .collect::<Vec<_>>()
+        .join(" | ");
+    let table = format!("| {header} |\n| {delimiter} |\n");
+    assert!(
+        parse_with_options(&table, &Options::gfm())
+            .resource_limits
+            .contains(ResourceLimit::TableColumns)
+    );
+}
+
+#[test]
+fn parse_reports_no_limit_for_fully_processed_input() {
+    let result = parse("# Heading\n\nA [safe link](https://example.com).\n");
+
+    assert!(result.resource_limits.is_empty());
+}
+
+#[test]
+fn exact_limits_and_rejected_table_candidates_are_not_reported() {
+    let nested = format!("{}content", "> ".repeat(limits::MAX_BLOCK_NESTING));
+    assert!(parse(&nested).resource_limits.is_empty());
+
+    let marks = "*x*".repeat(limits::MAX_INLINE_MARKS / 2);
+    assert!(parse(&marks).resource_limits.is_empty());
+
+    let backticks = "`".repeat(limits::MAX_CODE_SPAN_BACKTICKS);
+    assert!(
+        parse(&format!("{backticks}code{backticks}"))
+            .resource_limits
+            .is_empty()
+    );
+
+    let parentheses = format!(
+        "[link](url{}{})",
+        "(".repeat(limits::MAX_LINK_PAREN_DEPTH),
+        ")".repeat(limits::MAX_LINK_PAREN_DEPTH)
+    );
+    assert!(parse(&parentheses).resource_limits.is_empty());
+
+    let marker = format!("{}. item", "1".repeat(limits::MAX_LIST_MARKER_DIGITS));
+    assert!(parse(&marker).resource_limits.is_empty());
+
+    let delimiter = std::iter::repeat_n("---", limits::MAX_TABLE_COLUMNS + 1)
+        .collect::<Vec<_>>()
+        .join(" | ");
+    let rejected_table = format!("one cell\n| {delimiter} |\n");
+    assert!(
+        parse_with_options(&rejected_table, &Options::gfm())
+            .resource_limits
+            .is_empty()
+    );
+}
 
 #[test]
 fn block_container_nesting_is_bounded() {


### PR DESCRIPTION
Closes #165.

## Summary
- add typed `ResourceLimit` and compact `ResourceLimitReport` APIs
- expose accumulated block and inline fallback signals on `ParseResult` and reusable parsers
- report all seven bounded fallback paths while preserving existing rendered output
- document the new metadata and cover over-limit, exact-limit, and false-positive cases

## Verification
- `cargo test --locked`
- `cargo test --locked --all-features`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --locked --no-deps --no-default-features --features mdx`
- CI contract scripts