### PR TITLE
Surface Node highlighter failures

### DIFF
--- a/node/ferromark/README.md
+++ b/node/ferromark/README.md
@@ -95,11 +95,16 @@ const highlighter = await createHighlighter({
 const html = toHtmlWithHighlighter(
   '```rust\nfn main() {}\n```',
   highlighter,
-  { theme: 'github-dark' },
+  {
+    theme: 'github-dark',
+    onHighlightError(error, { lang }) {
+      console.warn(`Could not highlight ${lang}`, error)
+    },
+  },
 )
 ```
 
-Unsupported languages and highlighter errors fall back to ferromark's escaped `<pre><code>` output.
+Unsupported languages and highlighter exceptions fall back to ferromark's escaped `<pre><code>` output. Use `onHighlightError` to observe exceptions; if that callback throws, the render call throws too. Invalid highlighter return values also surface as native callback errors.
 Highlighter HTML is otherwise written verbatim, so only pass an implementation that escapes untrusted code and metadata.
 Fence meta text after the language (e.g. ` ```ts {1-3} title="…" `) reaches the highlighter as Shiki-style `meta.__raw`, so meta-driven transformers (line highlighting, titles) work unchanged.
 

--- a/node/ferromark/index.d.mts
+++ b/node/ferromark/index.d.mts
@@ -64,6 +64,8 @@ export interface CodeHighlighter {
 export interface HighlightOptions {
   theme: string
   fallbackLanguage?: string
+  /** Observe a highlighter exception before escaped-code fallback is used. */
+  onHighlightError?: (error: unknown, context: { lang: string }) => void
 }
 
 export declare function toHtml(markdown: string, options?: Options): string
@@ -77,7 +79,8 @@ export declare class Renderer {
 
 /**
  * Render fenced code with a trusted synchronous highlighter.
- * Highlighter errors fall back to ferromark's escaped code-block output.
+ * Highlighter exceptions fall back to ferromark's escaped code-block output
+ * and can be observed with `onHighlightError`.
  */
 export declare function toHtmlWithHighlighter(
   markdown: string,
@@ -113,7 +116,8 @@ export declare function transform(markdown: string, options?: Options): Transfor
 
 /**
  * `transform` with fenced code rendered by a trusted synchronous highlighter.
- * Highlighter errors fall back to ferromark's escaped code-block output.
+ * Highlighter exceptions fall back to ferromark's escaped code-block output
+ * and can be observed with `onHighlightError`.
  */
 export declare function transformWithHighlighter(
   markdown: string,

--- a/node/ferromark/index.mjs
+++ b/node/ferromark/index.mjs
@@ -92,22 +92,31 @@ function highlighterRenderer(highlighter, highlightOptions) {
   if (!highlightOptions || typeof highlightOptions.theme !== 'string') {
     throw new TypeError('highlightOptions.theme must be a string')
   }
+  if (
+    highlightOptions.onHighlightError != null
+    && typeof highlightOptions.onHighlightError !== 'function'
+  ) {
+    throw new TypeError('highlightOptions.onHighlightError must be a function')
+  }
 
   const fallbackLanguage = highlightOptions.fallbackLanguage ?? 'text'
+  const onHighlightError = highlightOptions.onHighlightError
   /**
    * @param {string} code
    * @param {string | null | undefined} language
    * @param {string | null | undefined} meta
    */
   return (code, language, meta) => {
+    const lang = language ?? fallbackLanguage
     try {
       return highlighter.codeToHtml(code, {
-        lang: language ?? fallbackLanguage,
+        lang,
         theme: highlightOptions.theme,
         ...(meta ? { meta: { __raw: meta } } : {}),
       })
     }
-    catch {
+    catch (error) {
+      onHighlightError?.(error, { lang })
       return null
     }
   }

--- a/node/ferromark/test/index.test.mjs
+++ b/node/ferromark/test/index.test.mjs
@@ -130,21 +130,75 @@ test('composes with a synchronous Ferriki-compatible highlighter', () => {
 })
 
 test('falls back to escaped code when highlighting fails', () => {
+  const failures = []
+  const failure = new Error('unsupported language')
   const highlighter = {
     codeToHtml() {
-      throw new Error('unsupported language')
+      throw failure
     },
   }
 
   const html = toHtmlWithHighlighter(
     '```unknown\n<tag>\n```',
     highlighter,
-    { theme: 'github-dark' },
+    {
+      theme: 'github-dark',
+      onHighlightError(error, context) {
+        failures.push({ error, context })
+      },
+    },
   )
 
   assert.equal(
     html,
     '<pre><code class="language-unknown">&lt;tag&gt;\n</code></pre>\n',
+  )
+  assert.deepEqual(failures, [{ error: failure, context: { lang: 'unknown' } }])
+  assert.equal(
+    toHtmlWithHighlighter(
+      '```unknown\n<tag>\n```',
+      highlighter,
+      { theme: 'github-dark' },
+    ),
+    html,
+  )
+})
+
+test('validates and surfaces highlighter error observers', () => {
+  const highlighter = {
+    codeToHtml() {
+      throw new Error('highlight failed')
+    },
+  }
+
+  assert.throws(
+    () => toHtmlWithHighlighter('```js\ncode\n```', highlighter, {
+      theme: 'dark',
+      onHighlightError: 'invalid',
+    }),
+    /onHighlightError must be a function/,
+  )
+  assert.throws(
+    () => transformWithHighlighter('```js\ncode\n```', highlighter, {
+      theme: 'dark',
+      onHighlightError() {
+        throw new Error('observer failed')
+      },
+    }),
+    /observer failed/,
+  )
+})
+
+test('surfaces invalid highlighter return values from the native callback', () => {
+  const highlighter = {
+    codeToHtml() {
+      return { html: '<pre>wrong shape</pre>' }
+    },
+  }
+
+  assert.throws(
+    () => toHtmlWithHighlighter('```js\ncode\n```', highlighter, { theme: 'dark' }),
+    error => error instanceof Error,
   )
 })
 

--- a/node/ferromark/test/types.test.mts
+++ b/node/ferromark/test/types.test.mts
@@ -19,4 +19,8 @@ toHtml('# Typed', options)
 new Renderer(options).toHtml('# Reused')
 toHtmlWithHighlighter('```ts\nconst typed = true\n```', highlighter, {
   theme: 'github-dark',
+  onHighlightError(error, { lang }) {
+    void error
+    lang.toUpperCase()
+  },
 })

--- a/node/native/src/lib.rs
+++ b/node/native/src/lib.rs
@@ -175,22 +175,38 @@ pub fn transform(markdown: String, options: Option<Options>) -> Result<Transform
 #[allow(clippy::type_complexity)]
 struct CallbackRenderer<'scope> {
     callback: Function<'scope, FnArgs<(String, Option<String>, Option<String>)>, Option<String>>,
+    error: Option<Error>,
+}
+
+impl CallbackRenderer<'_> {
+    fn finish<T>(self, result: Result<T>) -> Result<T> {
+        self.error.map_or(result, Err)
+    }
 }
 
 impl FencedCodeRenderer for CallbackRenderer<'_> {
     fn render(&mut self, block: FencedCodeBlock<'_>) -> Option<TrustedHtml> {
-        self.callback
-            .call(FnArgs::from((
-                block.code.to_owned(),
-                block.language.map(str::to_owned),
-                block.meta.map(str::to_owned),
-            )))
-            .ok()
-            .flatten()
-            .map(TrustedHtml::from_trusted)
+        if self.error.is_some() {
+            return None;
+        }
+
+        match self.callback.call(FnArgs::from((
+            block.code.to_owned(),
+            block.language.map(str::to_owned),
+            block.meta.map(str::to_owned),
+        ))) {
+            Ok(html) => html.map(TrustedHtml::from_trusted),
+            Err(error) => {
+                self.error = Some(error);
+                None
+            }
+        }
     }
 }
 
+/// Render Markdown with a synchronous fenced-code callback.
+///
+/// Callback exceptions and invalid return values are surfaced as N-API errors.
 #[napi(catch_unwind)]
 #[allow(clippy::type_complexity)]
 pub fn to_html_with_renderer(
@@ -199,16 +215,21 @@ pub fn to_html_with_renderer(
     renderer: Function<FnArgs<(String, Option<String>, Option<String>)>, Option<String>>,
 ) -> Result<String> {
     let options = core_options(options)?;
-    let mut renderer = CallbackRenderer { callback: renderer };
-    ferromark::try_to_html_with_renderer(&markdown, &options, &mut renderer)
-        .map_err(input_size_error)
+    let mut renderer = CallbackRenderer {
+        callback: renderer,
+        error: None,
+    };
+    let result = ferromark::try_to_html_with_renderer(&markdown, &options, &mut renderer)
+        .map_err(input_size_error);
+    renderer.finish(result)
 }
 
 /// `transform` with an opt-in fenced-code renderer callback.
 ///
 /// The callback receives `(code, language, meta)` and must return trusted,
 /// fully escaped HTML — or null/undefined to fall back to the default
-/// escaped `<pre><code>` output.
+/// escaped `<pre><code>` output. Callback exceptions and invalid return values
+/// are surfaced as N-API errors.
 #[napi(catch_unwind)]
 #[allow(clippy::type_complexity)]
 pub fn transform_with_renderer(
@@ -217,8 +238,12 @@ pub fn transform_with_renderer(
     renderer: Function<FnArgs<(String, Option<String>, Option<String>)>, Option<String>>,
 ) -> Result<TransformResult> {
     let options = core_options(options)?;
-    let mut renderer = CallbackRenderer { callback: renderer };
-    ferromark::try_parse_with_renderer(&markdown, &options, &mut renderer)
+    let mut renderer = CallbackRenderer {
+        callback: renderer,
+        error: None,
+    };
+    let result = ferromark::try_parse_with_renderer(&markdown, &options, &mut renderer)
         .map(transform_result)
-        .map_err(input_size_error)
+        .map_err(input_size_error);
+    renderer.finish(result)
 }


### PR DESCRIPTION
## Summary

- add an optional `onHighlightError` hook with language context while preserving escaped-code fallback
- propagate N-API callback exceptions and invalid return values instead of discarding them
- document and test the JavaScript and TypeScript contracts

## Verification

- `cargo test --locked`
- `cargo test --locked --all-features`
- `cargo clippy --all-targets --all-features --locked -- -D warnings`
- `RUSTDOCFLAGS=-Dwarnings cargo doc --no-deps --all-features --locked`
- `cargo fmt --all --check`
- Node tests and TypeScript typecheck
- Node README, package, and pack verification

Fixes #171