### PR TITLE
docs: scope benchmark claims to Apple Silicon

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,10 @@ APIs allow and binaries are non-PGO. ferromark also keeps its secure default
 rendering in this published product lane, so it performs URL and raw-HTML safety
 work that pulldown-cmark does not.
 
+These rankings are Apple Silicon results only. ferromark also uses baseline
+SSE2 for inline scanning on x86-64, but this comparison has not been re-measured
+there; do not infer the same relative ordering on x86-64 from these tables.
+
 **CommonMark 5 KB** (wiki-style, mixed content with tables)
 | Parser | Throughput | vs ferromark |
 |--------|----------:|------------:|
@@ -85,7 +89,9 @@ work that pulldown-cmark does not.
 | md4c (C) | 253.3 MiB/s | 0.90x |
 | comrak | 71.8 MiB/s | 0.26x |
 
-2% faster than pulldown-cmark. 11% faster than md4c. 4x faster than comrak. Competitor versions: pulldown-cmark 0.13.4, comrak 0.53, md4c @ 65c6c9d.
+On this Apple Silicon run, ferromark was 2% faster than pulldown-cmark, 11%
+faster than md4c, and 4x faster than comrak. Competitor versions:
+pulldown-cmark 0.13.4, comrak 0.53, md4c @ 65c6c9d.
 
 The fixtures are synthetic wiki-style documents with paragraphs, lists, code blocks, and tables. Nothing cherry-picked. The cross-parser harness is isolated from the library build and pins md4c at `65c6c9d` for the published numbers:
 
@@ -522,7 +528,7 @@ What makes this fast in practice:
 - **Block scanning** runs on `memchr` for line boundaries. Container state is a compact stack, not a tree.
 - **Inline parsing** has three phases: collect delimiter marks, resolve precedence (code spans, math, links, emphasis, strikethrough, subscript, superscript, highlight), emit. No backtracking.
 - **Emphasis resolution** uses the CommonMark modulo-3 rule with a delimiter stack instead of expensive rescans.
-- **SIMD scanning**: NEON (AArch64) drives the inline specials scan; the HTML escaper uses SSE2 (x86-64) and NEON short scans; memchr covers the remaining byte searches on every architecture.
+- **SIMD scanning**: NEON (AArch64) and baseline SSE2 (x86-64) drive the inline specials scan; the HTML escaper uses both for short scans; memchr covers the remaining byte searches on every architecture.
 - **Zero-copy references**: events carry `Range` pointers into the input, not copied strings.
 - **Compact events**: 24 bytes each, cache-line friendly.
 - **Hot/cold annotation**: `#[inline]` on tight loops, `#[cold]` on error paths, table-driven byte classification.
@@ -652,7 +658,7 @@ Ferromark optimization backlog: [docs/arch/ARCH-PLAN-001-performance-opportuniti
       <td align="center">🟩</td>
       <td align="center">🟥</td>
     </tr>
-    <tr><td colspan="5"><small>SIMD accelerates scanning for special characters. ferromark and pulldown-cmark have SIMD paths; md4c relies on C compiler optimizations; comrak is not SIMD-focused.</small></td></tr>
+    <tr><td colspan="5"><small>SIMD accelerates scanning for special characters. ferromark uses baseline NEON on AArch64 and SSE2 on x86-64, but the published comparison above measures Apple Silicon only. pulldown-cmark also has SIMD paths; md4c relies on C compiler optimizations; comrak is not SIMD-focused.</small></td></tr>
     <tr>
       <td><b>Hot-path control</b></td>
       <td align="center">🟩</td>
@@ -828,7 +834,7 @@ src/
 ├── inline/         # Inline-level parser
 │   ├── mod.rs      # Three-phase inline parsing
 │   ├── marks.rs    # Mark collection + SIMD integration
-│   ├── simd.rs     # SIMD character scanning (NEON)
+│   ├── simd.rs     # SIMD character scanning (SSE2/NEON)
 │   ├── event.rs    # InlineEvent types
 │   ├── code_span.rs
 │   ├── emphasis.rs      # Modulo-3 stack optimization

--- a/homepage/app/routes/guide/benchmarks.mdx
+++ b/homepage/app/routes/guide/benchmarks.mdx
@@ -11,6 +11,10 @@ are non-PGO. ferromark keeps its secure default rendering in this published
 product lane, so it also performs URL and raw-HTML safety work that
 pulldown-cmark does not.
 
+These rankings are Apple Silicon results only. ferromark also uses baseline
+SSE2 for inline scanning on x86-64, but this comparison has not been re-measured
+there; do not infer the same relative ordering on x86-64 from these tables.
+
 ## CommonMark 5 KB
 
 | Parser | Throughput | vs ferromark |
@@ -29,7 +33,9 @@ pulldown-cmark does not.
 | md4c (C) | 253.3 MiB/s | 0.90x |
 | comrak | 71.8 MiB/s | 0.26x |
 
-Summary: 2% faster than pulldown-cmark, 11% faster than md4c, and roughly 4x faster than comrak on this fixture set. Competitor versions: pulldown-cmark 0.13.4, comrak 0.53, md4c @ 65c6c9d.
+Summary: on this Apple Silicon fixture set, ferromark was 2% faster than
+pulldown-cmark, 11% faster than md4c, and roughly 4x faster than comrak.
+Competitor versions: pulldown-cmark 0.13.4, comrak 0.53, md4c @ 65c6c9d.
 
 ## Reproduce locally
 

--- a/homepage/app/routes/home.tsx
+++ b/homepage/app/routes/home.tsx
@@ -61,7 +61,7 @@ export default function HomePage() {
         <p className="eyebrow">Rust Markdown Engine</p>
         <h1>Markdown to HTML at 280 MiB/s</h1>
         <p className="lead">
-          ferromark is a streaming parser focused on one job: turning Markdown into HTML faster than
+          In our published Apple Silicon benchmark, ferromark turns Markdown into HTML faster than
           pulldown-cmark, md4c, and comrak while staying fully CommonMark compliant.
         </p>
         <div className="hero-actions">
@@ -95,7 +95,10 @@ export default function HomePage() {
         <div className="section-head">
           <p className="eyebrow">Proof</p>
           <h2>Benchmark numbers you can verify</h2>
-          <p>Apple Silicon (M-series), July 2026. Non-PGO binaries. Same GFM settings for all parsers.</p>
+          <p>
+            Apple Silicon (M-series), July 2026. Non-PGO binaries. Same GFM settings for all parsers.
+            The relative ranking has not been re-measured on x86-64.
+          </p>
         </div>
         <div className="benchmark-table">
           <table>

--- a/scripts/test-readme-structure-contract.rb
+++ b/scripts/test-readme-structure-contract.rb
@@ -42,6 +42,17 @@ def validate(document)
     fail_contract('Markdown configuration must document Options construction')
   end
   fail_contract('README must preserve the migration guide link') unless document.include?(MIGRATION_GUIDE)
+
+  benchmarks = section(document, 'Benchmarks')
+  unless benchmarks.include?('These rankings are Apple Silicon results only')
+    fail_contract('Benchmarks must scope published rankings to Apple Silicon')
+  end
+  unless benchmarks.include?('has not been re-measured') && benchmarks.include?('x86-64')
+    fail_contract('Benchmarks must disclose the missing x86-64 comparison')
+  end
+  unless document.include?('baseline SSE2 (x86-64)')
+    fail_contract('README must describe the x86-64 inline SIMD path')
+  end
 end
 
 def assert_rejected(label)
@@ -70,6 +81,12 @@ def self_test(document)
   end
   assert_rejected('migration guide link') do
     validate(document.sub(MIGRATION_GUIDE, 'migration guide'))
+  end
+  assert_rejected('Apple Silicon benchmark scope') do
+    validate(document.sub('These rankings are Apple Silicon results only', 'These rankings apply everywhere'))
+  end
+  assert_rejected('x86-64 benchmark caveat') do
+    validate(document.sub('has not been re-measured', 'has been re-measured'))
   end
 end
 


### PR DESCRIPTION
## Summary

- state explicitly that the published parser rankings are Apple Silicon-only and have not been re-measured on x86-64
- scope comparative performance wording in both the README and homepage to the measured architecture
- update the SIMD descriptions for the now-shipped baseline SSE2 and NEON inline scanners
- add a README contract check that preserves the architecture caveat

Fixes #153

## Testing

- `cargo fmt --check`
- `ruby scripts/test-readme-structure-contract.rb --self-test`
- homepage TypeScript check
- full homepage production build and prerender verification
- `git diff --check`

## Checklist

- [x] The change is focused and preserves existing compatibility unless documented.
- [x] Tests cover behavior changes and regressions.
- [x] Public APIs and user-facing behavior are documented.
- [x] `cargo fmt --check` and relevant lint/test commands pass locally.