### PR TITLE
ci: use Node 24 cache action

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -40,7 +40,7 @@ jobs:
       - uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae # v2
       - name: Restore benchmark history
         id: benchmark-history
-        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: .benchmark-cache
           key: ferromark-benchmark-${{ runner.os }}-main-${{ github.sha }}
@@ -70,7 +70,7 @@ jobs:
           summary-always: true
       - name: Save main benchmark history
         if: github.ref == 'refs/heads/main' && github.event_name != 'pull_request' && steps.benchmark-history.outputs.cache-hit != 'true'
-        uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: .benchmark-cache
           key: ferromark-benchmark-${{ runner.os }}-main-${{ github.sha }}

--- a/scripts/test-benchmark-ci-contract.rb
+++ b/scripts/test-benchmark-ci-contract.rb
@@ -9,9 +9,9 @@ WORKFLOW_PATH = File.expand_path('../.github/workflows/benchmarks.yml', __dir__)
 CHECKOUT_ACTION = 'actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1'
 RUST_TOOLCHAIN_ACTION = 'dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c'
 RUST_CACHE_ACTION = 'Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae'
-CACHE_RESTORE_ACTION = 'actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830'
+CACHE_RESTORE_ACTION = 'actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9'
 BENCHMARK_ACTION = 'benchmark-action/github-action-benchmark@52576c92bccf6ac60c8223ec7eb2565637cae9ba'
-CACHE_SAVE_ACTION = 'actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830'
+CACHE_SAVE_ACTION = 'actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9'
 CACHE_KEY = 'ferromark-benchmark-${{ runner.os }}-main-${{ github.sha }}'
 
 def fail_contract(message)


### PR DESCRIPTION
## Summary
- update benchmark cache restore and save steps from actions/cache v4.3.0 to v6.1.0
- use the release whose composite actions declare the Node 24 runtime
- keep the immutable SHA enforcement in the benchmark CI contract

## Motivation
The successful post-merge baseline run for #229 reported that the v4 cache actions target deprecated Node 20 and were being forced onto Node 24. This follow-up removes that CI annotation.

## Verification
- ruby ./scripts/test-benchmark-ci-contract.rb --self-test
- ./scripts/test-check-workflow-pins.sh
- ./scripts/check-workflow-pins.sh
- git diff --check

Refs #173