### PR TITLE
perf: bound inline boundary lookups

### DIFF
--- a/benches/parsing.rs
+++ b/benches/parsing.rs
@@ -107,6 +107,11 @@ to handle longer documents efficiently.
         "*a ".repeat(1000) + &"b* ".repeat(1000)
     }
 
+    /// Mark-capped emphasis followed by link boundaries found by full-text scans.
+    pub fn pathological_emphasis_boundaries() -> String {
+        "*a ".repeat(2048) + &"b* ".repeat(2048) + &"<https://example.com/path> ".repeat(4096)
+    }
+
     /// Document with deeply nested structures
     pub fn pathological_nested() -> String {
         "> ".repeat(100) + "deep\n"
@@ -276,6 +281,12 @@ fn bench_pathological(c: &mut Criterion) {
     group.throughput(Throughput::Bytes(emphasis.len() as u64));
     group.bench_function("emphasis_explosion", |b| {
         b.iter(|| ferromark::to_html(black_box(&emphasis)))
+    });
+
+    let emphasis_boundaries = samples::pathological_emphasis_boundaries();
+    group.throughput(Throughput::Bytes(emphasis_boundaries.len() as u64));
+    group.bench_function("emphasis_many_link_boundaries", |b| {
+        b.iter(|| ferromark::to_html(black_box(&emphasis_boundaries)))
     });
 
     let nested = samples::pathological_nested();

--- a/src/inline/emphasis.rs
+++ b/src/inline/emphasis.rs
@@ -3,7 +3,10 @@
 //! Uses the "modulo-3" stack optimization from md4c to efficiently
 //! match emphasis openers and closers according to CommonMark rules.
 
-use super::marks::{Mark, flags};
+use super::{
+    link_boundary_for,
+    marks::{Mark, flags},
+};
 
 /// Result of emphasis resolution for a mark pair.
 #[derive(Debug, Clone, Copy)]
@@ -197,12 +200,7 @@ impl<'a> EmphasisResolver<'a> {
     /// Find which link boundary (if any) a position is inside.
     /// Returns Some(index) if inside a link, None if outside all links.
     fn link_boundary_for(&self, pos: u32) -> Option<usize> {
-        for (i, &(start, end)) in self.link_boundaries.iter().enumerate() {
-            if pos >= start && pos < end {
-                return Some(i);
-            }
-        }
-        None
+        link_boundary_for(pos, self.link_boundaries)
     }
 
     /// Get stack index for a mark.

--- a/src/inline/highlight.rs
+++ b/src/inline/highlight.rs
@@ -3,7 +3,10 @@
 //! Matches equal-sign runs of exactly length 2 as opener/closer pairs.
 //! Uses the same flanking rules as `*` emphasis (already computed in mark collection).
 
-use super::marks::{Mark, flags};
+use super::{
+    marks::{Mark, flags},
+    same_link_boundary,
+};
 
 /// A matched highlight pair.
 #[derive(Debug, Clone, Copy)]
@@ -82,12 +85,6 @@ pub fn resolve_highlight_into(
             openers.push(i);
         }
     }
-}
-
-fn same_link_boundary(a: u32, b: u32, boundaries: &[(u32, u32)]) -> bool {
-    let a_boundary = boundaries.iter().position(|&(s, e)| a >= s && a < e);
-    let b_boundary = boundaries.iter().position(|&(s, e)| b >= s && b < e);
-    a_boundary == b_boundary
 }
 
 fn pos_in_ranges(pos: u32, ranges: &[(u32, u32)]) -> bool {

--- a/src/inline/mod.rs
+++ b/src/inline/mod.rs
@@ -621,6 +621,7 @@ impl InlineParser {
             self.link_boundaries
                 .push((inline_note.start, inline_note.end));
         }
+        normalize_link_boundaries(&mut self.link_boundaries);
         let emphasis_matches = if summary.has_emphasis() {
             resolve_emphasis_with_stacks_into(
                 self.mark_buffer.marks_mut(),
@@ -2100,6 +2101,50 @@ fn pos_in_ranges_u32(pos: u32, ranges: &[(u32, u32)], idx: &mut usize) -> bool {
     *idx < ranges.len() && pos >= ranges[*idx].0
 }
 
+/// Sort and coalesce link-like boundaries into disjoint half-open ranges.
+///
+/// Resolvers only need to know whether two delimiters occupy the same protected
+/// region. Coalescing nested or overlapping ranges preserves that property and
+/// makes logarithmic lookup possible.
+fn normalize_link_boundaries(boundaries: &mut Vec<(u32, u32)>) {
+    boundaries.sort_unstable_by_key(|&(start, end)| (start, end));
+
+    let mut write = 0;
+    for read in 0..boundaries.len() {
+        let (start, end) = boundaries[read];
+        if start >= end {
+            continue;
+        }
+
+        if write > 0 && start < boundaries[write - 1].1 {
+            boundaries[write - 1].1 = boundaries[write - 1].1.max(end);
+        } else {
+            boundaries[write] = (start, end);
+            write += 1;
+        }
+    }
+    boundaries.truncate(write);
+
+    debug_assert!(
+        boundaries
+            .windows(2)
+            .all(|pair| pair[0].0 < pair[0].1 && pair[0].1 <= pair[1].0)
+    );
+}
+
+#[inline]
+fn link_boundary_for(pos: u32, boundaries: &[(u32, u32)]) -> Option<usize> {
+    let index = boundaries
+        .partition_point(|&(start, _)| start <= pos)
+        .checked_sub(1)?;
+    (pos < boundaries[index].1).then_some(index)
+}
+
+#[inline]
+fn same_link_boundary(a: u32, b: u32, boundaries: &[(u32, u32)]) -> bool {
+    link_boundary_for(a, boundaries) == link_boundary_for(b, boundaries)
+}
+
 #[inline]
 fn is_escaped(text: &[u8], pos: usize) -> bool {
     if pos == 0 {
@@ -2327,6 +2372,30 @@ mod tests {
         let mut events = Vec::new();
         parser.parse(text.as_bytes(), None, true, &mut events);
         events
+    }
+
+    #[test]
+    fn link_boundaries_are_normalized_for_binary_lookup() {
+        let mut boundaries = vec![
+            (20, 30),
+            (8, 18),
+            (5, 15),
+            (30, 35),
+            (40, 40),
+            (2, 4),
+            (9, 10),
+        ];
+
+        normalize_link_boundaries(&mut boundaries);
+
+        assert_eq!(boundaries, vec![(2, 4), (5, 18), (20, 30), (30, 35)]);
+        assert_eq!(link_boundary_for(3, &boundaries), Some(0));
+        assert_eq!(link_boundary_for(4, &boundaries), None);
+        assert_eq!(link_boundary_for(17, &boundaries), Some(1));
+        assert_eq!(link_boundary_for(18, &boundaries), None);
+        assert_eq!(link_boundary_for(29, &boundaries), Some(2));
+        assert_eq!(link_boundary_for(30, &boundaries), Some(3));
+        assert_eq!(link_boundary_for(35, &boundaries), None);
     }
 
     #[test]

--- a/src/inline/strikethrough.rs
+++ b/src/inline/strikethrough.rs
@@ -3,7 +3,10 @@
 //! Matches double-tilde runs as opener/closer pairs.
 //! Uses same flanking rules as `*` emphasis (already computed in mark collection).
 
-use super::marks::{Mark, flags};
+use super::{
+    marks::{Mark, flags},
+    same_link_boundary,
+};
 
 /// A matched strikethrough pair.
 #[derive(Debug, Clone, Copy)]
@@ -82,11 +85,4 @@ pub fn resolve_strikethrough_into(
             openers.push(i);
         }
     }
-}
-
-fn same_link_boundary(a: u32, b: u32, boundaries: &[(u32, u32)]) -> bool {
-    // Both must be in the same link boundary (or both outside any)
-    let a_boundary = boundaries.iter().position(|&(s, e)| a >= s && a < e);
-    let b_boundary = boundaries.iter().position(|&(s, e)| b >= s && b < e);
-    a_boundary == b_boundary
 }

--- a/src/inline/subscript.rs
+++ b/src/inline/subscript.rs
@@ -3,7 +3,10 @@
 //! Matches single-tilde runs as opener/closer pairs.
 //! Uses the same flanking rules as `*` emphasis (already computed in mark collection).
 
-use super::marks::{Mark, flags};
+use super::{
+    marks::{Mark, flags},
+    same_link_boundary,
+};
 
 /// A matched subscript pair.
 #[derive(Debug, Clone, Copy)]
@@ -82,12 +85,6 @@ pub fn resolve_subscript_into(
             openers.push(i);
         }
     }
-}
-
-fn same_link_boundary(a: u32, b: u32, boundaries: &[(u32, u32)]) -> bool {
-    let a_boundary = boundaries.iter().position(|&(s, e)| a >= s && a < e);
-    let b_boundary = boundaries.iter().position(|&(s, e)| b >= s && b < e);
-    a_boundary == b_boundary
 }
 
 fn pos_in_ranges(pos: u32, ranges: &[(u32, u32)]) -> bool {

--- a/src/inline/superscript.rs
+++ b/src/inline/superscript.rs
@@ -3,7 +3,10 @@
 //! Matches single-caret runs as opener/closer pairs.
 //! Uses the same flanking rules as `*` emphasis (already computed in mark collection).
 
-use super::marks::{Mark, flags};
+use super::{
+    marks::{Mark, flags},
+    same_link_boundary,
+};
 
 /// A matched superscript pair.
 #[derive(Debug, Clone, Copy)]
@@ -82,12 +85,6 @@ pub fn resolve_superscript_into(
             openers.push(i);
         }
     }
-}
-
-fn same_link_boundary(a: u32, b: u32, boundaries: &[(u32, u32)]) -> bool {
-    let a_boundary = boundaries.iter().position(|&(s, e)| a >= s && a < e);
-    let b_boundary = boundaries.iter().position(|&(s, e)| b >= s && b < e);
-    a_boundary == b_boundary
 }
 
 fn pos_in_ranges(pos: u32, ranges: &[(u32, u32)]) -> bool {


### PR DESCRIPTION
Closes #167

## Summary
- normalize link-like ranges once into sorted, disjoint half-open boundaries
- replace per-delimiter linear scans with binary lookup for emphasis, strikethrough, subscript, superscript, and highlight
- add boundary normalization coverage and a 4,096-mark/4,096-boundary pathological benchmark

The affected phase changes from O(marks × boundaries) boundary lookup work to O(boundaries log boundaries + marks log boundaries).

## Validation
- cargo test --locked
- cargo test --locked --all-features
- cargo clippy --all-targets --all-features --locked -- -D warnings
- RUSTDOCFLAGS='-D warnings' cargo doc --no-deps --all-features --locked
- cargo fmt --check
- pathological/emphasis_many_link_boundaries: about 924 us, 127 MiB/s on Apple Silicon