### PR TITLE
Update README project structure tree

### DIFF
--- a/README.md
+++ b/README.md
@@ -844,6 +844,7 @@ src/
 │   ├── event.rs    # InlineEvent types
 │   ├── code_span.rs
 │   ├── emphasis.rs      # Modulo-3 stack optimization
+│   ├── highlight.rs     # Highlight/mark resolution (==text==)
 │   ├── strikethrough.rs # GFM strikethrough resolution
 │   ├── subscript.rs     # Subscript resolution (~text~)
 │   ├── superscript.rs   # Superscript resolution (^text^)
@@ -851,8 +852,10 @@ src/
 │   └── links.rs         # Link/image/autolink parsing
 ├── mdx/            # MDX segmenter + renderer (feature = "mdx")
 │   ├── mod.rs      # Public API — Segment enum, segment(), render()
+│   ├── events.rs   # Semantic event stream exposed by parse_events()
 │   ├── render.rs   # Assembly layer: segments → HTML body + ESM + front matter
 │   ├── splitter.rs # Line-based state machine
+│   ├── strict.rs   # Structural diagnostics exposed by segment_strict()
 │   ├── jsx_tag.rs  # JSX tag boundary parser
 │   └── expr.rs     # Expression boundary parser (brace/string/comment tracking)
 ├── footnote.rs     # Footnote store and rendering

--- a/scripts/test-readme-structure-contract.rb
+++ b/scripts/test-readme-structure-contract.rb
@@ -10,6 +10,7 @@ CONTRIBUTING_PATH = File.join(REPOSITORY_ROOT, 'CONTRIBUTING.md')
 BENCHMARK_LOCK_PATH = File.join(REPOSITORY_ROOT, 'benchmarks/md4c-comparison/Cargo.lock')
 BENCHMARK_BUILD_PATH = File.join(REPOSITORY_ROOT, 'benchmarks/md4c-comparison/build.rs')
 PERFORMANCE_PLAN_PATH = File.join(REPOSITORY_ROOT, 'docs/arch/ARCH-PLAN-001-performance-opportunities.md')
+PROJECT_STRUCTURE_FILES = %w[highlight.rs events.rs strict.rs].freeze
 
 def fail_contract(message)
   raise ContractError, "README structure contract: #{message}"
@@ -111,6 +112,13 @@ def validate(
   unless document.include?('baseline SSE2 (x86-64)')
     fail_contract('README must describe the x86-64 inline SIMD path')
   end
+
+  project_structure = section(document, 'Project structure')
+  PROJECT_STRUCTURE_FILES.each do |filename|
+    unless project_structure.include?(filename)
+      fail_contract("Project structure must include #{filename}")
+    end
+  end
 end
 
 def assert_rejected(label)
@@ -165,6 +173,11 @@ def self_test(document)
       document,
       performance_plan: performance_plan.gsub('MD4C_DIR=/path/to/md4c cargo bench --locked', 'cargo bench')
     )
+  end
+  PROJECT_STRUCTURE_FILES.each do |filename|
+    assert_rejected("project structure #{filename}") do
+      validate(document.sub(filename, 'omitted-source-file.rs'))
+    end
   end
 end
 


### PR DESCRIPTION
Fixes #187

## Summary
- add the inline highlight implementation to the project structure tree
- document the semantic MDX event-stream and strict-diagnostics modules
- extend the README structure contract with mutation coverage for all three entries

## Validation
- `ruby scripts/test-readme-structure-contract.rb --self-test`
- `cargo test --locked --all-features`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`