### PR TITLE
Align Node engine with CommonJS support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,6 +142,35 @@ jobs:
       - run: pnpm pack:check
       - run: pnpm smoke:clean
 
+  node-floor:
+    runs-on: ubuntu-latest
+    name: node (Node.js 22.12.0 floor)
+    defaults:
+      run:
+        working-directory: node
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6
+        with:
+          package_json_file: node/package.json
+      - name: Set workspace Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+        with:
+          node-version: "22.13.0"
+          cache: pnpm
+          cache-dependency-path: node/pnpm-lock.yaml
+      - uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # master
+        with:
+          toolchain: stable
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm build
+      - name: Set minimum supported Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+        with:
+          node-version: "22.12.0"
+      - name: Test minimum supported Node.js
+        run: node --test ferromark/test/index.test.mjs
+
   native:
     # Each target is built on a runner with the same architecture. GNU targets
     # use the glibc 2.17 napi-rs toolchain; musl targets use cargo-zigbuild.

--- a/docs/migration-0.4.md
+++ b/docs/migration-0.4.md
@@ -194,7 +194,7 @@ rustup toolchain install 1.88
 cargo +1.88 check --all-features
 ```
 
-The published `ferromark` npm package requires Node.js 22.0.0 or newer. Update
+The published `ferromark` npm package requires Node.js 22.12.0 or newer. Update
 the runtime before running `npm install ferromark` or loading the native
 module. Repository contributors who run the `node/` workspace also need its
 pinned pnpm 11.17.0 toolchain and Node.js 22.13.0 or newer.
@@ -205,7 +205,7 @@ Run the checks that match the surfaces your project uses:
 
 ```sh
 cargo check --all-features
-# For npm consumers, verify that `node --version` is 22.0.0 or newer.
+# For npm consumers, verify that `node --version` is 22.12.0 or newer.
 ```
 
 For custom renderers, include a fenced block with an info string in a local

--- a/node/ferromark/README.md
+++ b/node/ferromark/README.md
@@ -9,7 +9,7 @@ npm install ferromark
 # or: pnpm add ferromark
 ```
 
-The package requires Node.js 22 or newer. It installs one platform-specific
+The package requires Node.js 22.12 or newer. It installs one platform-specific
 native package for glibc or musl Linux, macOS, and Windows on x64 and arm64;
 musl support includes Alpine Linux. GNU Linux binaries target glibc 2.17 or
 newer, although the installed Node.js runtime may impose a newer requirement.
@@ -19,6 +19,12 @@ There is no WASM fallback.
 import { toHtml } from 'ferromark'
 
 const html = toHtml('# Hello')
+```
+
+Both ESM `import` and CommonJS `require()` work on supported Node.js versions:
+
+```js
+const { toHtml } = require('ferromark')
 ```
 
 ## Repeated rendering
@@ -140,7 +146,7 @@ The native binding loads when constructing `Renderer` or on the first call to
 
 | Message or environment | Resolution |
 | --- | --- |
-| Node.js below 22 | Upgrade to Node.js 22 or newer; this is the package's declared engine requirement. |
+| Node.js below 22.12 | Upgrade to Node.js 22.12 or newer; this is the package's declared engine requirement and the first Node 22 release with unflagged `require(esm)` support. |
 | Unsupported platform or architecture | Use macOS, Windows, or glibc/musl Linux on x64 or arm64. |
 | `could not load the optional native package` | Reinstall without `--omit=optional` and verify that your lockfile includes ferromark's package for the current platform. |
 | `ERR_DLOPEN_FAILED` | Read the wrapped loader message for the exact binary and platform. On GNU Linux, verify glibc 2.17 or newer and required shared libraries; on Windows, install or repair the Microsoft Visual C++ Redistributable; on macOS, check architecture, OS compatibility, quarantine, and code-signing policy. The original loader error is available as `error.cause`. |

--- a/node/ferromark/npm/darwin-arm64/package.json
+++ b/node/ferromark/npm/darwin-arm64/package.json
@@ -9,7 +9,7 @@
     "directory": "node/ferromark"
   },
   "engines": {
-    "node": ">=22.0.0"
+    "node": ">=22.12.0"
   },
   "os": [
     "darwin"

--- a/node/ferromark/npm/darwin-x64/package.json
+++ b/node/ferromark/npm/darwin-x64/package.json
@@ -9,7 +9,7 @@
     "directory": "node/ferromark"
   },
   "engines": {
-    "node": ">=22.0.0"
+    "node": ">=22.12.0"
   },
   "os": [
     "darwin"

--- a/node/ferromark/npm/linux-arm64-gnu/package.json
+++ b/node/ferromark/npm/linux-arm64-gnu/package.json
@@ -9,7 +9,7 @@
     "directory": "node/ferromark"
   },
   "engines": {
-    "node": ">=22.0.0"
+    "node": ">=22.12.0"
   },
   "os": [
     "linux"

--- a/node/ferromark/npm/linux-arm64-musl/package.json
+++ b/node/ferromark/npm/linux-arm64-musl/package.json
@@ -9,7 +9,7 @@
     "directory": "node/ferromark"
   },
   "engines": {
-    "node": ">=22.0.0"
+    "node": ">=22.12.0"
   },
   "os": [
     "linux"

--- a/node/ferromark/npm/linux-x64-gnu/package.json
+++ b/node/ferromark/npm/linux-x64-gnu/package.json
@@ -9,7 +9,7 @@
     "directory": "node/ferromark"
   },
   "engines": {
-    "node": ">=22.0.0"
+    "node": ">=22.12.0"
   },
   "os": [
     "linux"

--- a/node/ferromark/npm/linux-x64-musl/package.json
+++ b/node/ferromark/npm/linux-x64-musl/package.json
@@ -9,7 +9,7 @@
     "directory": "node/ferromark"
   },
   "engines": {
-    "node": ">=22.0.0"
+    "node": ">=22.12.0"
   },
   "os": [
     "linux"

--- a/node/ferromark/npm/win32-arm64-msvc/package.json
+++ b/node/ferromark/npm/win32-arm64-msvc/package.json
@@ -9,7 +9,7 @@
     "directory": "node/ferromark"
   },
   "engines": {
-    "node": ">=22.0.0"
+    "node": ">=22.12.0"
   },
   "os": [
     "win32"

--- a/node/ferromark/npm/win32-x64-msvc/package.json
+++ b/node/ferromark/npm/win32-x64-msvc/package.json
@@ -9,7 +9,7 @@
     "directory": "node/ferromark"
   },
   "engines": {
-    "node": ">=22.0.0"
+    "node": ">=22.12.0"
   },
   "os": [
     "win32"

--- a/node/ferromark/package.json
+++ b/node/ferromark/package.json
@@ -50,7 +50,7 @@
     "ferromark-win32-x64-msvc": "0.7.0"
   },
   "engines": {
-    "node": ">=22.0.0"
+    "node": ">=22.12.0"
   },
   "scripts": {
     "build": "node ./scripts/build-native.mjs && node ./scripts/verify-package.mjs",

--- a/node/ferromark/scripts/test-readme-contract.mjs
+++ b/node/ferromark/scripts/test-readme-contract.mjs
@@ -22,13 +22,15 @@ function assertReadmeContract(candidate) {
   assert.match(candidate, new RegExp(`npm install ${packageJson.name}`), 'README must show npm install')
   assert.match(candidate, new RegExp(`pnpm add ${packageJson.name}`), 'README must show pnpm add')
 
-  const minimumNode = packageJson.engines.node.match(/^>=(\d+)/)?.[1]
-  assert.ok(minimumNode, 'package.json must declare a minimum Node major version')
+  const minimumNode = packageJson.engines.node.match(/^>=(\d+\.\d+\.\d+)$/)?.[1]
+  assert.ok(minimumNode, 'package.json must declare an exact minimum Node version')
+  const documentedNode = minimumNode.replace(/\.0$/, '')
   assert.match(
     candidate,
-    new RegExp(`Node\\.js ${minimumNode} or newer`),
+    new RegExp(`Node\\.js ${documentedNode} or newer`),
     'README must state the package Node.js requirement',
   )
+  assert.match(candidate, /require\('ferromark'\)/, 'README must document CommonJS loading')
 
   assert.match(candidate, /^## Untrusted by default$/m, 'README must explain the default trust boundary')
   assert.match(declarations, /export type RenderPolicy = 'untrusted' \| 'trusted'/, 'declarations must expose both render policies')

--- a/node/ferromark/scripts/verify-package.mjs
+++ b/node/ferromark/scripts/verify-package.mjs
@@ -45,6 +45,7 @@ for (const triple of packageJson.napi.targets) {
   assert.deepEqual(platformPackage.libc, target.libc ? [target.libc] : undefined)
   assert.equal(platformPackage.main, `ferromark.${target.suffix}.node`)
   assert.deepEqual(platformPackage.files, [platformPackage.main])
+  assert.deepEqual(platformPackage.engines, packageJson.engines)
   assert.equal(platformPackage.publishConfig?.provenance, true)
   assert.ok(extraFiles.includes(packagePath), `${packagePath} must be versioned by release-please`)
   assert.ok(

--- a/node/ferromark/test/index.test.mjs
+++ b/node/ferromark/test/index.test.mjs
@@ -5,7 +5,7 @@ import { tmpdir } from 'node:os'
 import path from 'node:path'
 import process from 'node:process'
 import test from 'node:test'
-import { pathToFileURL } from 'node:url'
+import { fileURLToPath, pathToFileURL } from 'node:url'
 
 import {
   Renderer,
@@ -152,6 +152,20 @@ test('wraps native dynamic-loader failures with platform guidance', async (t) =>
       return true
     },
   )
+})
+
+test('loads the ESM entry point from CommonJS', () => {
+  const entry = fileURLToPath(new URL('../index.mjs', import.meta.url))
+  const script = `
+    const { toHtml } = require(${JSON.stringify(entry)})
+    process.stdout.write(toHtml('# CommonJS'))
+  `
+  const result = spawnSync(process.execPath, ['--input-type=commonjs', '--eval', script], {
+    encoding: 'utf8',
+  })
+
+  assert.equal(result.status, 0, result.stderr)
+  assert.equal(result.stdout, '<h1 id="commonjs">CommonJS</h1>\n')
 })
 
 test('composes with a synchronous Ferriki-compatible highlighter', () => {

--- a/scripts/test-migration-guide-contract.rb
+++ b/scripts/test-migration-guide-contract.rb
@@ -167,7 +167,7 @@ def self_test(repository_root)
     validate_document(guide.sub('requires Rust 1.88 or newer', 'requires Rust 1.85 or newer'), readme, cargo_toml, node_package, node_workspace, changelog)
   end
   assert_rejected('Node version') do
-    validate_document(guide.sub('Node.js 22.0.0 or newer', 'Node.js 20.0.0 or newer'), readme, cargo_toml, node_package, node_workspace, changelog)
+    validate_document(guide.sub('Node.js 22.12.0 or newer', 'Node.js 20.0.0 or newer'), readme, cargo_toml, node_package, node_workspace, changelog)
   end
 end
 

--- a/scripts/test-node-ci-matrix.rb
+++ b/scripts/test-node-ci-matrix.rb
@@ -5,6 +5,29 @@ require 'yaml'
 
 workflow_path = File.expand_path('../.github/workflows/ci.yml', __dir__)
 workflow = YAML.safe_load(File.read(workflow_path), aliases: false)
+node_versions = workflow.fetch('jobs').fetch('node').fetch('strategy').fetch('matrix').fetch('node')
+unless node_versions == ['22', '24']
+  abort 'Node CI matrix must test the current Node 22 and 24 release lines'
+end
+
+node_floor = workflow.fetch('jobs').fetch('node-floor')
+floor_steps = node_floor.fetch('steps')
+workspace_setup_index = floor_steps.index do |step|
+  step.dig('with', 'node-version') == '22.13.0'
+end
+build_index = floor_steps.index { |step| step['run'] == 'pnpm build' }
+floor_setup_index = floor_steps.index do |step|
+  step.dig('with', 'node-version') == '22.12.0'
+end
+floor_test_index = floor_steps.index do |step|
+  step['run'] == 'node --test ferromark/test/index.test.mjs'
+end
+unless workspace_setup_index && build_index && floor_setup_index && floor_test_index &&
+       workspace_setup_index < build_index && build_index < floor_setup_index &&
+       floor_setup_index < floor_test_index
+  abort 'Node floor CI must build on the workspace runtime before testing on Node 22.12.0'
+end
+
 native = workflow.fetch('jobs').fetch('native')
 
 unless native.fetch('runs-on') == '${{ matrix.os }}'


### PR DESCRIPTION
## Summary

- raise the main and platform package engine floor to Node.js 22.12.0
- run the Node CI lane on the exact supported floor instead of the latest Node 22 minor
- add a CommonJS `require()` smoke test and document both module-loading styles
- keep package, README, workflow, and migration contracts aligned

## Verification

- `pnpm test`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm pack:check`
- `pnpm smoke:clean`
- native-matrix and migration-guide contract tests
- workflow pin checks

Fixes #170