### PR TITLE
feat(node): publish per-platform native packages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,18 +123,20 @@ jobs:
 
   native:
     # Each target is built and loaded on a runner with the same architecture;
-    # this is runtime coverage, not a cross-compilation-only check.
+    # musl targets are cross-compiled because the hosted runners use glibc.
     permissions:
       contents: read
     strategy:
       fail-fast: false
       matrix:
         include:
-          - { os: macos-latest, rust_target: aarch64-apple-darwin }
-          - { os: macos-15-intel, rust_target: x86_64-apple-darwin }
-          - { os: ubuntu-24.04-arm, rust_target: aarch64-unknown-linux-gnu }
-          - { os: windows-latest, rust_target: x86_64-pc-windows-msvc }
-          - { os: windows-11-arm, rust_target: aarch64-pc-windows-msvc }
+          - { os: macos-latest, rust_target: aarch64-apple-darwin, artifact: darwin-arm64, runtime_test: true }
+          - { os: macos-15-intel, rust_target: x86_64-apple-darwin, artifact: darwin-x64, runtime_test: true }
+          - { os: ubuntu-24.04-arm, rust_target: aarch64-unknown-linux-gnu, artifact: linux-arm64-gnu, runtime_test: true }
+          - { os: ubuntu-latest, rust_target: x86_64-unknown-linux-musl, artifact: linux-x64-musl, runtime_test: false }
+          - { os: ubuntu-latest, rust_target: aarch64-unknown-linux-musl, artifact: linux-arm64-musl, runtime_test: false }
+          - { os: windows-latest, rust_target: x86_64-pc-windows-msvc, artifact: win32-x64-msvc, runtime_test: true }
+          - { os: windows-11-arm, rust_target: aarch64-pc-windows-msvc, artifact: win32-arm64-msvc, runtime_test: true }
     runs-on: ${{ matrix.os }}
     name: native (${{ matrix.rust_target }})
     defaults:
@@ -154,9 +156,22 @@ jobs:
         with:
           toolchain: stable
           targets: ${{ matrix.rust_target }}
+      - uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29 # v2
+        if: ${{ contains(matrix.rust_target, '-musl') }}
+        with:
+          version: 0.15.2
+      - uses: taiki-e/install-action@e67fa11c4b9316fa714ddf0abed07a0c3143b95b # v2
+        if: ${{ contains(matrix.rust_target, '-musl') }}
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        with:
+          tool: cargo-zigbuild
       - run: pnpm install --frozen-lockfile
       - run: pnpm build:native
         env:
           FERROMARK_RUST_TARGET: ${{ matrix.rust_target }}
       - name: Test native package
+        if: ${{ matrix.runtime_test }}
         run: pnpm test
+      - name: Verify platform package
+        run: node ./scripts/verify-platform-artifact.mjs ${{ matrix.artifact }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -61,21 +61,35 @@ jobs:
           - os: ubuntu-latest
             rust-target: x86_64-unknown-linux-gnu
             artifact: linux-x64-gnu
+            runtime_test: true
           - os: ubuntu-24.04-arm
             rust-target: aarch64-unknown-linux-gnu
             artifact: linux-arm64-gnu
+            runtime_test: true
+          - os: ubuntu-latest
+            rust-target: x86_64-unknown-linux-musl
+            artifact: linux-x64-musl
+            runtime_test: false
+          - os: ubuntu-latest
+            rust-target: aarch64-unknown-linux-musl
+            artifact: linux-arm64-musl
+            runtime_test: false
           - os: macos-latest
             rust-target: aarch64-apple-darwin
             artifact: darwin-arm64
+            runtime_test: true
           - os: macos-15-intel
             rust-target: x86_64-apple-darwin
             artifact: darwin-x64
+            runtime_test: true
           - os: windows-latest
             rust-target: x86_64-pc-windows-msvc
             artifact: win32-x64-msvc
+            runtime_test: true
           - os: windows-11-arm
             rust-target: aarch64-pc-windows-msvc
             artifact: win32-arm64-msvc
+            runtime_test: true
     runs-on: ${{ matrix.os }}
     defaults:
       run:
@@ -102,6 +116,20 @@ jobs:
           toolchain: stable
           targets: ${{ matrix.rust-target }}
 
+      - name: Set Zig
+        uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29 # v2
+        if: ${{ contains(matrix.rust-target, '-musl') }}
+        with:
+          version: 0.15.2
+
+      - name: Install cargo-zigbuild
+        uses: taiki-e/install-action@e67fa11c4b9316fa714ddf0abed07a0c3143b95b # v2
+        if: ${{ contains(matrix.rust-target, '-musl') }}
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        with:
+          tool: cargo-zigbuild
+
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
@@ -111,6 +139,7 @@ jobs:
           FERROMARK_RUST_TARGET: ${{ matrix.rust-target }}
 
       - name: Test native package
+        if: ${{ matrix.runtime_test }}
         run: pnpm test
 
       - name: Upload native binary
@@ -161,7 +190,10 @@ jobs:
         with:
           pattern: native-*
           merge-multiple: true
-          path: node/ferromark
+          path: node/ferromark/.napi-artifacts
+
+      - name: Assemble platform packages
+        run: pnpm --dir ferromark exec napi artifacts --output-dir .napi-artifacts --npm-dir npm
 
       - name: Verify release package
         run: node ./scripts/verify-release.mjs
@@ -174,7 +206,10 @@ jobs:
           node ./scripts/verify-pack.mjs --all-targets
           pnpm smoke:clean
 
-      - name: Publish to npm with trusted publishing
+      - name: Publish platform packages with trusted publishing
+        run: node ./scripts/publish-platform-packages.mjs
+
+      - name: Publish main package with trusted publishing
         working-directory: node/ferromark
         run: npm publish --access public --provenance
 

--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,10 @@
 /fuzz/target
 /node/node_modules
 /node/ferromark/*.node
+/node/ferromark/.napi-artifacts
+/node/ferromark/npm/*/*.node
 /node/artifacts
+/.pnpm-store
 .DS_Store
 *.swp
 *.swo

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 /fuzz/corpus
 /fuzz/target
 /node/node_modules
+/node/ferromark/node_modules
 /node/ferromark/*.node
 /node/ferromark/.napi-artifacts
 /node/ferromark/npm/*/*.node

--- a/node/ferromark/README.md
+++ b/node/ferromark/README.md
@@ -9,8 +9,9 @@ npm install ferromark
 # or: pnpm add ferromark
 ```
 
-The package requires Node.js 22 or newer. It ships native binaries for glibc
-Linux, macOS, and Windows on x64 and arm64; there is no WASM fallback.
+The package requires Node.js 22 or newer. It installs one platform-specific
+native package for glibc or musl Linux, macOS, and Windows on x64 and arm64;
+musl support includes Alpine Linux. There is no WASM fallback.
 
 ```js
 import { toHtml } from 'ferromark'
@@ -117,9 +118,8 @@ highlighter helper, not when this package is imported. If that call fails:
 | Message or environment | Resolution |
 | --- | --- |
 | Node.js below 22 | Upgrade to Node.js 22 or newer; this is the package's declared engine requirement. |
-| Alpine or another musl Linux environment | Use a glibc Linux environment. musl binaries are not published. |
-| Unsupported platform or architecture | Use macOS, Windows, or glibc Linux on x64 or arm64. |
-| `does not include a native binary` | Reinstall the published package and verify that installation did not omit its platform binary. |
+| Unsupported platform or architecture | Use macOS, Windows, or glibc/musl Linux on x64 or arm64. |
+| `could not load the optional native package` | Reinstall without `--omit=optional` and verify that your lockfile includes ferromark's package for the current platform. |
 
 This package does not include a WASM fallback, so unsupported environments need
 one of the supported native runtimes rather than a JavaScript fallback.

--- a/node/ferromark/index.mjs
+++ b/node/ferromark/index.mjs
@@ -151,6 +151,7 @@ function loadNative() {
 
   const target = nativeTarget()
   const filename = `ferromark.${target}.node`
+  let localError
   try {
     native = /** @type {NativeBindings} */ (
       require(fileURLToPath(new URL(filename, import.meta.url)))
@@ -161,30 +162,43 @@ function loadNative() {
     if (!(error instanceof Error) || !('code' in error) || error.code !== 'MODULE_NOT_FOUND') {
       throw error
     }
+    localError = error
+  }
+
+  const packageName = `ferromark-${target}`
+  try {
+    native = /** @type {NativeBindings} */ (require(packageName))
+    return native
+  }
+  catch (error) {
+    if (!(error instanceof Error) || !('code' in error) || error.code !== 'MODULE_NOT_FOUND') {
+      throw error
+    }
     throw new Error(
-      `ferromark does not include a native binary for ${process.platform}/${process.arch} (${target})`,
-      { cause: error },
+      `ferromark could not load the optional native package ${packageName} for ${process.platform}/${process.arch}`,
+      { cause: new AggregateError([localError, error], `No native binary found for ${target}`) },
     )
   }
 }
 
 function nativeTarget() {
-  const key = `${process.platform}-${process.arch}`
+  const report = /** @type {{ header?: { glibcVersionRuntime?: string } }} */ (
+    process.report?.getReport?.()
+  )
+  const libc = report?.header?.glibcVersionRuntime ? 'gnu' : 'musl'
+  const key = process.platform === 'linux'
+    ? `${process.platform}-${process.arch}-${libc}`
+    : `${process.platform}-${process.arch}`
   /** @type {Record<string, string>} */
   const targets = {
     'darwin-arm64': 'darwin-arm64',
     'darwin-x64': 'darwin-x64',
-    'linux-arm64': 'linux-arm64-gnu',
-    'linux-x64': 'linux-x64-gnu',
+    'linux-arm64-gnu': 'linux-arm64-gnu',
+    'linux-arm64-musl': 'linux-arm64-musl',
+    'linux-x64-gnu': 'linux-x64-gnu',
+    'linux-x64-musl': 'linux-x64-musl',
     'win32-arm64': 'win32-arm64-msvc',
     'win32-x64': 'win32-x64-msvc',
-  }
-
-  const report = /** @type {{ header?: { glibcVersionRuntime?: string } }} */ (
-    process.report?.getReport?.()
-  )
-  if (process.platform === 'linux' && !report?.header?.glibcVersionRuntime) {
-    throw new Error('ferromark currently supports glibc Linux builds; musl is not supported')
   }
 
   const target = targets[key]

--- a/node/ferromark/npm/darwin-arm64/README.md
+++ b/node/ferromark/npm/darwin-arm64/README.md
@@ -1,0 +1,3 @@
+# `ferromark-darwin-arm64`
+
+This is the **aarch64-apple-darwin** native binary for [`ferromark`](https://www.npmjs.com/package/ferromark).

--- a/node/ferromark/npm/darwin-arm64/package.json
+++ b/node/ferromark/npm/darwin-arm64/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "ferromark-darwin-arm64",
+  "version": "0.7.0",
+  "description": "Native aarch64-apple-darwin binary for ferromark",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/sebastian-software/ferromark.git",
+    "directory": "node/ferromark"
+  },
+  "engines": {
+    "node": ">=22.0.0"
+  },
+  "os": [
+    "darwin"
+  ],
+  "cpu": [
+    "arm64"
+  ],
+  "main": "ferromark.darwin-arm64.node",
+  "files": [
+    "ferromark.darwin-arm64.node"
+  ],
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
+  }
+}

--- a/node/ferromark/npm/darwin-x64/README.md
+++ b/node/ferromark/npm/darwin-x64/README.md
@@ -1,0 +1,3 @@
+# `ferromark-darwin-x64`
+
+This is the **x86_64-apple-darwin** native binary for [`ferromark`](https://www.npmjs.com/package/ferromark).

--- a/node/ferromark/npm/darwin-x64/package.json
+++ b/node/ferromark/npm/darwin-x64/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "ferromark-darwin-x64",
+  "version": "0.7.0",
+  "description": "Native x86_64-apple-darwin binary for ferromark",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/sebastian-software/ferromark.git",
+    "directory": "node/ferromark"
+  },
+  "engines": {
+    "node": ">=22.0.0"
+  },
+  "os": [
+    "darwin"
+  ],
+  "cpu": [
+    "x64"
+  ],
+  "main": "ferromark.darwin-x64.node",
+  "files": [
+    "ferromark.darwin-x64.node"
+  ],
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
+  }
+}

--- a/node/ferromark/npm/linux-arm64-gnu/README.md
+++ b/node/ferromark/npm/linux-arm64-gnu/README.md
@@ -1,0 +1,3 @@
+# `ferromark-linux-arm64-gnu`
+
+This is the **aarch64-unknown-linux-gnu** native binary for [`ferromark`](https://www.npmjs.com/package/ferromark).

--- a/node/ferromark/npm/linux-arm64-gnu/package.json
+++ b/node/ferromark/npm/linux-arm64-gnu/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "ferromark-linux-arm64-gnu",
+  "version": "0.7.0",
+  "description": "Native aarch64-unknown-linux-gnu binary for ferromark",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/sebastian-software/ferromark.git",
+    "directory": "node/ferromark"
+  },
+  "engines": {
+    "node": ">=22.0.0"
+  },
+  "os": [
+    "linux"
+  ],
+  "cpu": [
+    "arm64"
+  ],
+  "libc": [
+    "glibc"
+  ],
+  "main": "ferromark.linux-arm64-gnu.node",
+  "files": [
+    "ferromark.linux-arm64-gnu.node"
+  ],
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
+  }
+}

--- a/node/ferromark/npm/linux-arm64-musl/README.md
+++ b/node/ferromark/npm/linux-arm64-musl/README.md
@@ -1,0 +1,3 @@
+# `ferromark-linux-arm64-musl`
+
+This is the **aarch64-unknown-linux-musl** native binary for [`ferromark`](https://www.npmjs.com/package/ferromark).

--- a/node/ferromark/npm/linux-arm64-musl/package.json
+++ b/node/ferromark/npm/linux-arm64-musl/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "ferromark-linux-arm64-musl",
+  "version": "0.7.0",
+  "description": "Native aarch64-unknown-linux-musl binary for ferromark",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/sebastian-software/ferromark.git",
+    "directory": "node/ferromark"
+  },
+  "engines": {
+    "node": ">=22.0.0"
+  },
+  "os": [
+    "linux"
+  ],
+  "cpu": [
+    "arm64"
+  ],
+  "libc": [
+    "musl"
+  ],
+  "main": "ferromark.linux-arm64-musl.node",
+  "files": [
+    "ferromark.linux-arm64-musl.node"
+  ],
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
+  }
+}

--- a/node/ferromark/npm/linux-x64-gnu/README.md
+++ b/node/ferromark/npm/linux-x64-gnu/README.md
@@ -1,0 +1,3 @@
+# `ferromark-linux-x64-gnu`
+
+This is the **x86_64-unknown-linux-gnu** native binary for [`ferromark`](https://www.npmjs.com/package/ferromark).

--- a/node/ferromark/npm/linux-x64-gnu/package.json
+++ b/node/ferromark/npm/linux-x64-gnu/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "ferromark-linux-x64-gnu",
+  "version": "0.7.0",
+  "description": "Native x86_64-unknown-linux-gnu binary for ferromark",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/sebastian-software/ferromark.git",
+    "directory": "node/ferromark"
+  },
+  "engines": {
+    "node": ">=22.0.0"
+  },
+  "os": [
+    "linux"
+  ],
+  "cpu": [
+    "x64"
+  ],
+  "libc": [
+    "glibc"
+  ],
+  "main": "ferromark.linux-x64-gnu.node",
+  "files": [
+    "ferromark.linux-x64-gnu.node"
+  ],
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
+  }
+}

--- a/node/ferromark/npm/linux-x64-musl/README.md
+++ b/node/ferromark/npm/linux-x64-musl/README.md
@@ -1,0 +1,3 @@
+# `ferromark-linux-x64-musl`
+
+This is the **x86_64-unknown-linux-musl** native binary for [`ferromark`](https://www.npmjs.com/package/ferromark).

--- a/node/ferromark/npm/linux-x64-musl/package.json
+++ b/node/ferromark/npm/linux-x64-musl/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "ferromark-linux-x64-musl",
+  "version": "0.7.0",
+  "description": "Native x86_64-unknown-linux-musl binary for ferromark",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/sebastian-software/ferromark.git",
+    "directory": "node/ferromark"
+  },
+  "engines": {
+    "node": ">=22.0.0"
+  },
+  "os": [
+    "linux"
+  ],
+  "cpu": [
+    "x64"
+  ],
+  "libc": [
+    "musl"
+  ],
+  "main": "ferromark.linux-x64-musl.node",
+  "files": [
+    "ferromark.linux-x64-musl.node"
+  ],
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
+  }
+}

--- a/node/ferromark/npm/win32-arm64-msvc/README.md
+++ b/node/ferromark/npm/win32-arm64-msvc/README.md
@@ -1,0 +1,3 @@
+# `ferromark-win32-arm64-msvc`
+
+This is the **aarch64-pc-windows-msvc** native binary for [`ferromark`](https://www.npmjs.com/package/ferromark).

--- a/node/ferromark/npm/win32-arm64-msvc/package.json
+++ b/node/ferromark/npm/win32-arm64-msvc/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "ferromark-win32-arm64-msvc",
+  "version": "0.7.0",
+  "description": "Native aarch64-pc-windows-msvc binary for ferromark",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/sebastian-software/ferromark.git",
+    "directory": "node/ferromark"
+  },
+  "engines": {
+    "node": ">=22.0.0"
+  },
+  "os": [
+    "win32"
+  ],
+  "cpu": [
+    "arm64"
+  ],
+  "main": "ferromark.win32-arm64-msvc.node",
+  "files": [
+    "ferromark.win32-arm64-msvc.node"
+  ],
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
+  }
+}

--- a/node/ferromark/npm/win32-x64-msvc/README.md
+++ b/node/ferromark/npm/win32-x64-msvc/README.md
@@ -1,0 +1,3 @@
+# `ferromark-win32-x64-msvc`
+
+This is the **x86_64-pc-windows-msvc** native binary for [`ferromark`](https://www.npmjs.com/package/ferromark).

--- a/node/ferromark/npm/win32-x64-msvc/package.json
+++ b/node/ferromark/npm/win32-x64-msvc/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "ferromark-win32-x64-msvc",
+  "version": "0.7.0",
+  "description": "Native x86_64-pc-windows-msvc binary for ferromark",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/sebastian-software/ferromark.git",
+    "directory": "node/ferromark"
+  },
+  "engines": {
+    "node": ">=22.0.0"
+  },
+  "os": [
+    "win32"
+  ],
+  "cpu": [
+    "x64"
+  ],
+  "main": "ferromark.win32-x64-msvc.node",
+  "files": [
+    "ferromark.win32-x64-msvc.node"
+  ],
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
+  }
+}

--- a/node/ferromark/package.json
+++ b/node/ferromark/package.json
@@ -33,13 +33,22 @@
   "module": "./index.mjs",
   "types": "./index.d.mts",
   "files": [
-    "ferromark.*.node",
     "index.d.mts",
     "index.mjs",
     "LICENSE",
     "native.d.ts",
     "README.md"
   ],
+  "optionalDependencies": {
+    "ferromark-darwin-arm64": "0.7.0",
+    "ferromark-darwin-x64": "0.7.0",
+    "ferromark-linux-arm64-gnu": "0.7.0",
+    "ferromark-linux-arm64-musl": "0.7.0",
+    "ferromark-linux-x64-gnu": "0.7.0",
+    "ferromark-linux-x64-musl": "0.7.0",
+    "ferromark-win32-arm64-msvc": "0.7.0",
+    "ferromark-win32-x64-msvc": "0.7.0"
+  },
   "engines": {
     "node": ">=22.0.0"
   },
@@ -60,9 +69,11 @@
       "aarch64-apple-darwin",
       "aarch64-pc-windows-msvc",
       "aarch64-unknown-linux-gnu",
+      "aarch64-unknown-linux-musl",
       "x86_64-apple-darwin",
       "x86_64-pc-windows-msvc",
-      "x86_64-unknown-linux-gnu"
+      "x86_64-unknown-linux-gnu",
+      "x86_64-unknown-linux-musl"
     ]
   }
 }

--- a/node/ferromark/scripts/build-native.mjs
+++ b/node/ferromark/scripts/build-native.mjs
@@ -1,8 +1,18 @@
 import { spawnSync } from 'node:child_process'
+import { rm } from 'node:fs/promises'
+import path from 'node:path'
 import process from 'node:process'
+import { fileURLToPath } from 'node:url'
 
 const pnpm = process.platform === 'win32' ? 'pnpm.cmd' : 'pnpm'
 const outputDir = process.env.FERROMARK_NATIVE_OUTPUT_DIR ?? '.'
+const packageDir = fileURLToPath(new URL('..', import.meta.url))
+const buildOutputDir = outputDir === '.' ? '.napi-artifacts' : outputDir
+
+if (outputDir === '.') {
+  await rm(path.join(packageDir, buildOutputDir), { force: true, recursive: true })
+}
+
 const args = [
   'exec',
   'napi',
@@ -16,11 +26,14 @@ const args = [
   'native.d.ts',
   '--no-js',
   '--output-dir',
-  outputDir,
+  buildOutputDir,
 ]
 
 if (process.env.FERROMARK_RUST_TARGET) {
   args.push('--target', process.env.FERROMARK_RUST_TARGET)
+  if (process.env.FERROMARK_RUST_TARGET.endsWith('-musl')) {
+    args.push('--cross-compile')
+  }
 }
 
 if (process.env.FERROMARK_NAPI_FEATURES) {
@@ -39,5 +52,26 @@ const result = spawnSync(pnpm, args, {
 if (result.error) {
   throw result.error
 }
+if (result.status !== 0) {
+  process.exit(result.status ?? 1)
+}
 
-process.exit(result.status ?? 1)
+// Normal builds keep the local addon for development and copy it into the
+// matching optional package. Isolated verification builds use a temporary
+// output directory and must not modify package artifacts.
+if (outputDir === '.') {
+  const artifacts = spawnSync(
+    pnpm,
+    ['exec', 'napi', 'artifacts', '--output-dir', buildOutputDir, '--npm-dir', 'npm'],
+    {
+      cwd: new URL('..', import.meta.url),
+      shell: process.platform === 'win32',
+      stdio: 'inherit',
+    },
+  )
+  if (artifacts.error) {
+    throw artifacts.error
+  }
+  await rm(path.join(packageDir, buildOutputDir), { force: true, recursive: true })
+  process.exit(artifacts.status ?? 1)
+}

--- a/node/ferromark/scripts/test-readme-contract.mjs
+++ b/node/ferromark/scripts/test-readme-contract.mjs
@@ -51,14 +51,14 @@ function assertReadmeContract(candidate) {
   assert.match(candidate, /^## Troubleshooting native loading$/m, 'README must explain lazy loader failures')
   assert.match(candidate, /first call to `toHtml\(\)`, `transform\(\)`, or a\s+highlighter helper/i)
 
-  assert.match(loader, /musl is not supported/, 'loader must retain its musl diagnostic')
-  assert.match(candidate, /Alpine or another musl Linux environment/, 'README must cover the musl loader error')
+  assert.match(loader, /linux-arm64-musl/, 'loader must select the arm64 musl package')
+  assert.match(loader, /linux-x64-musl/, 'loader must select the x64 musl package')
   assert.match(loader, /does not support \$\{process\.platform\}/, 'loader must retain unsupported-target diagnostics')
   assert.match(candidate, /Unsupported platform or architecture/, 'README must cover unsupported targets')
-  assert.match(loader, /does not include a native binary/, 'loader must retain missing-binary diagnostics')
-  assert.match(candidate, /`does not include a native binary`/, 'README must cover missing binaries')
+  assert.match(loader, /could not load the optional native package/, 'loader must retain missing-package diagnostics')
+  assert.match(candidate, /`could not load the optional native package`/, 'README must cover missing platform packages')
 
-  const loaderTargets = [...loader.matchAll(/'([a-z0-9]+-(?:arm64|x64))': '([a-z0-9-]+)'/g)]
+  const loaderTargets = [...loader.matchAll(/'([a-z0-9]+-(?:arm64|x64)(?:-(?:gnu|musl))?)': '([a-z0-9-]+)'/g)]
     .map(([, host, target]) => ({ host, target }))
   const packageTargets = packageJson.napi.targets.map(packageTargetToBindingTarget)
   assert.deepEqual(
@@ -66,12 +66,12 @@ function assertReadmeContract(candidate) {
     packageTargets.slice().sort(),
     'loader targets and published native targets must stay aligned',
   )
-  assert.match(candidate, /glibc\s+Linux, macOS, and Windows on x64 and arm64/, 'README must state published platforms')
+  assert.match(candidate, /glibc or musl Linux, macOS, and Windows on x64 and arm64/, 'README must state published platforms')
   assert.match(candidate, /no WASM fallback/, 'README must state the missing fallback')
 }
 
 function packageTargetToBindingTarget(target) {
-  const match = target.match(/^(aarch64|x86_64)-(apple|unknown-linux|pc-windows)-(darwin|gnu|msvc)$/)
+  const match = target.match(/^(aarch64|x86_64)-(apple|unknown-linux|pc-windows)-(darwin|gnu|musl|msvc)$/)
   assert.ok(match, `unsupported napi target format: ${target}`)
 
   const [, architecture, platform, abi] = match
@@ -103,9 +103,9 @@ assert.throws(
   'security documentation contract must reject incorrect trusted output',
 )
 assert.throws(
-  () => assertReadmeContract(readme.replace('Alpine or another musl Linux environment', 'Linux environment')),
-  /musl loader error/,
-  'loader troubleshooting contract must reject missing musl guidance',
+  () => assertReadmeContract(readme.replace('glibc or musl Linux', 'glibc Linux')),
+  /published platforms/,
+  'loader contract must reject missing musl support documentation',
 )
 
 console.log('Node README package, security, and loader contract checks passed')

--- a/node/ferromark/scripts/verify-package.mjs
+++ b/node/ferromark/scripts/verify-package.mjs
@@ -1,11 +1,73 @@
+import assert from 'node:assert/strict'
 import { access, readFile } from 'node:fs/promises'
 
 const required = ['index.mjs', 'index.d.mts', 'native.d.ts', 'package.json']
 await Promise.all(required.map(file => access(new URL(`../${file}`, import.meta.url))))
 
-const declarations = await readFile(new URL('../native.d.ts', import.meta.url), 'utf8')
+const [declarations, packageJson, releaseConfig, buildNative] = await Promise.all([
+  readFile(new URL('../native.d.ts', import.meta.url), 'utf8'),
+  readFile(new URL('../package.json', import.meta.url), 'utf8').then(JSON.parse),
+  readFile(new URL('../../../release-please-config.json', import.meta.url), 'utf8').then(JSON.parse),
+  readFile(new URL('./build-native.mjs', import.meta.url), 'utf8'),
+])
 for (const name of ['Options', 'toHtml', 'toHtmlWithRenderer']) {
   if (!declarations.includes(name)) {
     throw new Error(`Generated native declarations are missing ${name}`)
+  }
+}
+
+assert.ok(!packageJson.files.some(file => file.endsWith('.node')), 'the main package must not ship native binaries')
+assert.match(
+  buildNative,
+  /endsWith\('-musl'\)[\s\S]*args\.push\('--cross-compile'\)/,
+  'musl targets must use napi-rs cargo-zigbuild cross-compilation',
+)
+
+const extraFiles = releaseConfig.packages['.']['extra-files']
+for (const triple of packageJson.napi.targets) {
+  const target = packageTarget(triple)
+  const dependency = `${packageJson.name}-${target.suffix}`
+  assert.equal(packageJson.optionalDependencies[dependency], packageJson.version)
+
+  const packagePath = `node/ferromark/npm/${target.suffix}/package.json`
+  const platformPackage = JSON.parse(
+    await readFile(new URL(`../npm/${target.suffix}/package.json`, import.meta.url), 'utf8'),
+  )
+  assert.equal(platformPackage.name, dependency)
+  assert.equal(platformPackage.version, packageJson.version)
+  assert.deepEqual(platformPackage.os, [target.os])
+  assert.deepEqual(platformPackage.cpu, [target.cpu])
+  assert.deepEqual(platformPackage.libc, target.libc ? [target.libc] : undefined)
+  assert.equal(platformPackage.main, `ferromark.${target.suffix}.node`)
+  assert.deepEqual(platformPackage.files, [platformPackage.main])
+  assert.equal(platformPackage.publishConfig?.provenance, true)
+  assert.ok(extraFiles.includes(packagePath), `${packagePath} must be versioned by release-please`)
+  assert.ok(
+    extraFiles.some(file => file?.jsonpath === `$.optionalDependencies['${dependency}']`),
+    `${dependency} must be versioned by release-please`,
+  )
+}
+
+assert.deepEqual(
+  Object.keys(packageJson.optionalDependencies).sort(),
+  packageJson.napi.targets.map(triple => `${packageJson.name}-${packageTarget(triple).suffix}`).sort(),
+  'optional dependencies must exactly match the configured native targets',
+)
+
+function packageTarget(triple) {
+  const match = triple.match(/^(aarch64|x86_64)-(apple|unknown-linux|pc-windows)-(darwin|gnu|musl|msvc)$/)
+  assert.ok(match, `Unsupported native target: ${triple}`)
+  const [, rustCpu, platform, abi] = match
+  const cpu = rustCpu === 'aarch64' ? 'arm64' : 'x64'
+  const os = {
+    apple: 'darwin',
+    'unknown-linux': 'linux',
+    'pc-windows': 'win32',
+  }[platform]
+  return {
+    cpu,
+    os,
+    libc: abi === 'gnu' ? 'glibc' : abi === 'musl' ? 'musl' : undefined,
+    suffix: abi === 'darwin' ? `${os}-${cpu}` : `${os}-${cpu}-${abi}`,
   }
 }

--- a/node/ferromark/test/index.test.mjs
+++ b/node/ferromark/test/index.test.mjs
@@ -1,4 +1,5 @@
 import assert from 'node:assert/strict'
+import { spawnSync } from 'node:child_process'
 import test from 'node:test'
 
 import { toHtml, toHtmlWithHighlighter, transform, transformWithHighlighter } from '../index.mjs'
@@ -55,6 +56,32 @@ test('rejects unknown option keys across every public render entry point', () =>
       error => error instanceof TypeError && /unknown option.*(?:taskList|footnote)/i.test(error.message),
     )
   }
+})
+
+test('selects the musl optional package on Alpine-style Linux', () => {
+  const entry = new URL('../index.mjs', import.meta.url).href
+  const script = `
+    Object.defineProperty(process, 'platform', { value: 'linux' })
+    Object.defineProperty(process, 'arch', { value: 'arm64' })
+    Object.defineProperty(process, 'report', {
+      value: { getReport: () => ({ header: {} }) },
+    })
+    const { toHtml } = await import(${JSON.stringify(entry)})
+    try {
+      toHtml('text')
+    }
+    catch (error) {
+      if (error instanceof Error && error.message.includes('ferromark-linux-arm64-musl')) {
+        process.exit(0)
+      }
+    }
+    process.exit(1)
+  `
+  const result = spawnSync(process.execPath, ['--input-type=module', '--eval', script], {
+    encoding: 'utf8',
+  })
+
+  assert.equal(result.status, 0, result.stderr)
 })
 
 test('composes with a synchronous Ferriki-compatible highlighter', () => {

--- a/node/package.json
+++ b/node/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "build": "pnpm --filter ferromark build",
     "build:native": "pnpm --filter ferromark build:native",
-    "lint": "node --check scripts/clean-install-smoke.mjs && node --check scripts/verify-npm-publish.mjs && node --check scripts/verify-pack.mjs && node --check scripts/verify-release.mjs && pnpm --filter ferromark lint",
+    "lint": "node --check scripts/clean-install-smoke.mjs && node --check scripts/publish-platform-packages.mjs && node --check scripts/verify-npm-publish.mjs && node --check scripts/verify-pack.mjs && node --check scripts/verify-platform-artifact.mjs && node --check scripts/verify-release.mjs && pnpm --filter ferromark lint",
     "typecheck": "tsc --noEmit -p tsconfig.json",
     "test": "pnpm --filter ferromark test",
     "pack:check": "node ./scripts/verify-pack.mjs",

--- a/node/pnpm-lock.yaml
+++ b/node/pnpm-lock.yaml
@@ -21,7 +21,48 @@ importers:
         specifier: 7.0.2
         version: 7.0.2
 
-  ferromark: {}
+  ferromark:
+    optionalDependencies:
+      ferromark-darwin-arm64:
+        specifier: 0.7.0
+        version: link:npm/darwin-arm64
+      ferromark-darwin-x64:
+        specifier: 0.7.0
+        version: link:npm/darwin-x64
+      ferromark-linux-arm64-gnu:
+        specifier: 0.7.0
+        version: link:npm/linux-arm64-gnu
+      ferromark-linux-arm64-musl:
+        specifier: 0.7.0
+        version: link:npm/linux-arm64-musl
+      ferromark-linux-x64-gnu:
+        specifier: 0.7.0
+        version: link:npm/linux-x64-gnu
+      ferromark-linux-x64-musl:
+        specifier: 0.7.0
+        version: link:npm/linux-x64-musl
+      ferromark-win32-arm64-msvc:
+        specifier: 0.7.0
+        version: link:npm/win32-arm64-msvc
+      ferromark-win32-x64-msvc:
+        specifier: 0.7.0
+        version: link:npm/win32-x64-msvc
+
+  ferromark/npm/darwin-arm64: {}
+
+  ferromark/npm/darwin-x64: {}
+
+  ferromark/npm/linux-arm64-gnu: {}
+
+  ferromark/npm/linux-arm64-musl: {}
+
+  ferromark/npm/linux-x64-gnu: {}
+
+  ferromark/npm/linux-x64-musl: {}
+
+  ferromark/npm/win32-arm64-msvc: {}
+
+  ferromark/npm/win32-x64-msvc: {}
 
 packages:
 

--- a/node/pnpm-workspace.yaml
+++ b/node/pnpm-workspace.yaml
@@ -1,5 +1,20 @@
 packages:
   - ferromark
+  - ferromark/npm/*
+
+linkWorkspacePackages: true
+
+supportedArchitectures:
+  os:
+    - darwin
+    - linux
+    - win32
+  cpu:
+    - arm64
+    - x64
+  libc:
+    - glibc
+    - musl
 
 onlyBuiltDependencies:
   - '@napi-rs/cli'

--- a/node/scripts/clean-install-smoke.mjs
+++ b/node/scripts/clean-install-smoke.mjs
@@ -8,8 +8,14 @@ import { fileURLToPath } from 'node:url'
 const workspace = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..')
 const artifacts = path.join(workspace, 'artifacts')
 const archives = (await readdir(artifacts)).filter(file => file.endsWith('.tgz'))
-if (archives.length !== 1) {
-  throw new Error(`Expected one packed archive, found ${archives.length}`)
+const target = nativeTarget()
+const mainArchive = archives.find(file => /^ferromark-\d/.test(file))
+const platformArchive = archives.find(file => file.startsWith(`ferromark-${target}-`))
+
+if (!mainArchive || !platformArchive) {
+  throw new Error(
+    `Expected main and ${target} archives, found: ${archives.sort().join(', ') || 'none'}`,
+  )
 }
 
 const consumer = await mkdtemp(path.join(tmpdir(), 'ferromark-consumer-'))
@@ -18,10 +24,17 @@ try {
     path.join(consumer, 'package.json'),
     JSON.stringify({ private: true, type: 'module' }),
   )
-  const archive = path.join(artifacts, archives[0])
   const install = spawnSync(
     'npm',
-    ['install', '--ignore-scripts', '--no-audit', '--no-fund', archive],
+    [
+      'install',
+      '--ignore-scripts',
+      '--no-audit',
+      '--no-fund',
+      '--omit=optional',
+      path.join(artifacts, mainArchive),
+      path.join(artifacts, platformArchive),
+    ],
     {
       cwd: consumer,
       encoding: 'utf8',
@@ -53,8 +66,29 @@ try {
   const installed = JSON.parse(
     await readFile(path.join(consumer, 'node_modules/ferromark/package.json'), 'utf8'),
   )
+  const mainFiles = await readdir(path.join(consumer, 'node_modules/ferromark'))
+  if (mainFiles.some(file => file.endsWith('.node'))) {
+    throw new Error('The installed main package unexpectedly contains a native binary')
+  }
+  await readFile(
+    path.join(
+      consumer,
+      'node_modules',
+      `ferromark-${target}`,
+      `ferromark.${target}.node`,
+    ),
+  )
   console.log(`Clean install passed for ferromark ${installed.version}`)
 }
 finally {
   await rm(consumer, { force: true, recursive: true })
+}
+
+function nativeTarget() {
+  const base = `${process.platform}-${process.arch}`
+  if (process.platform !== 'linux') {
+    return base === 'win32-arm64' || base === 'win32-x64' ? `${base}-msvc` : base
+  }
+  const report = process.report?.getReport?.()
+  return `${base}-${report?.header?.glibcVersionRuntime ? 'gnu' : 'musl'}`
 }

--- a/node/scripts/publish-platform-packages.mjs
+++ b/node/scripts/publish-platform-packages.mjs
@@ -1,0 +1,34 @@
+import { readFile } from 'node:fs/promises'
+import path from 'node:path'
+import process from 'node:process'
+import { spawnSync } from 'node:child_process'
+import { fileURLToPath } from 'node:url'
+
+const workspace = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..')
+const packageDir = path.join(workspace, 'ferromark')
+const packageJson = JSON.parse(await readFile(path.join(packageDir, 'package.json'), 'utf8'))
+const prefix = `${packageJson.name}-`
+
+for (const [name, version] of Object.entries(packageJson.optionalDependencies).sort()) {
+  if (!name.startsWith(prefix) || version !== packageJson.version) {
+    throw new Error(`Invalid platform dependency: ${name}@${version}`)
+  }
+
+  const target = name.slice(prefix.length)
+  console.log(`Publishing ${name}@${version}`)
+  const result = spawnSync(
+    'npm',
+    ['publish', '--access', 'public', '--provenance'],
+    {
+      cwd: path.join(packageDir, 'npm', target),
+      shell: process.platform === 'win32',
+      stdio: 'inherit',
+    },
+  )
+  if (result.error) {
+    throw result.error
+  }
+  if (result.status !== 0) {
+    process.exit(result.status ?? 1)
+  }
+}

--- a/node/scripts/verify-pack.mjs
+++ b/node/scripts/verify-pack.mjs
@@ -1,4 +1,4 @@
-import { mkdir, rm } from 'node:fs/promises'
+import { mkdir, readFile, rm } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import path from 'node:path'
 import process from 'node:process'
@@ -14,56 +14,75 @@ if (args.length > 1 || (args.length === 1 && args[0] !== '--all-targets')) {
   throw new Error(`Usage: node ${path.basename(fileURLToPath(import.meta.url))} [--all-targets]`)
 }
 
+const packageJson = JSON.parse(await readFile(path.join(packageDir, 'package.json'), 'utf8'))
+const platformTargets = Object.keys(packageJson.optionalDependencies)
+  .map(name => name.slice(`${packageJson.name}-`.length))
+const targets = args[0] === '--all-targets' ? platformTargets : [nativeTarget()]
+
 await rm(artifacts, { force: true, recursive: true })
 await mkdir(artifacts, { recursive: true })
 
-const packed = spawnSync(
-  'npm',
-  ['pack', '--json', '--pack-destination', artifacts],
-  {
-    cwd: packageDir,
-    encoding: 'utf8',
-    env: { ...process.env, npm_config_cache: path.join(tmpdir(), 'ferromark-npm-cache') },
-  },
-)
-if (packed.status !== 0) {
-  process.stderr.write(packed.stderr)
-  process.exit(packed.status ?? 1)
-}
-
-const [result] = JSON.parse(packed.stdout)
-const allowed = [
-  /^LICENSE$/,
-  /^README\.md$/,
-  /^ferromark\.[a-z0-9-]+\.node$/,
-  /^index\.d\.mts$/,
-  /^index\.mjs$/,
-  /^native\.d\.ts$/,
-  /^package\.json$/,
+const main = pack(packageDir)
+const mainFiles = main.files.map(file => file.path).sort()
+const allowedMain = [
+  'LICENSE',
+  'README.md',
+  'index.d.mts',
+  'index.mjs',
+  'native.d.ts',
+  'package.json',
 ]
-const files = result.files.map(file => file.path).sort()
-const unexpected = files.filter(file => !allowed.some(pattern => pattern.test(file)))
-if (unexpected.length > 0) {
-  throw new Error(`Packed package contains unexpected files:\n${unexpected.join('\n')}`)
+if (mainFiles.some(file => file.endsWith('.node'))) {
+  throw new Error('Main package must not contain a native binary')
 }
-const nativeFiles = files.filter(file => /^ferromark\.[a-z0-9-]+\.node$/.test(file))
-if (nativeFiles.length === 0) {
-  throw new Error('Packed package does not contain a native binary')
+if (mainFiles.some(file => !allowedMain.includes(file))) {
+  throw new Error(`Main package contains unexpected files:\n${mainFiles.join('\n')}`)
+}
+if (main.unpackedSize >= 100_000) {
+  throw new Error(`Main package is unexpectedly large: ${main.unpackedSize} bytes unpacked`)
 }
 
-if (args[0] === '--all-targets') {
-  const expectedNativeFiles = [
-    'ferromark.darwin-arm64.node',
-    'ferromark.darwin-x64.node',
-    'ferromark.linux-arm64-gnu.node',
-    'ferromark.linux-x64-gnu.node',
-    'ferromark.win32-arm64-msvc.node',
-    'ferromark.win32-x64-msvc.node',
+const platforms = targets.map((target) => {
+  const result = pack(path.join(packageDir, 'npm', target))
+  const files = result.files.map(file => file.path).sort()
+  const expected = [
+    'README.md',
+    `ferromark.${target}.node`,
+    'package.json',
   ]
-  const missingNativeFiles = expectedNativeFiles.filter(file => !nativeFiles.includes(file))
-  if (missingNativeFiles.length > 0) {
-    throw new Error(`Packed package is missing native binaries:\n${missingNativeFiles.join('\n')}`)
+  if (files.length !== expected.length || expected.some(file => !files.includes(file))) {
+    throw new Error(`${target} package has invalid contents:\n${files.join('\n')}`)
   }
+  return { filename: result.filename, files, unpackedSize: result.unpackedSize }
+})
+
+console.log(JSON.stringify({
+  main: { filename: main.filename, files: mainFiles, unpackedSize: main.unpackedSize },
+  platforms,
+}, null, 2))
+
+function pack(directory) {
+  const packed = spawnSync(
+    'npm',
+    ['pack', '--json', '--pack-destination', artifacts],
+    {
+      cwd: directory,
+      encoding: 'utf8',
+      env: { ...process.env, npm_config_cache: path.join(tmpdir(), 'ferromark-npm-cache') },
+    },
+  )
+  if (packed.status !== 0) {
+    process.stderr.write(packed.stderr)
+    process.exit(packed.status ?? 1)
+  }
+  return JSON.parse(packed.stdout)[0]
 }
 
-console.log(JSON.stringify({ filename: result.filename, files }, null, 2))
+function nativeTarget() {
+  const base = `${process.platform}-${process.arch}`
+  if (process.platform !== 'linux') {
+    return base === 'win32-arm64' || base === 'win32-x64' ? `${base}-msvc` : base
+  }
+  const report = process.report?.getReport?.()
+  return `${base}-${report?.header?.glibcVersionRuntime ? 'gnu' : 'musl'}`
+}

--- a/node/scripts/verify-platform-artifact.mjs
+++ b/node/scripts/verify-platform-artifact.mjs
@@ -1,0 +1,28 @@
+import assert from 'node:assert/strict'
+import { readFile, stat } from 'node:fs/promises'
+import path from 'node:path'
+import process from 'node:process'
+import { fileURLToPath } from 'node:url'
+
+const workspace = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..')
+const packageDir = path.join(workspace, 'ferromark')
+const [target, ...extraArgs] = process.argv.slice(2)
+
+if (!target || extraArgs.length > 0 || !/^[a-z0-9-]+$/.test(target)) {
+  throw new Error(`Usage: node ${path.basename(fileURLToPath(import.meta.url))} <platform-target>`)
+}
+
+const [mainPackage, platformPackage] = await Promise.all([
+  readFile(path.join(packageDir, 'package.json'), 'utf8').then(JSON.parse),
+  readFile(path.join(packageDir, 'npm', target, 'package.json'), 'utf8').then(JSON.parse),
+])
+const dependency = `${mainPackage.name}-${target}`
+const binary = path.join(packageDir, 'npm', target, `ferromark.${target}.node`)
+const binaryInfo = await stat(binary)
+
+assert.equal(platformPackage.name, dependency)
+assert.equal(platformPackage.version, mainPackage.version)
+assert.equal(mainPackage.optionalDependencies[dependency], mainPackage.version)
+assert.ok(binaryInfo.isFile() && binaryInfo.size > 0, `Invalid native binary: ${binary}`)
+
+console.log(`Verified ${dependency}@${platformPackage.version} (${binaryInfo.size} bytes)`)

--- a/node/scripts/verify-release.mjs
+++ b/node/scripts/verify-release.mjs
@@ -19,16 +19,30 @@ const targets = [
   'darwin-arm64',
   'darwin-x64',
   'linux-arm64-gnu',
+  'linux-arm64-musl',
   'linux-x64-gnu',
+  'linux-x64-musl',
   'win32-arm64-msvc',
   'win32-x64-msvc',
 ]
 for (const target of targets) {
-  const file = path.join(packageDir, `ferromark.${target}.node`)
+  const platformDir = path.join(packageDir, 'npm', target)
+  const platformPackage = JSON.parse(
+    await readFile(path.join(platformDir, 'package.json'), 'utf8'),
+  )
+  if (platformPackage.version !== packageJson.version) {
+    throw new Error(
+      `Platform package version mismatch: ${platformPackage.name}@${platformPackage.version}`,
+    )
+  }
+  if (packageJson.optionalDependencies[platformPackage.name] !== packageJson.version) {
+    throw new Error(`Main package does not pin ${platformPackage.name}@${packageJson.version}`)
+  }
+  const file = path.join(platformDir, `ferromark.${target}.node`)
   const info = await stat(file)
   if (!info.isFile() || info.size === 0) {
     throw new Error(`Invalid native binary: ${file}`)
   }
 }
 
-console.log(`Verified ferromark ${packageJson.version} with ${targets.length} native binaries`)
+console.log(`Verified ferromark ${packageJson.version} with ${targets.length} platform packages`)

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -6,7 +6,55 @@
       "bump-minor-pre-major": true,
       "bump-patch-for-minor-pre-major": true,
       "extra-files": [
-        "node/ferromark/package.json"
+        "node/ferromark/package.json",
+        "node/ferromark/npm/darwin-arm64/package.json",
+        "node/ferromark/npm/darwin-x64/package.json",
+        "node/ferromark/npm/linux-arm64-gnu/package.json",
+        "node/ferromark/npm/linux-arm64-musl/package.json",
+        "node/ferromark/npm/linux-x64-gnu/package.json",
+        "node/ferromark/npm/linux-x64-musl/package.json",
+        "node/ferromark/npm/win32-arm64-msvc/package.json",
+        "node/ferromark/npm/win32-x64-msvc/package.json",
+        {
+          "type": "json",
+          "path": "node/ferromark/package.json",
+          "jsonpath": "$.optionalDependencies['ferromark-darwin-arm64']"
+        },
+        {
+          "type": "json",
+          "path": "node/ferromark/package.json",
+          "jsonpath": "$.optionalDependencies['ferromark-darwin-x64']"
+        },
+        {
+          "type": "json",
+          "path": "node/ferromark/package.json",
+          "jsonpath": "$.optionalDependencies['ferromark-linux-arm64-gnu']"
+        },
+        {
+          "type": "json",
+          "path": "node/ferromark/package.json",
+          "jsonpath": "$.optionalDependencies['ferromark-linux-arm64-musl']"
+        },
+        {
+          "type": "json",
+          "path": "node/ferromark/package.json",
+          "jsonpath": "$.optionalDependencies['ferromark-linux-x64-gnu']"
+        },
+        {
+          "type": "json",
+          "path": "node/ferromark/package.json",
+          "jsonpath": "$.optionalDependencies['ferromark-linux-x64-musl']"
+        },
+        {
+          "type": "json",
+          "path": "node/ferromark/package.json",
+          "jsonpath": "$.optionalDependencies['ferromark-win32-arm64-msvc']"
+        },
+        {
+          "type": "json",
+          "path": "node/ferromark/package.json",
+          "jsonpath": "$.optionalDependencies['ferromark-win32-x64-msvc']"
+        }
       ]
     }
   }

--- a/scripts/test-node-ci-matrix.rb
+++ b/scripts/test-node-ci-matrix.rb
@@ -16,26 +16,49 @@ unless native.fetch('permissions') == { 'contents' => 'read' }
 end
 
 expected_targets = [
-  { 'os' => 'macos-latest', 'rust_target' => 'aarch64-apple-darwin' },
-  { 'os' => 'macos-15-intel', 'rust_target' => 'x86_64-apple-darwin' },
-  { 'os' => 'ubuntu-24.04-arm', 'rust_target' => 'aarch64-unknown-linux-gnu' },
-  { 'os' => 'windows-latest', 'rust_target' => 'x86_64-pc-windows-msvc' },
-  { 'os' => 'windows-11-arm', 'rust_target' => 'aarch64-pc-windows-msvc' }
+  { 'os' => 'macos-latest', 'rust_target' => 'aarch64-apple-darwin', 'artifact' => 'darwin-arm64', 'runtime_test' => true },
+  { 'os' => 'macos-15-intel', 'rust_target' => 'x86_64-apple-darwin', 'artifact' => 'darwin-x64', 'runtime_test' => true },
+  { 'os' => 'ubuntu-24.04-arm', 'rust_target' => 'aarch64-unknown-linux-gnu', 'artifact' => 'linux-arm64-gnu', 'runtime_test' => true },
+  { 'os' => 'ubuntu-latest', 'rust_target' => 'x86_64-unknown-linux-musl', 'artifact' => 'linux-x64-musl', 'runtime_test' => false },
+  { 'os' => 'ubuntu-latest', 'rust_target' => 'aarch64-unknown-linux-musl', 'artifact' => 'linux-arm64-musl', 'runtime_test' => false },
+  { 'os' => 'windows-latest', 'rust_target' => 'x86_64-pc-windows-msvc', 'artifact' => 'win32-x64-msvc', 'runtime_test' => true },
+  { 'os' => 'windows-11-arm', 'rust_target' => 'aarch64-pc-windows-msvc', 'artifact' => 'win32-arm64-msvc', 'runtime_test' => true }
 ]
 actual_targets = native.fetch('strategy').fetch('matrix').fetch('include')
 
 unless actual_targets == expected_targets
-  abort "native CI matrix must execute the supported macOS, Linux arm64, and Windows targets"
+  abort "native CI matrix must build every non-host platform, including Linux musl"
 end
 
 steps = native.fetch('steps')
 build_index = steps.index { |step| step['run'] == 'pnpm build:native' }
 test_index = steps.index { |step| step['run'] == 'pnpm test' }
+verify_index = steps.index do |step|
+  step['run'] == 'node ./scripts/verify-platform-artifact.mjs ${{ matrix.artifact }}'
+end
+zig_index = steps.index do |step|
+  step['uses'] == 'mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29'
+end
+zigbuild_index = steps.index do |step|
+  step['uses'] == 'taiki-e/install-action@e67fa11c4b9316fa714ddf0abed07a0c3143b95b'
+end
 
 abort 'native CI job must build the N-API binding' unless build_index
 unless steps.fetch(build_index).fetch('env') == { 'FERROMARK_RUST_TARGET' => '${{ matrix.rust_target }}' }
   abort 'native CI job must build the N-API binding for the matrix target'
 end
 abort 'native CI job must run pnpm test after building the N-API binding' unless test_index && test_index > build_index
+unless steps.fetch(test_index).fetch('if') == '${{ matrix.runtime_test }}'
+  abort 'native CI job must skip runtime tests only for cross-compiled musl targets'
+end
+unless verify_index && verify_index > build_index
+  abort 'native CI job must verify the generated platform package'
+end
+unless zig_index && steps.fetch(zig_index).fetch('if') == "${{ contains(matrix.rust_target, '-musl') }}"
+  abort 'native CI job must install Zig for musl targets'
+end
+unless zigbuild_index && steps.fetch(zigbuild_index).fetch('with') == { 'tool' => 'cargo-zigbuild' }
+  abort 'native CI job must install cargo-zigbuild for musl targets'
+end
 
 puts 'native CI matrix checks passed'

--- a/scripts/test-publish-verification.mjs
+++ b/scripts/test-publish-verification.mjs
@@ -44,8 +44,34 @@ function assertCratePublicationWaitsForVerification(source) {
   assert.doesNotMatch(crateJob, /- publish-npm/)
 }
 
+function assertPlatformPackagesArePublished(source) {
+  for (const artifact of [
+    'darwin-arm64',
+    'darwin-x64',
+    'linux-arm64-gnu',
+    'linux-arm64-musl',
+    'linux-x64-gnu',
+    'linux-x64-musl',
+    'win32-arm64-msvc',
+    'win32-x64-msvc',
+  ]) {
+    assert.match(source, new RegExp(`artifact: ${artifact}\\n`))
+  }
+
+  const assembleIndex = source.indexOf(
+    'run: pnpm --dir ferromark exec napi artifacts --output-dir .napi-artifacts --npm-dir npm',
+  )
+  const verifyIndex = source.indexOf('run: node ./scripts/verify-release.mjs')
+  const platformPublishIndex = source.indexOf('run: node ./scripts/publish-platform-packages.mjs')
+  const mainPublishIndex = source.indexOf('run: npm publish --access public --provenance')
+  assert.ok(assembleIndex !== -1 && assembleIndex < verifyIndex)
+  assert.ok(verifyIndex < platformPublishIndex)
+  assert.ok(platformPublishIndex < mainPublishIndex)
+}
+
 assertValidVerifierJob(workflow)
 assertCratePublicationWaitsForVerification(workflow)
+assertPlatformPackagesArePublished(workflow)
 assert.throws(
   () => assertValidVerifierJob(workflow.replace('\n  verify-npm-publish:\n', '\n  npm-check:\n')),
   /verify-npm-publish/,


### PR DESCRIPTION
Closes #155

## Summary
- split the Node addon into eight OS/CPU/libc-specific optional packages
- add x64 and arm64 Linux musl builds and Alpine-aware runtime selection
- assemble, verify, and publish platform packages before the small main package
- harden package and clean-install checks against regressions

## Verification
- cargo test --locked --all-features
- cargo clippy --all-targets --all-features --locked -- -D warnings
- repeated pnpm build, followed by pnpm test/typecheck/lint
- pnpm pack:check (main package: 21,596 bytes unpacked)
- clean-install smoke test
- workflow, release, README, and documentation contract checks