### PR TITLE
Avoid diagnostic reports outside Linux

### DIFF
--- a/node/ferromark/index.mjs
+++ b/node/ferromark/index.mjs
@@ -249,13 +249,14 @@ function nativeLoadHint(target) {
 }
 
 function nativeTarget() {
-  const report = /** @type {{ header?: { glibcVersionRuntime?: string } }} */ (
-    process.report?.getReport?.()
-  )
-  const libc = report?.header?.glibcVersionRuntime ? 'gnu' : 'musl'
-  const key = process.platform === 'linux'
-    ? `${process.platform}-${process.arch}-${libc}`
-    : `${process.platform}-${process.arch}`
+  let key = `${process.platform}-${process.arch}`
+  if (process.platform === 'linux') {
+    const report = /** @type {{ header?: { glibcVersionRuntime?: string } }} */ (
+      process.report?.getReport?.()
+    )
+    const libc = report?.header?.glibcVersionRuntime ? 'gnu' : 'musl'
+    key = `${key}-${libc}`
+  }
   /** @type {Record<string, string>} */
   const targets = {
     'darwin-arm64': 'darwin-arm64',

--- a/node/ferromark/test/index.test.mjs
+++ b/node/ferromark/test/index.test.mjs
@@ -112,6 +112,31 @@ test('selects the musl optional package on Alpine-style Linux', () => {
   assert.equal(result.status, 0, result.stderr)
 })
 
+test('does not collect a diagnostic report on non-Linux platforms', () => {
+  const entry = new URL('../index.mjs', import.meta.url).href
+  const script = `
+    Object.defineProperty(process, 'platform', { value: 'darwin' })
+    Object.defineProperty(process, 'arch', { value: 'arm64' })
+    Object.defineProperty(process, 'report', {
+      value: { getReport: () => { throw new Error('diagnostic report collected') } },
+    })
+    const { toHtml } = await import(${JSON.stringify(entry)})
+    try {
+      toHtml('text')
+    }
+    catch (error) {
+      if (error instanceof Error && error.message === 'diagnostic report collected') {
+        process.exit(1)
+      }
+    }
+  `
+  const result = spawnSync(process.execPath, ['--input-type=module', '--eval', script], {
+    encoding: 'utf8',
+  })
+
+  assert.equal(result.status, 0, result.stderr)
+})
+
 test('wraps native dynamic-loader failures with platform guidance', async (t) => {
   const target = currentNativeTarget()
   const packageName = `ferromark-${target}`


### PR DESCRIPTION
## Summary

- call `process.report.getReport()` only when Linux libc detection is needed
- avoid diagnostic-report allocation on macOS and Windows first load
- add a regression test that fails if a non-Linux target touches the report API

## Verification

- `pnpm test`
- `pnpm lint`
- `pnpm typecheck`

Fixes #172