### PR TITLE
Ignore leading UTF-8 BOM in MDX documents

### DIFF
--- a/src/mdx/events.rs
+++ b/src/mdx/events.rs
@@ -328,8 +328,9 @@ fn promotable_paragraph(source: &[u8], events: &[MdxEvent]) -> Option<MdxEvent> 
 }
 
 fn front_matter_event(input: &str) -> (usize, Option<MdxEvent>) {
-    let Some((content, rest_offset)) = crate::extract_front_matter(input) else {
-        return (0, None);
+    let (document, document_start) = super::content_after_bom(input);
+    let Some((content, rest_offset)) = crate::extract_front_matter(document) else {
+        return (document_start, None);
     };
 
     let input_start = input.as_ptr() as usize;
@@ -339,9 +340,9 @@ fn front_matter_event(input: &str) -> (usize, Option<MdxEvent>) {
     let content_end = content_start + content.len();
 
     (
-        rest_offset,
+        document_start + rest_offset,
         Some(MdxEvent::FrontMatter {
-            range: Range::from_usize(0, rest_offset),
+            range: Range::from_usize(document_start, document_start + rest_offset),
             content: Range::from_usize(content_start, content_end),
         }),
     )

--- a/src/mdx/mod.rs
+++ b/src/mdx/mod.rs
@@ -5,6 +5,10 @@
 //! segments need to go through ferromark's Markdown parser; JSX, expressions,
 //! and ESM statements are passed through unchanged.
 //!
+//! All entry points ignore one leading UTF-8 byte-order mark. Source ranges
+//! remain absolute offsets into the original input, so content after a BOM
+//! starts at byte 3.
+//!
 //! This module is gated behind the `mdx` Cargo feature.
 //!
 //! # Example
@@ -159,7 +163,8 @@ pub enum Segment<'a> {
 /// The range covers precisely the bytes in [`Self::segment`], including
 /// delimiters, indentation, and a trailing line ending when the segmenter
 /// includes one. The returned ranges are ordered, contiguous, and cover the
-/// complete input without gaps or overlap.
+/// complete parsed content without gaps or overlap. A leading UTF-8 byte-order
+/// mark is ignored, so it is not covered by a segment range.
 ///
 /// Like [`Segment`], this type borrows from the input and performs no copying.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -225,7 +230,8 @@ pub struct SourceLocation {
 /// Segment an MDX document into typed blocks.
 ///
 /// This is the primary entry point. The returned segments cover the entire
-/// input — no bytes are dropped.
+/// input except for an optional leading UTF-8 byte-order mark, which is
+/// ignored before parsing.
 ///
 /// # Panics
 ///
@@ -239,7 +245,8 @@ pub fn segment(input: &str) -> Vec<Segment<'_>> {
 /// Segment an MDX document without panicking for oversized input.
 pub fn try_segment(input: &str) -> Result<Vec<Segment<'_>>, crate::InputSizeError> {
     crate::validate_input_size(input.len())?;
-    Ok(splitter::split(input))
+    let (content, _) = content_after_bom(input);
+    Ok(splitter::split(content))
 }
 
 /// Segment an MDX document and retain exact byte ranges for each segment.
@@ -248,7 +255,8 @@ pub fn try_segment(input: &str) -> Result<Vec<Segment<'_>>, crate::InputSizeErro
 /// same segmentation semantics, while each result records its position in the
 /// original UTF-8 input. The range includes every byte represented by the
 /// segment, including MDX delimiters and any trailing newline owned by that
-/// segment.
+/// segment. An optional leading UTF-8 byte-order mark is ignored, so the first
+/// range begins at byte 3 when one is present.
 ///
 /// # Panics
 ///
@@ -264,17 +272,25 @@ pub fn segment_spanned(input: &str) -> Vec<SpannedSegment<'_>> {
 /// input.
 pub fn try_segment_spanned(input: &str) -> Result<Vec<SpannedSegment<'_>>, crate::InputSizeError> {
     crate::validate_input_size(input.len())?;
-    Ok(spanned_segments(input, splitter::split(input)))
+    let (content, _) = content_after_bom(input);
+    Ok(spanned_segments(input, splitter::split(content)))
 }
 
 pub(crate) fn segment_spanned_with_expression_ends<'a>(
     input: &'a str,
+    content: &'a str,
     expression_ends: &expr::ExpressionEnds,
 ) -> Vec<SpannedSegment<'a>> {
     spanned_segments(
         input,
-        splitter::split_with_expression_ends(input, expression_ends),
+        splitter::split_with_expression_ends(content, expression_ends),
     )
+}
+
+pub(crate) fn content_after_bom(input: &str) -> (&str, usize) {
+    input
+        .strip_prefix('\u{feff}')
+        .map_or((input, 0), |content| (content, '\u{feff}'.len_utf8()))
 }
 
 fn spanned_segments<'a>(input: &'a str, segments: Vec<Segment<'a>>) -> Vec<SpannedSegment<'a>> {

--- a/src/mdx/strict.rs
+++ b/src/mdx/strict.rs
@@ -27,16 +27,30 @@ struct OpenTag {
 }
 
 pub(super) fn segment_strict(input: &str) -> Result<Vec<SpannedSegment<'_>>, Vec<MdxDiagnostic>> {
-    let expression_ends = ExpressionEnds::new(input.as_bytes());
-    let diagnostics = validate(input, &expression_ends);
+    let (content, content_start) = super::content_after_bom(input);
+    let expression_ends = ExpressionEnds::new(content.as_bytes());
+    let mut diagnostics = validate(content, &expression_ends);
     if diagnostics.is_empty() {
         Ok(segment_spanned_with_expression_ends(
             input,
+            content,
             &expression_ends,
         ))
     } else {
+        if content_start != 0 {
+            for diagnostic in &mut diagnostics {
+                diagnostic.primary_range = offset_range(diagnostic.primary_range, content_start);
+                diagnostic.related_range = diagnostic
+                    .related_range
+                    .map(|range| offset_range(range, content_start));
+            }
+        }
         Err(diagnostics)
     }
+}
+
+fn offset_range(range: Range, offset: usize) -> Range {
+    Range::from_usize(range.start_usize() + offset, range.end_usize() + offset)
 }
 
 fn validate(input: &str, expression_ends: &ExpressionEnds) -> Vec<MdxDiagnostic> {

--- a/tests/mdx_event_tests.rs
+++ b/tests/mdx_event_tests.rs
@@ -101,6 +101,37 @@ import Card from './Card'
 }
 
 #[test]
+fn leading_utf8_bom_is_ignored_with_absolute_event_ranges() {
+    let input = "\u{feff}---\ntitle: Hello\n---\nimport Card from './Card'\n\n<Card />\n";
+    let stream = parse_events(input);
+
+    let Some(MdxEvent::FrontMatter { range, content }) = stream.events.first() else {
+        panic!("expected front matter as the first event");
+    };
+    assert_eq!(range.start_usize(), 3);
+    assert_eq!(
+        range.slice_str(input.as_bytes()).unwrap(),
+        "---\ntitle: Hello\n---\n"
+    );
+    assert_eq!(
+        content.slice_str(input.as_bytes()).unwrap(),
+        "title: Hello\n"
+    );
+    assert!(stream.events.iter().any(|event| {
+        matches!(event, MdxEvent::Esm(range)
+            if range.slice_str(input.as_bytes()).unwrap()
+                == "import Card from './Card'\n")
+    }));
+    assert!(stream.events.iter().any(|event| {
+        matches!(event, MdxEvent::FlowJsxSelfClose(range)
+            if range.slice_str(input.as_bytes()).unwrap() == "<Card />\n")
+    }));
+
+    let strict = parse_events_strict(input).unwrap();
+    assert_eq!(strict.events, stream.events);
+}
+
+#[test]
 fn reference_consumer_can_collect_translatable_prose_without_code_or_mdx() {
     let input = "\
 # Hello *world*

--- a/tests/mdx_segment_tests.rs
+++ b/tests/mdx_segment_tests.rs
@@ -36,6 +36,38 @@ fn whitespace_only() {
 }
 
 #[test]
+fn leading_utf8_bom_is_ignored_before_segmenting() {
+    let input = "\u{feff}import Card from './Card'\n\n<Card />\n";
+    let content = &input['\u{feff}'.len_utf8()..];
+    let expected = vec![
+        Segment::Esm("import Card from './Card'\n"),
+        Segment::Markdown("\n"),
+        Segment::JsxBlockSelfClose("<Card />\n"),
+    ];
+
+    assert_eq!(segment(input), expected);
+
+    let spanned = segment_spanned(input);
+    assert_eq!(
+        spanned
+            .iter()
+            .map(|segment| segment.segment.clone())
+            .collect::<Vec<_>>(),
+        expected
+    );
+    assert_eq!(spanned.first().unwrap().range.start_usize(), 3);
+    assert_eq!(spanned.last().unwrap().range.end_usize(), input.len());
+    assert_eq!(
+        spanned
+            .iter()
+            .map(|segment| segment.segment.as_str())
+            .collect::<String>(),
+        content
+    );
+    assert_eq!(segment_strict(input).unwrap(), spanned);
+}
+
+#[test]
 fn spanned_segments_cover_input_with_exact_byte_ranges() {
     let input = "import A from 'a'\r\n\r\n# Grüß\r\n\r\n<Card />\r\n\r\n{user.name}\r\n";
     let segments = segment_spanned(input);
@@ -1135,6 +1167,29 @@ fn strict_mode_reports_mismatched_jsx_tags_with_related_opening_range() {
 }
 
 #[test]
+fn strict_diagnostics_after_a_leading_utf8_bom_keep_absolute_ranges() {
+    let input = "\u{feff}<Outer>\n<Inner>\n</Outer>\n";
+    let diagnostics = segment_strict(input).unwrap_err();
+
+    assert_eq!(diagnostics.len(), 1);
+    assert_eq!(
+        diagnostics[0]
+            .primary_range
+            .slice_str(input.as_bytes())
+            .unwrap(),
+        "</Outer>"
+    );
+    assert_eq!(
+        diagnostics[0]
+            .related_range
+            .unwrap()
+            .slice_str(input.as_bytes())
+            .unwrap(),
+        "<Inner>"
+    );
+}
+
+#[test]
 fn strict_mode_reports_an_unmatched_jsx_closing_tag() {
     let input = "</Card>\n";
     let diagnostics = segment_strict(input).unwrap_err();
@@ -2204,6 +2259,17 @@ fn render_front_matter() {
     assert_eq!(out.front_matter, Some("title: Hello\nauthor: World\n"));
     assert!(out.body.contains("<h1"));
     assert!(out.body.contains("Heading"));
+}
+
+#[test]
+fn render_ignores_a_leading_utf8_bom_before_front_matter_and_esm() {
+    let input = "\u{feff}---\ntitle: Hello\n---\n\nimport Card from './Card'\n\n# Heading\n";
+    let out = render(input);
+
+    assert_eq!(out.front_matter, Some("title: Hello\n"));
+    assert_eq!(out.esm, vec!["import Card from './Card'\n"]);
+    assert!(out.body.contains("Heading"));
+    assert!(!out.body.contains('\u{feff}'));
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- ignore one leading UTF-8 BOM before all MDX segmentation and event entry points
- preserve absolute source ranges into the original input, including strict diagnostic offsets
- cover ESM, JSX, front matter, rendering, event streams, and strict diagnostics with regression tests

Fixes #182

## Verification
- cargo test --locked
- cargo test --locked --all-features
- cargo clippy --all-targets --all-features --locked -- -D warnings
- cargo fmt --all --check
- RUSTDOCFLAGS=-Dwarnings cargo doc --no-deps --all-features --locked
- git diff --check