### PR TITLE
test(node): expand coverage beyond happy paths

### DIFF
--- a/node/ferromark/index.mjs
+++ b/node/ferromark/index.mjs
@@ -2,6 +2,8 @@ import { createRequire } from 'node:module'
 import process from 'node:process'
 import { fileURLToPath } from 'node:url'
 
+import { nativeTarget as resolveNativeTarget } from './native-target.mjs'
+
 const require = createRequire(import.meta.url)
 
 const optionKeys = new Set([
@@ -249,29 +251,14 @@ function nativeLoadHint(target) {
 }
 
 function nativeTarget() {
-  let key = `${process.platform}-${process.arch}`
-  if (process.platform === 'linux') {
-    const report = /** @type {{ header?: { glibcVersionRuntime?: string } }} */ (
-      process.report?.getReport?.()
-    )
-    const libc = report?.header?.glibcVersionRuntime ? 'gnu' : 'musl'
-    key = `${key}-${libc}`
-  }
-  /** @type {Record<string, string>} */
-  const targets = {
-    'darwin-arm64': 'darwin-arm64',
-    'darwin-x64': 'darwin-x64',
-    'linux-arm64-gnu': 'linux-arm64-gnu',
-    'linux-arm64-musl': 'linux-arm64-musl',
-    'linux-x64-gnu': 'linux-x64-gnu',
-    'linux-x64-musl': 'linux-x64-musl',
-    'win32-arm64': 'win32-arm64-msvc',
-    'win32-x64': 'win32-x64-msvc',
-  }
-
-  const target = targets[key]
-  if (!target) {
-    throw new Error(`ferromark does not support ${process.platform}/${process.arch}`)
-  }
-  return target
+  const report = process.platform === 'linux'
+    ? /** @type {{ header?: { glibcVersionRuntime?: string } }} */ (
+        process.report?.getReport?.()
+      )
+    : undefined
+  return resolveNativeTarget(
+    process.platform,
+    process.arch,
+    report?.header?.glibcVersionRuntime,
+  )
 }

--- a/node/ferromark/native-target.mjs
+++ b/node/ferromark/native-target.mjs
@@ -1,0 +1,33 @@
+/**
+ * Resolve a Node platform, architecture, and Linux libc to the native package suffix.
+ *
+ * `glibcVersionRuntime` is intentionally supplied by the caller so the target table
+ * can be tested without mutating process globals or collecting diagnostic reports.
+ *
+ * @param {NodeJS.Platform} platform
+ * @param {string} arch
+ * @param {string | undefined} [glibcVersionRuntime]
+ */
+export function nativeTarget(platform, arch, glibcVersionRuntime) {
+  const libc = platform === 'linux'
+    ? glibcVersionRuntime ? '-gnu' : '-musl'
+    : ''
+  const key = `${platform}-${arch}${libc}`
+  /** @type {Record<string, string>} */
+  const targets = {
+    'darwin-arm64': 'darwin-arm64',
+    'darwin-x64': 'darwin-x64',
+    'linux-arm64-gnu': 'linux-arm64-gnu',
+    'linux-arm64-musl': 'linux-arm64-musl',
+    'linux-x64-gnu': 'linux-x64-gnu',
+    'linux-x64-musl': 'linux-x64-musl',
+    'win32-arm64': 'win32-arm64-msvc',
+    'win32-x64': 'win32-x64-msvc',
+  }
+
+  const target = targets[key]
+  if (!target) {
+    throw new Error(`ferromark does not support ${platform}/${arch}`)
+  }
+  return target
+}

--- a/node/ferromark/package.json
+++ b/node/ferromark/package.json
@@ -36,6 +36,7 @@
     "index.d.mts",
     "index.mjs",
     "LICENSE",
+    "native-target.mjs",
     "native.d.ts",
     "README.md"
   ],
@@ -55,7 +56,7 @@
   "scripts": {
     "build": "node ./scripts/build-native.mjs && node ./scripts/verify-package.mjs",
     "build:native": "node ./scripts/build-native.mjs",
-    "lint": "node --check index.mjs && node --check scripts/build-native.mjs && node --check scripts/verify-package.mjs && node --check scripts/verify-panic-unwind.mjs && node scripts/test-readme-contract.mjs",
+    "lint": "node --check index.mjs && node --check native-target.mjs && node --check scripts/build-native.mjs && node --check scripts/verify-package.mjs && node --check scripts/verify-panic-unwind.mjs && node scripts/test-readme-contract.mjs",
     "test": "node --test test/*.test.mjs && node ./scripts/verify-panic-unwind.mjs"
   },
   "publishConfig": {

--- a/node/ferromark/scripts/test-readme-contract.mjs
+++ b/node/ferromark/scripts/test-readme-contract.mjs
@@ -4,18 +4,21 @@ import { readFile } from 'node:fs/promises'
 const readmeUrl = new URL('../README.md', import.meta.url)
 const packageUrl = new URL('../package.json', import.meta.url)
 const loaderUrl = new URL('../index.mjs', import.meta.url)
+const nativeTargetUrl = new URL('../native-target.mjs', import.meta.url)
 const declarationUrl = new URL('../index.d.mts', import.meta.url)
 const nativeOptionsUrl = new URL('../../native/src/lib.rs', import.meta.url)
 const coreOptionsUrl = new URL('../../../src/lib.rs', import.meta.url)
 
-const [readme, packageJson, loader, declarations, nativeOptions, coreOptions] = await Promise.all([
-  readFile(readmeUrl, 'utf8'),
-  readFile(packageUrl, 'utf8').then(JSON.parse),
-  readFile(loaderUrl, 'utf8'),
-  readFile(declarationUrl, 'utf8'),
-  readFile(nativeOptionsUrl, 'utf8'),
-  readFile(coreOptionsUrl, 'utf8'),
-])
+const [readme, packageJson, loader, nativeTargets, declarations, nativeOptions, coreOptions]
+  = await Promise.all([
+    readFile(readmeUrl, 'utf8'),
+    readFile(packageUrl, 'utf8').then(JSON.parse),
+    readFile(loaderUrl, 'utf8'),
+    readFile(nativeTargetUrl, 'utf8'),
+    readFile(declarationUrl, 'utf8'),
+    readFile(nativeOptionsUrl, 'utf8'),
+    readFile(coreOptionsUrl, 'utf8'),
+  ])
 
 function assertReadmeContract(candidate) {
   assert.match(candidate, /^## Install$/m, 'README must have an install section')
@@ -58,9 +61,9 @@ function assertReadmeContract(candidate) {
   assert.match(candidate, /^## Troubleshooting native loading$/m, 'README must explain lazy loader failures')
   assert.match(candidate, /constructing `Renderer` or on the first call to\s+`toHtml\(\)`, `transform\(\)`, or a highlighter helper/i)
 
-  assert.match(loader, /linux-arm64-musl/, 'loader must select the arm64 musl package')
-  assert.match(loader, /linux-x64-musl/, 'loader must select the x64 musl package')
-  assert.match(loader, /does not support \$\{process\.platform\}/, 'loader must retain unsupported-target diagnostics')
+  assert.match(nativeTargets, /linux-arm64-musl/, 'loader must select the arm64 musl package')
+  assert.match(nativeTargets, /linux-x64-musl/, 'loader must select the x64 musl package')
+  assert.match(nativeTargets, /does not support \$\{platform\}/, 'loader must retain unsupported-target diagnostics')
   assert.match(candidate, /Unsupported platform or architecture/, 'README must cover unsupported targets')
   assert.match(loader, /could not load the optional native package/, 'loader must retain missing-package diagnostics')
   assert.match(candidate, /`could not load the optional native package`/, 'README must cover missing platform packages')
@@ -68,7 +71,7 @@ function assertReadmeContract(candidate) {
   assert.match(candidate, /glibc 2\.17/, 'README must document the GNU Linux binary baseline')
   assert.match(candidate, /`ERR_DLOPEN_FAILED`/, 'README must cover native dynamic-loader failures')
 
-  const loaderTargets = [...loader.matchAll(/'([a-z0-9]+-(?:arm64|x64)(?:-(?:gnu|musl))?)': '([a-z0-9-]+)'/g)]
+  const loaderTargets = [...nativeTargets.matchAll(/'([a-z0-9]+-(?:arm64|x64)(?:-(?:gnu|musl))?)': '([a-z0-9-]+)'/g)]
     .map(([, host, target]) => ({ host, target }))
   const packageTargets = packageJson.napi.targets.map(packageTargetToBindingTarget)
   assert.deepEqual(

--- a/node/ferromark/scripts/verify-package.mjs
+++ b/node/ferromark/scripts/verify-package.mjs
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict'
 import { access, readFile } from 'node:fs/promises'
 
-const required = ['index.mjs', 'index.d.mts', 'native.d.ts', 'package.json']
+const required = ['index.mjs', 'index.d.mts', 'native-target.mjs', 'native.d.ts', 'package.json']
 await Promise.all(required.map(file => access(new URL(`../${file}`, import.meta.url))))
 
 const [declarations, packageJson, releaseConfig, buildNative] = await Promise.all([

--- a/node/ferromark/test/index.test.mjs
+++ b/node/ferromark/test/index.test.mjs
@@ -1,6 +1,7 @@
 import assert from 'node:assert/strict'
 import { spawnSync } from 'node:child_process'
 import { copyFile, mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { createRequire } from 'node:module'
 import { tmpdir } from 'node:os'
 import path from 'node:path'
 import process from 'node:process'
@@ -14,9 +15,25 @@ import {
   transform,
   transformWithHighlighter,
 } from '../index.mjs'
+import { nativeTarget } from '../native-target.mjs'
 
 test('renders Markdown through the native binding', () => {
   assert.equal(toHtml('# Hello'), '<h1 id="hello">Hello</h1>\n')
+})
+
+test('rejects non-string Markdown across every public render entry point', () => {
+  const highlighter = { codeToHtml: () => '<pre><code></code></pre>\n' }
+  const calls = [
+    () => toHtml(123),
+    () => transform(null),
+    () => new Renderer().toHtml({}),
+    () => toHtmlWithHighlighter(123, highlighter, { theme: 'dark' }),
+    () => transformWithHighlighter(123, highlighter, { theme: 'dark' }),
+  ]
+
+  for (const call of calls) {
+    assert.throws(call, error => error instanceof Error && /string/i.test(error.message))
+  }
 })
 
 test('reuses a renderer without leaking document state', () => {
@@ -62,6 +79,17 @@ test('maps typed options to the Rust surface', () => {
   assert.throws(
     () => toHtml('text', { renderPolicy: 'invalid' }),
     /renderPolicy must be either 'untrusted' or 'trusted'/,
+  )
+})
+
+test('requires trusted rendering before allowHtml passes raw HTML through', () => {
+  assert.equal(
+    toHtml('<i>content</i>', { allowHtml: true }),
+    '<p>&lt;i&gt;content&lt;/i&gt;</p>\n',
+  )
+  assert.equal(
+    toHtml('<i>content</i>', { renderPolicy: 'trusted', allowHtml: true }),
+    '<p><i>content</i></p>\n',
   )
 })
 
@@ -112,6 +140,31 @@ test('selects the musl optional package on Alpine-style Linux', () => {
   assert.equal(result.status, 0, result.stderr)
 })
 
+test('maps every supported native platform and rejects unsupported targets', () => {
+  const targets = [
+    ['darwin', 'arm64', undefined, 'darwin-arm64'],
+    ['darwin', 'x64', undefined, 'darwin-x64'],
+    ['linux', 'arm64', '2.17', 'linux-arm64-gnu'],
+    ['linux', 'arm64', undefined, 'linux-arm64-musl'],
+    ['linux', 'x64', '2.39', 'linux-x64-gnu'],
+    ['linux', 'x64', undefined, 'linux-x64-musl'],
+    ['win32', 'arm64', undefined, 'win32-arm64-msvc'],
+    ['win32', 'x64', undefined, 'win32-x64-msvc'],
+  ]
+
+  for (const [platform, arch, glibcVersionRuntime, expected] of targets) {
+    assert.equal(nativeTarget(platform, arch, glibcVersionRuntime), expected)
+  }
+  assert.throws(
+    () => nativeTarget('linux', 'riscv64', '2.39'),
+    /ferromark does not support linux\/riscv64/,
+  )
+  assert.throws(
+    () => nativeTarget('freebsd', 'x64'),
+    /ferromark does not support freebsd\/x64/,
+  )
+})
+
 test('does not collect a diagnostic report on non-Linux platforms', () => {
   const entry = new URL('../index.mjs', import.meta.url).href
   const script = `
@@ -149,6 +202,10 @@ test('wraps native dynamic-loader failures with platform guidance', async (t) =>
   await mkdir(packageDir, { recursive: true })
   await Promise.all([
     copyFile(new URL('../index.mjs', import.meta.url), entry),
+    copyFile(
+      new URL('../native-target.mjs', import.meta.url),
+      path.join(fixture, 'native-target.mjs'),
+    ),
     writeFile(
       path.join(packageDir, 'package.json'),
       JSON.stringify({ name: packageName, main: binaryName }),
@@ -179,18 +236,11 @@ test('wraps native dynamic-loader failures with platform guidance', async (t) =>
   )
 })
 
-test('loads the ESM entry point from CommonJS', () => {
-  const entry = fileURLToPath(new URL('../index.mjs', import.meta.url))
-  const script = `
-    const { toHtml } = require(${JSON.stringify(entry)})
-    process.stdout.write(toHtml('# CommonJS'))
-  `
-  const result = spawnSync(process.execPath, ['--input-type=commonjs', '--eval', script], {
-    encoding: 'utf8',
-  })
+test('loads the package by name from CommonJS', () => {
+  const require = createRequire(import.meta.url)
+  const { toHtml: cjsToHtml } = require('ferromark')
 
-  assert.equal(result.status, 0, result.stderr)
-  assert.equal(result.stdout, '<h1 id="commonjs">CommonJS</h1>\n')
+  assert.equal(cjsToHtml('# CommonJS'), '<h1 id="commonjs">CommonJS</h1>\n')
 })
 
 test('composes with a synchronous Ferriki-compatible highlighter', () => {
@@ -250,6 +300,38 @@ test('falls back to escaped code when highlighting fails', () => {
   )
 })
 
+test('uses fallbackLanguage and preserves transform metadata when highlighting fails', () => {
+  const calls = []
+  const failure = new Error('unsupported language')
+  const highlighter = {
+    codeToHtml(code, options) {
+      calls.push({ code, options })
+      throw failure
+    },
+  }
+  const failures = []
+  const result = transformWithHighlighter(
+    '```\n<tag>\n```\n\n# After',
+    highlighter,
+    {
+      theme: 'github-dark',
+      fallbackLanguage: 'plaintext',
+      onHighlightError(error, context) {
+        failures.push({ error, context })
+      },
+    },
+  )
+
+  assert.match(result.html, /<pre><code>&lt;tag&gt;\n<\/code><\/pre>/)
+  assert.match(result.html, /<h1 id="after">After<\/h1>/)
+  assert.deepEqual(result.headings, [{ level: 1, id: 'after', text: 'After' }])
+  assert.deepEqual(calls, [{
+    code: '<tag>\n',
+    options: { lang: 'plaintext', theme: 'github-dark' },
+  }])
+  assert.deepEqual(failures, [{ error: failure, context: { lang: 'plaintext' } }])
+})
+
 test('validates and surfaces highlighter error observers', () => {
   const highlighter = {
     codeToHtml() {
@@ -297,6 +379,13 @@ test('transform returns html, headings, and front matter', () => {
     { level: 1, id: 'top', text: 'Top' },
     { level: 2, id: 'sub-code', text: 'Sub code' },
   ])
+})
+
+test('transform extracts TOML-style front matter', () => {
+  const result = transform('+++\ntitle = "TOML"\n+++\n# Top', { frontMatter: true })
+
+  assert.equal(result.frontMatter, 'title = "TOML"\n')
+  assert.match(result.html, /<h1 id="top">Top<\/h1>/)
 })
 
 test('transform omits ids when headingIds is disabled', () => {

--- a/node/scripts/verify-pack.mjs
+++ b/node/scripts/verify-pack.mjs
@@ -29,6 +29,7 @@ const allowedMain = [
   'README.md',
   'index.d.mts',
   'index.mjs',
+  'native-target.mjs',
   'native.d.ts',
   'package.json',
 ]


### PR DESCRIPTION
## Summary

- extract the internal native target resolver and test all eight published target mappings plus unsupported platforms
- cover invalid Markdown argument types, trusted raw HTML, TOML-style front matter, fallback languages, and transform renderer fallback
- exercise CommonJS loading through the actual `ferromark` package name
- keep package-content and README loader contracts aligned with the internal module

## Verification

- `pnpm test` (22/22 Node tests)
- `pnpm typecheck`
- `pnpm lint`
- `pnpm pack:check`
- `pnpm smoke:clean`

Fixes #178