### PR TITLE
ci: test mdx feature in isolation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,7 @@ jobs:
           - { os: macos-latest, rust: stable, features: default, args: "" }
           - { os: windows-latest, rust: stable, features: default, args: "" }
           - { os: ubuntu-latest, rust: stable, features: all, args: "--all-features" }
+          - { os: ubuntu-latest, rust: stable, features: mdx, args: "--no-default-features --features mdx" }
           - { os: ubuntu-latest, rust: "1.88", features: default, args: "" }
           - { os: ubuntu-latest, rust: "1.88", features: all, args: "--all-features" }
     runs-on: ${{ matrix.os }}

--- a/scripts/test-contributing-ci-contract.rb
+++ b/scripts/test-contributing-ci-contract.rb
@@ -66,6 +66,17 @@ def validate(repository_root)
   all_feature_args = test_matrix.map { |entry| entry['args'] if entry['args'] == '--all-features' }.compact
   fail_contract('CI test matrix must include --all-features') if all_feature_args.empty?
 
+  mdx_entries = test_matrix.select { |entry| entry['features'] == 'mdx' }
+  expected_mdx_entry = {
+    'os' => 'ubuntu-latest',
+    'rust' => 'stable',
+    'features' => 'mdx',
+    'args' => '--no-default-features --features mdx'
+  }
+  unless mdx_entries == [expected_mdx_entry]
+    fail_contract('CI test matrix must isolate the mdx feature on stable Ubuntu')
+  end
+
   msrv_entries = test_matrix.select { |entry| entry['rust'] == rust_version }
   fail_contract("CI test matrix must test Rust #{rust_version}") if msrv_entries.empty?
   msrv_args = msrv_entries.map { |entry| entry['args'] }
@@ -175,6 +186,15 @@ def self_test(source_root)
     )
     File.write(path, document)
     assert_rejected('bootstrap cargo command') { validate(fixture_root) }
+  end
+
+  with_fixture(source_root) do |fixture_root|
+    path = File.join(fixture_root, '.github/workflows/ci.yml')
+    document = File.read(path)
+    mdx_entry = '          - { os: ubuntu-latest, rust: stable, features: mdx, args: "--no-default-features --features mdx" }'
+    document.sub!("#{mdx_entry}\n", '') || raise('test fixture is missing the isolated mdx matrix entry')
+    File.write(path, document)
+    assert_rejected('isolated mdx matrix entry') { validate(fixture_root) }
   end
 end
 


### PR DESCRIPTION
## Summary

- add a stable Ubuntu CI matrix leg that enables only the `mdx` feature
- protect the exact isolated feature configuration in the existing CI contract self-test

## Verification

- `cargo test --locked --no-default-features --features mdx`
- `cargo clippy --all-targets --no-default-features --features mdx --locked -- -D warnings`
- `ruby ./scripts/test-contributing-ci-contract.rb --self-test`
- workflow pin checks, formatting, and diff checks

Fixes #176