### PR TITLE
Hide parser implementation modules behind root facade

### DIFF
--- a/README.md
+++ b/README.md
@@ -333,7 +333,7 @@ let html = ferromark::to_html_with_options(trusted_markdown, &options);
 `disallowed_raw_html` implements the narrower GFM tag filter in trusted mode. It is not a general-purpose HTML sanitizer and does not make arbitrary raw HTML safe by itself.
 
 Upgrading from an older release? See the [0.8 migration guide](docs/migration-0.8.md)
-for the `Options` and event-match migration, the
+for the `Options`, event-match, and crate-root import migration, the
 [0.4–0.7 migration guide](docs/migration-0.4.md) for `Profile`, inline-parser,
 fenced-renderer, Rust, and Node.js changes, the
 [0.2 migration guide](docs/migration-0.2.md) for the rendering default and the

--- a/benches/fenced_code_renderer.rs
+++ b/benches/fenced_code_renderer.rs
@@ -2,7 +2,8 @@ use std::hint::black_box;
 
 use criterion::{Criterion, criterion_group, criterion_main};
 use ferromark::{
-    FencedCodeBlock, FencedCodeRenderer, Options, TrustedHtml, to_html, to_html_with_renderer,
+    FencedCodeBlock, FencedCodeRenderer, Options, TrustedHtml, escape_text_into, to_html,
+    to_html_with_renderer,
 };
 
 struct FallbackRenderer;
@@ -19,7 +20,7 @@ struct EscapingRenderer;
 impl FencedCodeRenderer for EscapingRenderer {
     fn render(&mut self, block: FencedCodeBlock<'_>) -> Option<TrustedHtml> {
         let mut escaped = Vec::with_capacity(block.code.len());
-        ferromark::escape::escape_text_into(&mut escaped, block.code.as_bytes());
+        escape_text_into(&mut escaped, block.code.as_bytes());
         let escaped = String::from_utf8(escaped).expect("HTML escaping preserves UTF-8");
         Some(TrustedHtml::from_trusted(format!(
             "<pre class=\"highlighted\"><code>{escaped}</code></pre>\n"

--- a/benches/parsing.rs
+++ b/benches/parsing.rs
@@ -5,6 +5,7 @@
 use std::hint::black_box;
 
 use criterion::{Criterion, Throughput, criterion_group, criterion_main};
+use ferromark::escape_text_into;
 
 /// Sample Markdown documents of various sizes
 mod samples {
@@ -254,7 +255,7 @@ fn bench_escaping(c: &mut Criterion) {
     group.bench_function("plain_text", |b| {
         b.iter(|| {
             let mut out = Vec::with_capacity(plain.len());
-            ferromark::escape::escape_text_into(&mut out, black_box(plain.as_bytes()));
+            escape_text_into(&mut out, black_box(plain.as_bytes()));
             out
         })
     });
@@ -265,7 +266,7 @@ fn bench_escaping(c: &mut Criterion) {
     group.bench_function("html_heavy", |b| {
         b.iter(|| {
             let mut out = Vec::with_capacity(html_heavy.len() * 2);
-            ferromark::escape::escape_text_into(&mut out, black_box(html_heavy.as_bytes()));
+            escape_text_into(&mut out, black_box(html_heavy.as_bytes()));
             out
         })
     });

--- a/docs/migration-0.8.md
+++ b/docs/migration-0.8.md
@@ -1,8 +1,10 @@
 # Migrating to ferromark 0.8
 
 Version 0.8 makes ferromark's public `Options` and event/type enums
-forward-compatible before 1.0. This is an intentional pre-1.0 breaking API
-change: update option construction and exhaustive enum matches as below.
+forward-compatible before 1.0 and moves parser implementation modules behind
+the stable crate-root facade. These are intentional pre-1.0 breaking API
+changes: update option construction, exhaustive enum matches, and
+module-qualified imports as below.
 
 ## Configure non-exhaustive options from a preset
 
@@ -51,3 +53,32 @@ let label = match RenderPolicy::Untrusted {
 };
 assert_eq!(label, "untrusted");
 ```
+
+## Import public types and helpers from the crate root
+
+The `block`, `cursor`, `escape`, `footnote`, `inline`, `link_ref`, `range`, and
+`render` modules are now private implementation details. Public parsers,
+events, stores, ranges, the HTML writer, and the supported escaping helpers are
+available directly from `ferromark`.
+
+Replace module-qualified imports:
+
+```rust,ignore
+use ferromark::block::{ListKind, TaskState};
+use ferromark::inline::AutolinkLiteralKind;
+use ferromark::escape::escape_text_into;
+```
+
+with crate-root imports:
+
+```rust
+use ferromark::{AutolinkLiteralKind, ListKind, TaskState, escape_text_into};
+
+let mut escaped = Vec::new();
+escape_text_into(&mut escaped, b"<code>");
+assert_eq!(escaped, b"&lt;code&gt;");
+```
+
+`Cursor`, mark-resolution internals, and other low-level helpers no longer form
+part of the public API. Keep custom integrations on the root-level
+`BlockParser`, `InlineParser`, event, store, `Range`, and `HtmlWriter` types.

--- a/examples/fenced_code_renderer.rs
+++ b/examples/fenced_code_renderer.rs
@@ -1,4 +1,7 @@
-use ferromark::{FencedCodeBlock, FencedCodeRenderer, Options, TrustedHtml, to_html_with_renderer};
+use ferromark::{
+    FencedCodeBlock, FencedCodeRenderer, Options, TrustedHtml, escape_text_into,
+    to_html_with_renderer,
+};
 
 struct RustCodeRenderer;
 
@@ -9,7 +12,7 @@ impl FencedCodeRenderer for RustCodeRenderer {
         }
 
         let mut escaped = Vec::with_capacity(block.code.len());
-        ferromark::escape::escape_text_into(&mut escaped, block.code.as_bytes());
+        escape_text_into(&mut escaped, block.code.as_bytes());
         let escaped = String::from_utf8(escaped).expect("HTML escaping preserves UTF-8");
 
         // TrustedHtml is written verbatim. A production renderer must escape

--- a/src/cursor.rs
+++ b/src/cursor.rs
@@ -3,24 +3,10 @@
 //! Uses raw pointers internally for maximum scanning speed,
 //! wrapped in a safe API with bounds checking at block entry.
 
-use crate::Range;
-
 /// A cursor for efficient byte-by-byte scanning.
 ///
 /// Internally uses raw pointers to avoid bounds checks in tight loops.
 /// The cursor is bounds-checked at creation and when advancing past known-safe regions.
-///
-/// # Example
-/// ```
-/// use ferromark::cursor::Cursor;
-///
-/// let input = b"Hello, World!";
-/// let mut cursor = Cursor::new(input);
-///
-/// assert_eq!(cursor.peek(), Some(b'H'));
-/// cursor.advance(7);
-/// assert_eq!(cursor.peek(), Some(b'W'));
-/// ```
 #[derive(Clone, Copy)]
 pub struct Cursor<'a> {
     ptr: *const u8,
@@ -109,17 +95,6 @@ impl<'a> Cursor<'a> {
         }
     }
 
-    /// Peek the current byte without bounds check.
-    ///
-    /// # Safety
-    /// Caller must ensure cursor is not at EOF.
-    #[inline]
-    pub unsafe fn peek_unchecked(&self) -> u8 {
-        debug_assert!(!self.is_eof());
-        // SAFETY: Caller guarantees not at EOF
-        unsafe { *self.ptr }
-    }
-
     /// Peek at byte n positions ahead.
     #[inline]
     pub fn peek_ahead(&self, n: usize) -> Option<u8> {
@@ -129,23 +104,6 @@ impl<'a> Cursor<'a> {
             // SAFETY: n < remaining
             Some(unsafe { *self.ptr.add(n) })
         }
-    }
-
-    /// Advance by n bytes.
-    ///
-    /// # Panics
-    ///
-    /// Panics if `n` exceeds the number of remaining bytes.
-    #[inline]
-    pub fn advance(&mut self, n: usize) {
-        let remaining = self.remaining();
-        assert!(
-            n <= remaining,
-            "cannot advance cursor by {n} bytes with only {remaining} remaining"
-        );
-        // SAFETY: The assertion above keeps the pointer within the allocation
-        // or exactly one byte past its end.
-        self.ptr = unsafe { self.ptr.add(n) };
     }
 
     /// Advance without checking the remaining length.
@@ -164,18 +122,6 @@ impl<'a> Cursor<'a> {
         self.ptr = unsafe { self.ptr.add(n) };
     }
 
-    /// Advance by 1 byte.
-    ///
-    /// # Panics
-    ///
-    /// Panics if the cursor is already at EOF.
-    #[inline]
-    pub fn bump(&mut self) {
-        assert!(!self.is_eof(), "cannot bump cursor past EOF");
-        // SAFETY: The assertion above guarantees one byte remains.
-        self.ptr = unsafe { self.ptr.add(1) };
-    }
-
     /// Advance by one byte without checking for EOF.
     ///
     /// # Safety
@@ -188,33 +134,10 @@ impl<'a> Cursor<'a> {
         self.ptr = unsafe { self.ptr.add(1) };
     }
 
-    /// Consume and return current byte.
-    #[inline]
-    #[allow(clippy::should_implement_trait)]
-    pub fn next(&mut self) -> Option<u8> {
-        if self.is_eof() {
-            None
-        } else {
-            // SAFETY: not at EOF
-            let b = unsafe { *self.ptr };
-            self.ptr = unsafe { self.ptr.add(1) };
-            Some(b)
-        }
-    }
-
     /// Check if current position matches a byte.
     #[inline]
     pub fn at(&self, b: u8) -> bool {
         self.peek() == Some(b)
-    }
-
-    /// Check if current position matches any of the given bytes.
-    #[inline]
-    pub fn at_any(&self, bytes: &[u8]) -> bool {
-        match self.peek() {
-            Some(b) => bytes.contains(&b),
-            None => false,
-        }
     }
 
     /// Skip while predicate is true.
@@ -240,47 +163,6 @@ impl<'a> Cursor<'a> {
         self.skip_while(|b| b == b' ' || b == b'\t')
     }
 
-    /// Skip spaces only.
-    #[inline]
-    pub fn skip_spaces(&mut self) -> usize {
-        self.skip_while(|b| b == b' ')
-    }
-
-    /// Consume a specific byte if present.
-    #[inline]
-    pub fn eat(&mut self, b: u8) -> bool {
-        if self.at(b) {
-            // SAFETY: `at` can only succeed when a byte remains.
-            unsafe { self.bump_unchecked() };
-            true
-        } else {
-            false
-        }
-    }
-
-    /// Consume a specific byte sequence if present.
-    #[inline]
-    pub fn eat_bytes(&mut self, bytes: &[u8]) -> bool {
-        if self.remaining() < bytes.len() {
-            return false;
-        }
-        // SAFETY: remaining >= bytes.len()
-        let slice = unsafe { std::slice::from_raw_parts(self.ptr, bytes.len()) };
-        if slice == bytes {
-            // SAFETY: The remaining-length check above covers `bytes.len()`.
-            unsafe { self.advance_unchecked(bytes.len()) };
-            true
-        } else {
-            false
-        }
-    }
-
-    /// Get a range from a start offset to current position.
-    #[inline]
-    pub fn range_from(&self, start: usize) -> Range {
-        Range::from_usize(start, self.offset())
-    }
-
     /// Get the remaining bytes as a slice.
     #[inline]
     pub fn remaining_slice(&self) -> &'a [u8] {
@@ -298,28 +180,6 @@ impl<'a> Cursor<'a> {
     #[inline]
     pub fn find_newline(&self) -> Option<usize> {
         self.find(b'\n')
-    }
-
-    /// Advance to the next newline, returning the range of the line (excluding newline).
-    #[inline]
-    pub fn consume_line(&mut self) -> Range {
-        let start = self.offset();
-        match self.find_newline() {
-            Some(pos) => {
-                let end = start + pos;
-                // SAFETY: `pos` identifies a newline in the remaining slice.
-                unsafe { self.advance_unchecked(pos + 1) }; // Skip past newline
-                Range::from_usize(start, end)
-            }
-            None => {
-                // No newline found, consume rest of input
-                let end = start + self.remaining();
-                let remaining = self.remaining();
-                // SAFETY: Advancing by the exact remaining length reaches EOF.
-                unsafe { self.advance_unchecked(remaining) };
-                Range::from_usize(start, end)
-            }
-        }
     }
 }
 
@@ -365,43 +225,10 @@ mod tests {
     }
 
     #[test]
-    fn test_cursor_advance() {
-        let mut cursor = Cursor::new(b"Hello");
-        assert_eq!(cursor.peek(), Some(b'H'));
-
-        cursor.advance(2);
-        assert_eq!(cursor.offset(), 2);
-        assert_eq!(cursor.peek(), Some(b'l'));
-
-        cursor.bump();
-        assert_eq!(cursor.offset(), 3);
-        assert_eq!(cursor.peek(), Some(b'l'));
-    }
-
-    #[test]
-    fn test_cursor_next() {
-        let mut cursor = Cursor::new(b"abc");
-        assert_eq!(cursor.next(), Some(b'a'));
-        assert_eq!(cursor.next(), Some(b'b'));
-        assert_eq!(cursor.next(), Some(b'c'));
-        assert_eq!(cursor.next(), None);
-    }
-
-    #[test]
     fn test_cursor_at() {
         let cursor = Cursor::new(b"abc");
         assert!(cursor.at(b'a'));
         assert!(!cursor.at(b'b'));
-        assert!(cursor.at_any(b"axy"));
-        assert!(!cursor.at_any(b"xyz"));
-    }
-
-    #[test]
-    fn test_cursor_skip_while() {
-        let mut cursor = Cursor::new(b"   abc");
-        let skipped = cursor.skip_spaces();
-        assert_eq!(skipped, 3);
-        assert_eq!(cursor.peek(), Some(b'a'));
     }
 
     #[test]
@@ -413,61 +240,10 @@ mod tests {
     }
 
     #[test]
-    fn test_cursor_eat() {
-        let mut cursor = Cursor::new(b"abc");
-        assert!(cursor.eat(b'a'));
-        assert!(!cursor.eat(b'a'));
-        assert!(cursor.eat(b'b'));
-    }
-
-    #[test]
-    fn test_cursor_eat_bytes() {
-        let mut cursor = Cursor::new(b"hello world");
-        assert!(cursor.eat_bytes(b"hello"));
-        assert_eq!(cursor.peek(), Some(b' '));
-        assert!(!cursor.eat_bytes(b"hello"));
-        assert!(cursor.eat_bytes(b" world"));
-        assert!(cursor.is_eof());
-    }
-
-    #[test]
     fn test_cursor_find() {
         let cursor = Cursor::new(b"hello\nworld");
         assert_eq!(cursor.find(b'\n'), Some(5));
         assert_eq!(cursor.find(b'x'), None);
-    }
-
-    #[test]
-    fn test_cursor_consume_line() {
-        let mut cursor = Cursor::new(b"line1\nline2\nline3");
-
-        let line1 = cursor.consume_line();
-        assert_eq!(line1.slice(b"line1\nline2\nline3"), b"line1");
-
-        let line2 = cursor.consume_line();
-        assert_eq!(line2.slice(b"line1\nline2\nline3"), b"line2");
-
-        let line3 = cursor.consume_line();
-        assert_eq!(line3.slice(b"line1\nline2\nline3"), b"line3");
-
-        assert!(cursor.is_eof());
-    }
-
-    #[test]
-    fn test_cursor_consume_line_no_trailing_newline() {
-        let mut cursor = Cursor::new(b"hello");
-        let line = cursor.consume_line();
-        assert_eq!(line.slice(b"hello"), b"hello");
-        assert!(cursor.is_eof());
-    }
-
-    #[test]
-    fn test_cursor_range_from() {
-        let mut cursor = Cursor::new(b"hello world");
-        cursor.advance(6);
-        let range = cursor.range_from(0);
-        assert_eq!(range.start, 0);
-        assert_eq!(range.end, 6);
     }
 
     #[test]
@@ -482,19 +258,5 @@ mod tests {
     #[should_panic(expected = "cursor offset 2 exceeds input length 1")]
     fn new_at_panics_when_offset_exceeds_input() {
         let _ = Cursor::new_at(b"x", 2);
-    }
-
-    #[test]
-    #[should_panic(expected = "cannot advance cursor by 2 bytes with only 1 remaining")]
-    fn advance_panics_when_distance_exceeds_remaining_input() {
-        let mut cursor = Cursor::new(b"x");
-        cursor.advance(2);
-    }
-
-    #[test]
-    #[should_panic(expected = "cannot bump cursor past EOF")]
-    fn bump_panics_at_eof() {
-        let mut cursor = Cursor::new(b"");
-        cursor.bump();
     }
 }

--- a/src/escape.rs
+++ b/src/escape.rs
@@ -5,44 +5,13 @@
 
 use memchr::{memchr, memchr2, memchr3};
 
-/// Characters that need escaping in HTML text content.
-#[allow(dead_code)]
-const TEXT_ESCAPE_CHARS: &[u8] = b"<>&";
-
-/// Characters that need escaping in HTML attribute values.
-#[allow(dead_code)]
-const ATTR_ESCAPE_CHARS: &[u8] = b"<>&\"'";
-
-/// Lookup table for escapable characters in text content.
-/// Index by byte value, true if needs escaping.
-/// Note: We escape " as &quot; for CommonMark spec compliance.
-const TEXT_ESCAPE_TABLE: [bool; 256] = {
-    let mut table = [false; 256];
-    table[b'<' as usize] = true;
-    table[b'>' as usize] = true;
-    table[b'&' as usize] = true;
-    table[b'"' as usize] = true;
-    table
-};
-
-/// Lookup table for escapable characters in attributes.
-const ATTR_ESCAPE_TABLE: [bool; 256] = {
-    let mut table = [false; 256];
-    table[b'<' as usize] = true;
-    table[b'>' as usize] = true;
-    table[b'&' as usize] = true;
-    table[b'"' as usize] = true;
-    table[b'\'' as usize] = true;
-    table
-};
-
 /// Escape HTML text content into output buffer.
 ///
 /// Escapes `<`, `>`, and `&` to their HTML entity equivalents.
 ///
 /// # Example
 /// ```
-/// use ferromark::escape::escape_text_into;
+/// use ferromark::escape_text_into;
 ///
 /// let mut out = Vec::new();
 /// escape_text_into(&mut out, b"<script>");
@@ -97,7 +66,7 @@ pub fn escape_full_into(out: &mut Vec<u8>, input: &[u8]) {
 ///
 /// # Example
 /// ```
-/// use ferromark::escape::escape_attr_into;
+/// use ferromark::escape_attr_into;
 ///
 /// let mut out = Vec::new();
 /// escape_attr_into(&mut out, b"value=\"test\"");
@@ -106,18 +75,6 @@ pub fn escape_full_into(out: &mut Vec<u8>, input: &[u8]) {
 #[inline]
 pub fn escape_attr_into(out: &mut Vec<u8>, input: &[u8]) {
     escape_full_into(out, input)
-}
-
-/// Check if a byte slice needs any escaping for text content.
-#[inline]
-pub fn needs_text_escape(input: &[u8]) -> bool {
-    input.iter().any(|&b| TEXT_ESCAPE_TABLE[b as usize])
-}
-
-/// Check if a byte slice needs any escaping for attribute values.
-#[inline]
-pub fn needs_attr_escape(input: &[u8]) -> bool {
-    input.iter().any(|&b| ATTR_ESCAPE_TABLE[b as usize])
 }
 
 /// Below this length the local short scan beats SIMD memchr passes, whose
@@ -292,25 +249,6 @@ unsafe fn first_escape_neon<const ATTR: bool>(input: &[u8]) -> Option<usize> {
         }
     }
     None
-}
-
-/// Escape and return as a new Vec.
-///
-/// Prefer `escape_text_into` to reuse buffers.
-pub fn escape_text(input: &[u8]) -> Vec<u8> {
-    let mut out = Vec::with_capacity(input.len() + input.len() / 8);
-    escape_text_into(&mut out, input);
-    out
-}
-
-/// Escape and return as a String.
-///
-/// Prefer `escape_text_into` to reuse buffers.
-pub fn escape_text_to_string(input: &str) -> String {
-    let escaped = escape_text(input.as_bytes());
-    // SAFETY: We only add ASCII sequences, so if input was valid UTF-8,
-    // output is also valid UTF-8
-    unsafe { String::from_utf8_unchecked(escaped) }
 }
 
 /// URL percent-encode special characters, then HTML-escape for href attribute.
@@ -572,14 +510,6 @@ mod tests {
     }
 
     #[test]
-    fn test_needs_escape() {
-        assert!(!needs_text_escape(b"hello"));
-        assert!(needs_text_escape(b"<hello>"));
-        assert!(needs_text_escape(b"a & b"));
-        assert!(!needs_text_escape(b""));
-    }
-
-    #[test]
     fn test_escape_consecutive() {
         let mut out = Vec::new();
         escape_text_into(&mut out, b"<<<");
@@ -599,12 +529,6 @@ mod tests {
         out.clear();
         escape_text_into(&mut out, b"<hello");
         assert_eq!(out, b"&lt;hello");
-    }
-
-    #[test]
-    fn test_escape_to_string() {
-        let result = escape_text_to_string("<script>");
-        assert_eq!(result, "&lt;script&gt;");
     }
 
     #[test]

--- a/src/inline/marks.rs
+++ b/src/inline/marks.rs
@@ -249,25 +249,6 @@ impl Default for MarkBuffer {
     }
 }
 
-/// Lookup table for special inline characters.
-/// Returns true if the character might be a delimiter.
-pub static SPECIAL_CHARS: [bool; 256] = {
-    let mut table = [false; 256];
-    table[b'`' as usize] = true; // Code span
-    table[b'*' as usize] = true; // Emphasis
-    table[b'_' as usize] = true; // Emphasis
-    table[b'~' as usize] = true; // Strikethrough
-    table[b'=' as usize] = true; // Highlight
-    table[b'^' as usize] = true; // Superscript
-    table[b'$' as usize] = true; // Math span
-    table[b'\\' as usize] = true; // Escape
-    table[b'\n' as usize] = true; // Line break
-    table[b'[' as usize] = true; // Link
-    table[b']' as usize] = true; // Link
-    table[b'<' as usize] = true; // Autolink/HTML
-    table
-};
-
 /// Scan text and collect marks for the default inline syntax set.
 ///
 /// # Panics

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,8 @@
 //! ferromark streams Markdown into HTML without building an AST. Its default
 //! [`RenderPolicy::Untrusted`] escapes raw HTML and restricts unsafe URL
 //! schemes. Use [`Options`] to select syntax extensions and rendering policy.
+//! Parser implementation modules are private; stable parser, event, range,
+//! store, escaping, and writer types are re-exported from the crate root.
 //!
 //! # Quick start
 //!
@@ -26,27 +28,31 @@
 //! scalar scanner. See the repository benchmark documentation for current,
 //! reproducible measurements.
 
-pub mod block;
-pub mod cursor;
-pub mod escape;
-pub mod footnote;
-pub mod inline;
+mod block;
+mod cursor;
+mod escape;
+mod footnote;
+mod inline;
 pub mod limits;
-pub mod link_ref;
+mod link_ref;
 #[cfg(feature = "mdx")]
 pub mod mdx;
 #[cfg(feature = "profiling")]
 #[doc(hidden)]
 pub mod profiling;
-pub mod range;
-pub mod render;
+mod range;
+mod render;
 
 use smallvec::SmallVec;
 
 // Re-export primary types
-pub use block::{Alignment, BlockEvent, BlockParser, CalloutType, CodeBlockKind, fixup_list_tight};
-pub use footnote::FootnoteStore;
-pub use inline::{InlineEvent, InlineParser};
+pub use block::{
+    Alignment, BlockEvent, BlockParser, CalloutType, CodeBlockKind, ListKind, TaskState,
+    fixup_list_tight,
+};
+pub use escape::{escape_attr_into, escape_text_into};
+pub use footnote::{FootnoteDef, FootnoteStore};
+pub use inline::{AutolinkLiteralKind, InlineEvent, InlineParser};
 pub use limits::{ResourceLimit, ResourceLimitReport};
 pub use link_ref::{LinkRefDef, LinkRefStore};
 pub use range::{InputSizeError, MAX_INPUT_BYTES, Range, validate_input_size};

--- a/src/link_ref.rs
+++ b/src/link_ref.rs
@@ -1,6 +1,5 @@
 //! Link reference definitions (CommonMark).
 
-use crate::Range;
 use memchr::memchr;
 use rustc_hash::FxBuildHasher as FastHashBuilder;
 use std::borrow::Cow;
@@ -74,14 +73,6 @@ impl LinkRefStore {
     pub(crate) fn append_definitions_to(&self, definitions: &mut Vec<LinkRefDef>) {
         definitions.extend(self.defs.iter().cloned());
     }
-}
-
-/// Normalize a link label per CommonMark: decode entities, process backslash escapes,
-/// collapse internal whitespace to single spaces, trim, and case-fold.
-pub fn normalize_label(bytes: &[u8]) -> String {
-    let mut out = String::new();
-    normalize_label_into(bytes, &mut out);
-    out
 }
 
 /// Normalize a link label into a reusable buffer.
@@ -188,14 +179,4 @@ fn normalize_label_text_ascii(input: &[u8], out: &mut String) {
 #[inline]
 fn is_label_escapable(b: u8) -> bool {
     matches!(b, b'[' | b']' | b'\\')
-}
-
-/// Convenience helper to create a definition from ranges in input.
-pub fn def_from_ranges(input: &[u8], url: Range, title: Option<Range>) -> LinkRefDef {
-    let url_bytes = url.slice(input).to_vec();
-    let title_bytes = title.map(|r| r.slice(input).to_vec());
-    LinkRefDef {
-        url: url_bytes,
-        title: title_bytes,
-    }
 }

--- a/tests/non_exhaustive_api_tests.rs
+++ b/tests/non_exhaustive_api_tests.rs
@@ -1,10 +1,22 @@
 //! Public API compatibility checks compiled as an external crate.
 
-use ferromark::block::{ListKind, TaskState};
-use ferromark::inline::AutolinkLiteralKind;
 use ferromark::{
-    Alignment, BlockEvent, CalloutType, CodeBlockKind, InlineEvent, Options, RenderPolicy,
+    Alignment, AutolinkLiteralKind, BlockEvent, CalloutType, CodeBlockKind, FootnoteDef,
+    FootnoteStore, InlineEvent, ListKind, Options, RenderPolicy, TaskState, escape_attr_into,
+    escape_text_into,
 };
+
+#[test]
+fn downstream_uses_the_stable_root_facade() {
+    let mut escaped = Vec::new();
+    escape_text_into(&mut escaped, b"<text>");
+    escape_attr_into(&mut escaped, b"\"");
+    assert_eq!(escaped, b"&lt;text&gt;&quot;");
+
+    let store = FootnoteStore::new();
+    let definition: Option<&FootnoteDef> = store.get(0);
+    assert!(definition.is_none());
+}
 
 #[test]
 fn downstream_can_customize_non_exhaustive_options_by_mutating_a_preset() {


### PR DESCRIPTION
Fixes #166

## Summary
- make low-level parser, storage, range, and rendering modules private while preserving intended types at the crate root
- re-export event support types, stores, and documented escape helpers from the stable facade
- remove helper APIs that became demonstrably dead once the modules were private
- update external API tests, examples, benchmarks, README, and 0.8 migration guidance

## Validation
- cargo check --locked --all-targets --all-features
- cargo test --locked --all-features
- cargo clippy --locked --all-targets --all-features -- -D warnings
- RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features --locked
- cargo public-api -p ferromark --simplified --color never
- cargo fmt --all -- --check
- ruby scripts/test-readme-structure-contract.rb --self-test
- git diff --check