### PR TITLE
fix(node): reject unknown option keys

### DIFF
--- a/node/ferromark/README.md
+++ b/node/ferromark/README.md
@@ -51,6 +51,9 @@ the highlighter helpers below accept trusted highlighter HTML.
 
 Every `Options` property is optional; omitted values use the Rust `Options::default()` values. The TypeScript declaration is the complete, editor-linked reference. Defaults on: `allowHtml`, `allowLinkRefs`, `tables`, `strikethrough`, `taskLists`, `disallowedRawHtml`, `headingIds`, `callouts`, and `indentedCodeBlocks`. All other boolean syntax extensions default off; `renderPolicy` defaults to `'untrusted'` and `linkBasePath` is unset.
 
+Unknown option names throw a `TypeError` that identifies the rejected key, so
+misspellings such as `taskList` cannot silently change rendered output.
+
 `mergedTableCells` and `tableColumnWidths` require `tables`. `disallowedRawHtml` only filters a narrow GFM tag list in trusted mode and is not a sanitizer. `renderPolicy: 'trusted'` permits raw HTML and unrestricted URL schemes, so use it only for trusted Markdown. See [`Options`](./index.d.mts) for each field's semantics and examples above for `frontMatter` and `linkBasePath`.
 
 ## Input size limit

--- a/node/ferromark/index.mjs
+++ b/node/ferromark/index.mjs
@@ -4,11 +4,53 @@ import { fileURLToPath } from 'node:url'
 
 const require = createRequire(import.meta.url)
 
+const optionKeys = new Set([
+  'renderPolicy',
+  'allowHtml',
+  'allowLinkRefs',
+  'tables',
+  'mergedTableCells',
+  'tableColumnWidths',
+  'strikethrough',
+  'highlight',
+  'superscript',
+  'subscript',
+  'taskLists',
+  'autolinkLiterals',
+  'disallowedRawHtml',
+  'footnotes',
+  'inlineFootnotes',
+  'frontMatter',
+  'headingIds',
+  'math',
+  'callouts',
+  'definitionLists',
+  'lineComments',
+  'indentedCodeBlocks',
+  'linkBasePath',
+])
+
+/** @param {import('./index.mjs').Options | null | undefined} options */
+function validateOptions(options) {
+  if (options == null) {
+    return
+  }
+  if (typeof options !== 'object' && typeof options !== 'function') {
+    throw new TypeError('options must be an object')
+  }
+  for (const key of Reflect.ownKeys(options)) {
+    if (typeof key !== 'string' || !optionKeys.has(key)) {
+      throw new TypeError(`unknown option "${String(key)}"`)
+    }
+  }
+}
+
 /**
  * @param {string} markdown
  * @param {import('./index.mjs').Options} [options]
  */
 export function toHtml(markdown, options) {
+  validateOptions(options)
   return loadNative().toHtml(markdown, options)
 }
 
@@ -17,6 +59,7 @@ export function toHtml(markdown, options) {
  * @param {import('./index.mjs').Options} [options]
  */
 export function transform(markdown, options) {
+  validateOptions(options)
   return loadNative().transform(markdown, options)
 }
 
@@ -59,6 +102,7 @@ function highlighterRenderer(highlighter, highlightOptions) {
  * @param {import('./index.mjs').Options} [options]
  */
 export function toHtmlWithHighlighter(markdown, highlighter, highlightOptions, options) {
+  validateOptions(options)
   const render = highlighterRenderer(highlighter, highlightOptions)
   return loadNative().toHtmlWithRenderer(markdown, options, render)
 }
@@ -70,6 +114,7 @@ export function toHtmlWithHighlighter(markdown, highlighter, highlightOptions, o
  * @param {import('./index.mjs').Options} [options]
  */
 export function transformWithHighlighter(markdown, highlighter, highlightOptions, options) {
+  validateOptions(options)
   const render = highlighterRenderer(highlighter, highlightOptions)
   return loadNative().transformWithRenderer(markdown, options, render)
 }

--- a/node/ferromark/test/index.test.mjs
+++ b/node/ferromark/test/index.test.mjs
@@ -36,6 +36,27 @@ test('maps typed options to the Rust surface', () => {
   )
 })
 
+test('rejects unknown option keys across every public render entry point', () => {
+  const highlighter = {
+    codeToHtml() {
+      return '<pre><code></code></pre>\n'
+    },
+  }
+  const calls = [
+    () => toHtml('text', { taskList: true }),
+    () => transform('text', { footnote: true }),
+    () => toHtmlWithHighlighter('text', highlighter, { theme: 'dark' }, { taskList: true }),
+    () => transformWithHighlighter('text', highlighter, { theme: 'dark' }, { footnote: true }),
+  ]
+
+  for (const call of calls) {
+    assert.throws(
+      call,
+      error => error instanceof TypeError && /unknown option.*(?:taskList|footnote)/i.test(error.message),
+    )
+  }
+})
+
 test('composes with a synchronous Ferriki-compatible highlighter', () => {
   const calls = []
   const highlighter = {

--- a/scripts/test-node-options-docs-contract.rb
+++ b/scripts/test-node-options-docs-contract.rb
@@ -5,6 +5,7 @@ TYPE_PATH = 'node/ferromark/index.d.mts'
 README_PATH = 'node/ferromark/README.md'
 RUST_PATH = 'src/lib.rs'
 NATIVE_PATH = 'node/native/src/lib.rs'
+JAVASCRIPT_PATH = 'node/ferromark/index.mjs'
 
 class ContractFailure < StandardError; end
 
@@ -54,6 +55,15 @@ def native_option_fields(native)
   body.scan(/^    pub (\w+): /).to_h { |(field)| [field, true] }
 end
 
+def javascript_option_fields(javascript)
+  body = source_block(
+    javascript,
+    /const optionKeys = new Set\(\[(.*?)^\]\)/m,
+    'JavaScript option-key set'
+  )
+  body.scan(/^  '([^']+)',$/).flatten
+end
+
 def list_with_and(items)
   return items.first if items.length == 1
   return items.join(' and ') if items.length == 2
@@ -61,14 +71,16 @@ def list_with_and(items)
   "#{items[0...-1].join(', ')}, and #{items.last}"
 end
 
-def validate(types, readme, rust, native)
+def validate(types, readme, rust, native, javascript)
   rust_fields = rust_options(rust)
   node_docs = node_option_docs(types)
   native_fields = native_option_fields(native)
+  javascript_fields = javascript_option_fields(javascript)
   expected_node_fields = rust_fields.keys.to_h { |field| [camel_case(field), field] }
 
   fail_contract("Node Options field mismatch: expected #{expected_node_fields.keys.join(', ')}") unless node_docs.keys.sort == expected_node_fields.keys.sort
   fail_contract("native Options field mismatch: expected #{rust_fields.keys.join(', ')}") unless native_fields.keys.sort == rust_fields.keys.sort
+  fail_contract("JavaScript option-key mismatch: expected #{expected_node_fields.keys.join(', ')}") unless javascript_fields.sort == expected_node_fields.keys.sort
 
   rust_fields.each do |rust_field, default_value|
     node_field = camel_case(rust_field)
@@ -89,8 +101,8 @@ def validate(types, readme, rust, native)
   fail_contract('README must document table constraints') unless readme.include?('require `tables`')
 end
 
-types = File.read(TYPE_PATH); readme = File.read(README_PATH); rust = File.read(RUST_PATH); native = File.read(NATIVE_PATH)
-validate(types, readme, rust, native)
+types = File.read(TYPE_PATH); readme = File.read(README_PATH); rust = File.read(RUST_PATH); native = File.read(NATIVE_PATH); javascript = File.read(JAVASCRIPT_PATH)
+validate(types, readme, rust, native, javascript)
 if ARGV == ['--self-test']
   def rejected
     yield
@@ -100,10 +112,10 @@ if ARGV == ['--self-test']
     fail_contract('mutation unexpectedly passed')
   end
   rejected do
-    validate(types.sub('Default: on', 'Default: off'), readme, rust, native)
+    validate(types.sub('Default: on', 'Default: off'), readme, rust, native, javascript)
   end
   rejected do
-    validate(types, readme.gsub('[`Options`](./index.d.mts)', 'Options'), rust, native)
+    validate(types, readme.gsub('[`Options`](./index.d.mts)', 'Options'), rust, native, javascript)
   end
   future_field = rust.sub(
     '    pub link_base_path: Option<Box<str>>,',
@@ -113,14 +125,17 @@ if ARGV == ['--self-test']
     "            link_base_path: None,\n            future_option: false,"
   )
   rejected do
-    validate(types, readme, future_field, native)
+    validate(types, readme, future_field, native, javascript)
   end
   future_with_docs = types.sub(
     "  /**\n   * Prefix internal absolute link destinations",
     "  /** Future option. Default: off. */\n  futureOption?: boolean\n  /**\n   * Prefix internal absolute link destinations"
   )
   rejected do
-    validate(future_with_docs, readme, future_field, native)
+    validate(future_with_docs, readme, future_field, native, javascript)
+  end
+  rejected do
+    validate(types, readme, rust, native, javascript.sub("  'linkBasePath',\n", ''))
   end
 elsif !ARGV.empty?
   fail_contract('usage: test-node-options-docs-contract.rb [--self-test]')


### PR DESCRIPTION
Closes #168.

## Summary
- validate option keys before all four public JavaScript render entry points
- throw a `TypeError` naming the rejected key instead of silently ignoring typos
- keep the runtime key set synchronized with Rust, N-API, and TypeScript option declarations via the existing contract test
- document the strict option behavior

## Verification
- `pnpm audit --audit-level high`
- `pnpm build`
- `pnpm test`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm pack:check`
- `pnpm smoke:clean`
- `ruby ./scripts/test-node-options-docs-contract.rb --self-test`