### PR TITLE
Harden native addon loading and glibc compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,8 +143,8 @@ jobs:
       - run: pnpm smoke:clean
 
   native:
-    # Each target is built and loaded on a runner with the same architecture;
-    # musl targets are cross-compiled because the hosted runners use glibc.
+    # Each target is built on a runner with the same architecture. GNU targets
+    # use the glibc 2.17 napi-rs toolchain; musl targets use cargo-zigbuild.
     permissions:
       contents: read
     strategy:
@@ -154,6 +154,7 @@ jobs:
           - { os: macos-latest, rust_target: aarch64-apple-darwin, artifact: darwin-arm64, runtime_test: true }
           - { os: macos-15-intel, rust_target: x86_64-apple-darwin, artifact: darwin-x64, runtime_test: true }
           - { os: ubuntu-24.04-arm, rust_target: aarch64-unknown-linux-gnu, artifact: linux-arm64-gnu, runtime_test: true }
+          - { os: ubuntu-latest, rust_target: x86_64-unknown-linux-gnu, artifact: linux-x64-gnu, runtime_test: true }
           - { os: ubuntu-latest, rust_target: x86_64-unknown-linux-musl, artifact: linux-x64-musl, runtime_test: false }
           - { os: ubuntu-latest, rust_target: aarch64-unknown-linux-musl, artifact: linux-arm64-musl, runtime_test: false }
           - { os: windows-latest, rust_target: x86_64-pc-windows-msvc, artifact: win32-x64-msvc, runtime_test: true }

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -142,6 +142,9 @@ jobs:
         if: ${{ matrix.runtime_test }}
         run: pnpm test
 
+      - name: Verify native artifact
+        run: node ./scripts/verify-platform-artifact.mjs ${{ matrix.artifact }}
+
       - name: Upload native binary
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -5,11 +5,15 @@ Release Please owns the shared Rust and npm version. Its release PR updates `Car
 When that PR merges, `.github/workflows/publish.yml`:
 
 1. creates the GitHub release,
-2. builds and tests native packages for x64 and arm64 on macOS, Windows, and glibc Linux,
+2. builds and tests native packages for x64 and arm64 on macOS, Windows, and Linux,
 3. verifies the complete binary matrix and packed npm contents,
 4. runs a clean consumer install,
 5. publishes `ferromark` to npm through trusted publishing,
 6. publishes the matching Rust crate to crates.io.
+
+GNU Linux binaries use napi-rs's pinned cross-toolchain so their native glibc
+symbol floor stays at 2.17 instead of following the current GitHub runner. CI
+checks each GNU artifact with `readelf`; musl binaries use cargo-zigbuild.
 
 ## npm trusted publisher setup
 

--- a/node/ferromark/README.md
+++ b/node/ferromark/README.md
@@ -11,7 +11,9 @@ npm install ferromark
 
 The package requires Node.js 22 or newer. It installs one platform-specific
 native package for glibc or musl Linux, macOS, and Windows on x64 and arm64;
-musl support includes Alpine Linux. There is no WASM fallback.
+musl support includes Alpine Linux. GNU Linux binaries target glibc 2.17 or
+newer, although the installed Node.js runtime may impose a newer requirement.
+There is no WASM fallback.
 
 ```js
 import { toHtml } from 'ferromark'
@@ -141,6 +143,7 @@ The native binding loads when constructing `Renderer` or on the first call to
 | Node.js below 22 | Upgrade to Node.js 22 or newer; this is the package's declared engine requirement. |
 | Unsupported platform or architecture | Use macOS, Windows, or glibc/musl Linux on x64 or arm64. |
 | `could not load the optional native package` | Reinstall without `--omit=optional` and verify that your lockfile includes ferromark's package for the current platform. |
+| `ERR_DLOPEN_FAILED` | Read the wrapped loader message for the exact binary and platform. On GNU Linux, verify glibc 2.17 or newer and required shared libraries; on Windows, install or repair the Microsoft Visual C++ Redistributable; on macOS, check architecture, OS compatibility, quarantine, and code-signing policy. The original loader error is available as `error.cause`. |
 
 This package does not include a WASM fallback, so unsupported environments need
 one of the supported native runtimes rather than a JavaScript fallback.

--- a/node/ferromark/index.mjs
+++ b/node/ferromark/index.mjs
@@ -188,7 +188,10 @@ function loadNative() {
     return native
   }
   catch (error) {
-    if (!(error instanceof Error) || !('code' in error) || error.code !== 'MODULE_NOT_FOUND') {
+    if (hasErrorCode(error, 'ERR_DLOPEN_FAILED')) {
+      throw nativeBinaryLoadError(filename, 'the local package', target, error)
+    }
+    if (!hasErrorCode(error, 'MODULE_NOT_FOUND')) {
       throw error
     }
     localError = error
@@ -200,7 +203,10 @@ function loadNative() {
     return native
   }
   catch (error) {
-    if (!(error instanceof Error) || !('code' in error) || error.code !== 'MODULE_NOT_FOUND') {
+    if (hasErrorCode(error, 'ERR_DLOPEN_FAILED')) {
+      throw nativeBinaryLoadError(filename, `the optional package ${packageName}`, target, error)
+    }
+    if (!hasErrorCode(error, 'MODULE_NOT_FOUND')) {
       throw error
     }
     throw new Error(
@@ -208,6 +214,38 @@ function loadNative() {
       { cause: new AggregateError([localError, error], `No native binary found for ${target}`) },
     )
   }
+}
+
+/** @param {unknown} error @param {string} code */
+function hasErrorCode(error, code) {
+  return error instanceof Error && 'code' in error && error.code === code
+}
+
+/**
+ * @param {string} filename
+ * @param {string} source
+ * @param {string} target
+ * @param {unknown} cause
+ */
+function nativeBinaryLoadError(filename, source, target, cause) {
+  return new Error(
+    `ferromark could not load native binary ${filename} from ${source} for ${process.platform}/${process.arch} (ERR_DLOPEN_FAILED). ${nativeLoadHint(target)}`,
+    { cause },
+  )
+}
+
+/** @param {string} target */
+function nativeLoadHint(target) {
+  if (target.endsWith('-gnu')) {
+    return 'Check that glibc 2.17 or newer is available and that no required shared library is missing.'
+  }
+  if (target.endsWith('-musl')) {
+    return 'Check that the musl runtime is compatible and that no required shared library is missing.'
+  }
+  if (target.startsWith('win32-')) {
+    return 'Install or repair the Microsoft Visual C++ Redistributable and verify the binary architecture.'
+  }
+  return 'Check the macOS version and binary architecture, and whether quarantine or code-signing policy blocked the addon.'
 }
 
 function nativeTarget() {

--- a/node/ferromark/npm/linux-arm64-gnu/README.md
+++ b/node/ferromark/npm/linux-arm64-gnu/README.md
@@ -1,3 +1,5 @@
 # `ferromark-linux-arm64-gnu`
 
 This is the **aarch64-unknown-linux-gnu** native binary for [`ferromark`](https://www.npmjs.com/package/ferromark).
+
+Published binaries target glibc 2.17 or newer.

--- a/node/ferromark/npm/linux-x64-gnu/README.md
+++ b/node/ferromark/npm/linux-x64-gnu/README.md
@@ -1,3 +1,5 @@
 # `ferromark-linux-x64-gnu`
 
 This is the **x86_64-unknown-linux-gnu** native binary for [`ferromark`](https://www.npmjs.com/package/ferromark).
+
+Published binaries target glibc 2.17 or newer.

--- a/node/ferromark/scripts/build-native.mjs
+++ b/node/ferromark/scripts/build-native.mjs
@@ -31,7 +31,10 @@ const args = [
 
 if (process.env.FERROMARK_RUST_TARGET) {
   args.push('--target', process.env.FERROMARK_RUST_TARGET)
-  if (process.env.FERROMARK_RUST_TARGET.endsWith('-musl')) {
+  if (process.env.FERROMARK_RUST_TARGET.includes('-unknown-linux-gnu')) {
+    args.push('--use-napi-cross')
+  }
+  else if (process.env.FERROMARK_RUST_TARGET.endsWith('-musl')) {
     args.push('--cross-compile')
   }
 }

--- a/node/ferromark/scripts/test-readme-contract.mjs
+++ b/node/ferromark/scripts/test-readme-contract.mjs
@@ -62,6 +62,9 @@ function assertReadmeContract(candidate) {
   assert.match(candidate, /Unsupported platform or architecture/, 'README must cover unsupported targets')
   assert.match(loader, /could not load the optional native package/, 'loader must retain missing-package diagnostics')
   assert.match(candidate, /`could not load the optional native package`/, 'README must cover missing platform packages')
+  assert.match(loader, /ERR_DLOPEN_FAILED/, 'loader must wrap native dynamic-loader failures')
+  assert.match(candidate, /glibc 2\.17/, 'README must document the GNU Linux binary baseline')
+  assert.match(candidate, /`ERR_DLOPEN_FAILED`/, 'README must cover native dynamic-loader failures')
 
   const loaderTargets = [...loader.matchAll(/'([a-z0-9]+-(?:arm64|x64)(?:-(?:gnu|musl))?)': '([a-z0-9-]+)'/g)]
     .map(([, host, target]) => ({ host, target }))

--- a/node/ferromark/scripts/verify-package.mjs
+++ b/node/ferromark/scripts/verify-package.mjs
@@ -22,6 +22,11 @@ assert.match(
   /endsWith\('-musl'\)[\s\S]*args\.push\('--cross-compile'\)/,
   'musl targets must use napi-rs cargo-zigbuild cross-compilation',
 )
+assert.match(
+  buildNative,
+  /includes\('-unknown-linux-gnu'\)[\s\S]*args\.push\('--use-napi-cross'\)/,
+  'GNU Linux targets must use the napi-rs glibc 2.17 cross-toolchain',
+)
 
 const extraFiles = releaseConfig.packages['.']['extra-files']
 for (const triple of packageJson.napi.targets) {

--- a/node/ferromark/test/index.test.mjs
+++ b/node/ferromark/test/index.test.mjs
@@ -1,6 +1,11 @@
 import assert from 'node:assert/strict'
 import { spawnSync } from 'node:child_process'
+import { copyFile, mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import process from 'node:process'
 import test from 'node:test'
+import { pathToFileURL } from 'node:url'
 
 import {
   Renderer,
@@ -105,6 +110,48 @@ test('selects the musl optional package on Alpine-style Linux', () => {
   })
 
   assert.equal(result.status, 0, result.stderr)
+})
+
+test('wraps native dynamic-loader failures with platform guidance', async (t) => {
+  const target = currentNativeTarget()
+  const packageName = `ferromark-${target}`
+  const binaryName = `ferromark.${target}.node`
+  const fixture = await mkdtemp(path.join(tmpdir(), 'ferromark-loader-'))
+  const packageDir = path.join(fixture, 'node_modules', packageName)
+  const entry = path.join(fixture, 'index.mjs')
+  t.after(() => rm(fixture, { force: true, recursive: true }))
+
+  await mkdir(packageDir, { recursive: true })
+  await Promise.all([
+    copyFile(new URL('../index.mjs', import.meta.url), entry),
+    writeFile(
+      path.join(packageDir, 'package.json'),
+      JSON.stringify({ name: packageName, main: binaryName }),
+    ),
+    writeFile(path.join(packageDir, binaryName), 'not a native addon'),
+  ])
+
+  const fixtureModule = await import(pathToFileURL(entry).href)
+  assert.throws(
+    () => fixtureModule.toHtml('text'),
+    (error) => {
+      assert.ok(error instanceof Error)
+      assert.match(error.message, new RegExp(binaryName.replaceAll('.', '\\.')))
+      assert.match(error.message, new RegExp(`${process.platform}/${process.arch}`))
+      assert.match(error.message, /ERR_DLOPEN_FAILED/)
+      assert.equal(error.cause?.code, 'ERR_DLOPEN_FAILED')
+      if (process.platform === 'linux') {
+        assert.match(error.message, /glibc 2\.17|musl runtime/)
+      }
+      else if (process.platform === 'win32') {
+        assert.match(error.message, /Visual C\+\+ Redistributable/)
+      }
+      else {
+        assert.match(error.message, /quarantine or code-signing policy/)
+      }
+      return true
+    },
+  )
 })
 
 test('composes with a synchronous Ferriki-compatible highlighter', () => {
@@ -252,3 +299,24 @@ test('highlighter receives fence meta as Shiki-style __raw', () => {
     { lang: 'ts', theme: 'github-dark' },
   ])
 })
+
+function currentNativeTarget() {
+  const report = process.report?.getReport?.()
+  const libc = report?.header?.glibcVersionRuntime ? 'gnu' : 'musl'
+  const key = process.platform === 'linux'
+    ? `${process.platform}-${process.arch}-${libc}`
+    : `${process.platform}-${process.arch}`
+  const targets = {
+    'darwin-arm64': 'darwin-arm64',
+    'darwin-x64': 'darwin-x64',
+    'linux-arm64-gnu': 'linux-arm64-gnu',
+    'linux-arm64-musl': 'linux-arm64-musl',
+    'linux-x64-gnu': 'linux-x64-gnu',
+    'linux-x64-musl': 'linux-x64-musl',
+    'win32-arm64': 'win32-arm64-msvc',
+    'win32-x64': 'win32-x64-msvc',
+  }
+  const target = targets[key]
+  assert.ok(target, `test requires a supported native target, received ${key}`)
+  return target
+}

--- a/node/scripts/verify-platform-artifact.mjs
+++ b/node/scripts/verify-platform-artifact.mjs
@@ -1,4 +1,5 @@
 import assert from 'node:assert/strict'
+import { spawnSync } from 'node:child_process'
 import { readFile, stat } from 'node:fs/promises'
 import path from 'node:path'
 import process from 'node:process'
@@ -25,4 +26,32 @@ assert.equal(platformPackage.version, mainPackage.version)
 assert.equal(mainPackage.optionalDependencies[dependency], mainPackage.version)
 assert.ok(binaryInfo.isFile() && binaryInfo.size > 0, `Invalid native binary: ${binary}`)
 
+if (target.endsWith('-gnu')) {
+  verifyGlibcBaseline(binary)
+}
+
 console.log(`Verified ${dependency}@${platformPackage.version} (${binaryInfo.size} bytes)`)
+
+function verifyGlibcBaseline(filename) {
+  const baseline = [2, 17]
+  const result = spawnSync('readelf', ['--version-info', filename], { encoding: 'utf8' })
+  if (result.error) {
+    throw result.error
+  }
+  assert.equal(result.status, 0, result.stderr)
+
+  const versions = [...result.stdout.matchAll(/\bGLIBC_(\d+)\.(\d+)(?:\.\d+)?\b/g)]
+    .map(([, major, minor]) => [Number(major), Number(minor)])
+  assert.ok(versions.length > 0, `No glibc symbol versions found in ${filename}`)
+
+  const newer = versions.filter(version => compareVersions(version, baseline) > 0)
+  assert.deepEqual(
+    newer,
+    [],
+    `${filename} requires glibc newer than ${baseline.join('.')}`,
+  )
+}
+
+function compareVersions(left, right) {
+  return left[0] - right[0] || left[1] - right[1]
+}

--- a/scripts/test-node-ci-matrix.rb
+++ b/scripts/test-node-ci-matrix.rb
@@ -19,6 +19,7 @@ expected_targets = [
   { 'os' => 'macos-latest', 'rust_target' => 'aarch64-apple-darwin', 'artifact' => 'darwin-arm64', 'runtime_test' => true },
   { 'os' => 'macos-15-intel', 'rust_target' => 'x86_64-apple-darwin', 'artifact' => 'darwin-x64', 'runtime_test' => true },
   { 'os' => 'ubuntu-24.04-arm', 'rust_target' => 'aarch64-unknown-linux-gnu', 'artifact' => 'linux-arm64-gnu', 'runtime_test' => true },
+  { 'os' => 'ubuntu-latest', 'rust_target' => 'x86_64-unknown-linux-gnu', 'artifact' => 'linux-x64-gnu', 'runtime_test' => true },
   { 'os' => 'ubuntu-latest', 'rust_target' => 'x86_64-unknown-linux-musl', 'artifact' => 'linux-x64-musl', 'runtime_test' => false },
   { 'os' => 'ubuntu-latest', 'rust_target' => 'aarch64-unknown-linux-musl', 'artifact' => 'linux-arm64-musl', 'runtime_test' => false },
   { 'os' => 'windows-latest', 'rust_target' => 'x86_64-pc-windows-msvc', 'artifact' => 'win32-x64-msvc', 'runtime_test' => true },

--- a/scripts/test-publish-verification.mjs
+++ b/scripts/test-publish-verification.mjs
@@ -61,9 +61,15 @@ function assertPlatformPackagesArePublished(source) {
   const assembleIndex = source.indexOf(
     'run: pnpm --dir ferromark exec napi artifacts --output-dir .napi-artifacts --npm-dir npm',
   )
+  const buildIndex = source.indexOf('run: pnpm build:native')
+  const artifactVerifyIndex = source.indexOf(
+    'run: node ./scripts/verify-platform-artifact.mjs ${{ matrix.artifact }}',
+  )
   const verifyIndex = source.indexOf('run: node ./scripts/verify-release.mjs')
   const platformPublishIndex = source.indexOf('run: node ./scripts/publish-platform-packages.mjs')
   const mainPublishIndex = source.indexOf('run: npm publish --access public --provenance')
+  assert.ok(buildIndex !== -1 && buildIndex < artifactVerifyIndex)
+  assert.ok(artifactVerifyIndex < assembleIndex)
   assert.ok(assembleIndex !== -1 && assembleIndex < verifyIndex)
   assert.ok(verifyIndex < platformPublishIndex)
   assert.ok(platformPublishIndex < mainPublishIndex)


### PR DESCRIPTION
## Summary

- wrap `ERR_DLOPEN_FAILED` with the binary, host platform, likely causes, and the original error as `cause`
- build GNU Linux addons with the pinned napi-rs glibc 2.17 cross-toolchain
- verify GNU symbol requirements with `readelf` in both CI and the release workflow
- add the missing x64 GNU native-matrix job and document the compatibility contract

## Verification

- `pnpm test`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm pack:check`
- publish-workflow and native-matrix contract tests
- workflow pin checks
- `cargo fmt --all --check`

Fixes #169