### PR TITLE
Enforce complete public API documentation

### DIFF
--- a/src/footnote.rs
+++ b/src/footnote.rs
@@ -21,6 +21,8 @@ pub struct FootnoteStore {
 }
 
 impl FootnoteStore {
+    /// Create an empty footnote-definition store.
+    #[must_use]
     pub fn new() -> Self {
         Self::default()
     }
@@ -35,6 +37,7 @@ impl FootnoteStore {
         self.by_label.insert(normalized_label, idx);
     }
 
+    /// Return the insertion-order index for a normalized label.
     pub fn get_index(&self, label: &str) -> Option<usize> {
         self.by_label.get(label).copied()
     }
@@ -59,14 +62,19 @@ impl FootnoteStore {
         self.by_label.get(normalized).copied()
     }
 
+    /// Return the definition at an insertion-order index.
     pub fn get(&self, idx: usize) -> Option<&FootnoteDef> {
         self.defs.get(idx)
     }
 
+    /// Return whether the store contains no definitions.
+    #[must_use]
     pub fn is_empty(&self) -> bool {
         self.defs.is_empty()
     }
 
+    /// Return the number of stored definitions.
+    #[must_use]
     pub fn len(&self) -> usize {
         self.defs.len()
     }

--- a/src/inline/marks.rs
+++ b/src/inline/marks.rs
@@ -14,8 +14,11 @@ use memchr::memchr3;
 
 /// Flags for mark state.
 pub mod flags {
+    /// The delimiter may open an inline construct.
     pub const POTENTIAL_OPENER: u8 = 0b0001;
+    /// The delimiter may close an inline construct.
     pub const POTENTIAL_CLOSER: u8 = 0b0010;
+    /// The delimiter has already been consumed by a construct.
     pub const RESOLVED: u8 = 0b0100;
     /// Mark is part of a code span (skip in emphasis processing).
     pub const IN_CODE: u8 = 0b1000;
@@ -44,36 +47,50 @@ impl MarkSummary {
     }
 
     #[inline]
+    /// Return whether the input contains a possible code-span delimiter.
+    #[must_use]
     pub const fn has_code(self) -> bool {
         self.0 & Self::CODE != 0
     }
 
     #[inline]
+    /// Return whether the input contains a possible math delimiter.
+    #[must_use]
     pub const fn has_math(self) -> bool {
         self.0 & Self::MATH != 0
     }
 
     #[inline]
+    /// Return whether the input contains a possible emphasis delimiter.
+    #[must_use]
     pub const fn has_emphasis(self) -> bool {
         self.0 & Self::EMPHASIS != 0
     }
 
     #[inline]
+    /// Return whether the input contains a possible tilde-based delimiter.
+    #[must_use]
     pub const fn has_tilde(self) -> bool {
         self.0 & Self::TILDE != 0
     }
 
     #[inline]
+    /// Return whether the input contains a possible highlight delimiter.
+    #[must_use]
     pub const fn has_highlight(self) -> bool {
         self.0 & Self::HIGHLIGHT != 0
     }
 
     #[inline]
+    /// Return whether the input contains a possible superscript delimiter.
+    #[must_use]
     pub const fn has_superscript(self) -> bool {
         self.0 & Self::SUPERSCRIPT != 0
     }
 
     #[inline]
+    /// Return whether the input contains a less-than sign that may start HTML.
+    #[must_use]
     pub const fn has_less_than(self) -> bool {
         self.0 & Self::LESS_THAN != 0
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,5 @@
+#![warn(missing_docs)]
+
 //! Markdown to HTML with a secure rendering default.
 //!
 //! ferromark streams Markdown into HTML without building an AST. Its default
@@ -789,6 +791,15 @@ pub fn try_to_html(input: &str) -> Result<String, InputSizeError> {
 /// This reuses only the output buffer. Use [`Renderer`] to retain parser and
 /// renderer scratch allocations across documents as well.
 ///
+/// # Example
+///
+/// ```
+/// let mut output = Vec::new();
+/// ferromark::to_html_into("**Hello**", &mut output);
+///
+/// assert_eq!(output, b"<p><strong>Hello</strong></p>\n");
+/// ```
+///
 /// # Panics
 ///
 /// Panics when the input exceeds [`MAX_INPUT_BYTES`]. Use
@@ -807,6 +818,20 @@ pub fn try_to_html_into(input: &str, out: &mut Vec<u8>) -> Result<(), InputSizeE
 ///
 /// When `options.front_matter` is `true`, any front matter at the start of the
 /// document is silently stripped before parsing.
+///
+/// # Example
+///
+/// ```
+/// use ferromark::{Options, to_html_with_options};
+///
+/// let mut options = Options::gfm();
+/// options.heading_ids = true;
+///
+/// assert_eq!(
+///     to_html_with_options("# Hello", &options),
+///     "<h1 id=\"hello\">Hello</h1>\n"
+/// );
+/// ```
 ///
 /// # Panics
 ///

--- a/src/link_ref.rs
+++ b/src/link_ref.rs
@@ -9,7 +9,9 @@ use std::collections::HashMap;
 /// A link reference definition (URL + optional title).
 #[derive(Debug, Clone)]
 pub struct LinkRefDef {
+    /// Destination URL bytes after parsing the definition.
     pub url: Vec<u8>,
+    /// Optional title bytes after parsing the definition.
     pub title: Option<Vec<u8>>,
 }
 
@@ -21,6 +23,8 @@ pub struct LinkRefStore {
 }
 
 impl LinkRefStore {
+    /// Create an empty link-reference-definition store.
+    #[must_use]
     pub fn new() -> Self {
         Self::default()
     }
@@ -35,14 +39,18 @@ impl LinkRefStore {
         self.by_label.insert(label, idx);
     }
 
+    /// Return the insertion-order index for a normalized label.
     pub fn get_index(&self, label: &str) -> Option<usize> {
         self.by_label.get(label).copied()
     }
 
+    /// Return the definition at an insertion-order index.
     pub fn get(&self, idx: usize) -> Option<&LinkRefDef> {
         self.defs.get(idx)
     }
 
+    /// Return whether the store contains no definitions.
+    #[must_use]
     pub fn is_empty(&self) -> bool {
         self.defs.is_empty()
     }

--- a/src/mdx/mod.rs
+++ b/src/mdx/mod.rs
@@ -126,8 +126,11 @@
 //! TypeScript syntax inside otherwise well-delimited ESM and expressions.
 
 mod events;
+/// JavaScript-expression boundary scanning used by MDX parsers.
 pub mod expr;
+/// JSX tag parsing and structural metadata.
 pub mod jsx_tag;
+/// Rendering MDX segments as a JavaScript component module.
 pub mod render;
 mod splitter;
 mod strict;

--- a/src/range.rs
+++ b/src/range.rs
@@ -78,7 +78,9 @@ pub(crate) fn offset_to_u32(offset: usize) -> u32 {
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Default)]
 #[repr(C)]
 pub struct Range {
+    /// Inclusive byte offset where the range starts.
     pub start: u32,
+    /// Exclusive byte offset where the range ends.
     pub end: u32,
 }
 


### PR DESCRIPTION
Fixes #183

## Summary
- enable the crate-wide `missing_docs` lint
- document re-exported footnote and link-reference store APIs plus remaining exposed helpers
- add runnable examples for buffer and options rendering APIs

## Validation
- `cargo test --locked --all-features`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features --locked`
- `cargo public-api --simplified --all-features --color never`
- `cargo fmt --all -- --check`
- `git diff --check`