### PR TITLE
Node: reduce copies at the N-API boundary

### DIFF
--- a/node/ferromark/README.md
+++ b/node/ferromark/README.md
@@ -43,6 +43,21 @@ const second = renderer.toHtml('# Second')
 
 Create one renderer per worker; its options are fixed at construction.
 
+## Buffer output
+
+Use `toHtmlBuffer()` when the rendered HTML goes directly to a byte-oriented
+consumer such as an HTTP response. It returns a UTF-8 Node.js `Buffer` backed by
+the native output allocation, avoiding the extra JavaScript string transcode.
+
+```js
+import { toHtmlBuffer } from 'ferromark'
+
+response.end(toHtmlBuffer('# Hello'))
+```
+
+Reusable renderers provide the same output path through
+`renderer.toHtmlBuffer(markdown)`.
+
 ## Untrusted by default
 
 `toHtml()` and `transform()` default to `renderPolicy: 'untrusted'`. Raw HTML
@@ -142,7 +157,8 @@ Image sources and autolinks are not rewritten.
 ## Troubleshooting native loading
 
 The native binding loads when constructing `Renderer` or on the first call to
-`toHtml()`, `transform()`, or a highlighter helper. If that load fails:
+`toHtml()`, `toHtmlBuffer()`, `transform()`, or a highlighter helper. If that
+load fails:
 
 | Message or environment | Resolution |
 | --- | --- |

--- a/node/ferromark/index.d.mts
+++ b/node/ferromark/index.d.mts
@@ -1,3 +1,5 @@
+import type { Buffer } from 'node:buffer'
+
 export type RenderPolicy = 'untrusted' | 'trusted'
 
 export interface Options {
@@ -70,11 +72,16 @@ export interface HighlightOptions {
 
 export declare function toHtml(markdown: string, options?: Options): string
 
+/** Render UTF-8 HTML directly into a Node.js Buffer. */
+export declare function toHtmlBuffer(markdown: string, options?: Options): Buffer
+
 /** Reusable Markdown renderer with fixed options. */
 export declare class Renderer {
   constructor(options?: Options)
   /** Render one document while retaining parser scratch allocations. */
   toHtml(markdown: string): string
+  /** Render UTF-8 HTML directly into a Node.js Buffer. */
+  toHtmlBuffer(markdown: string): Buffer
 }
 
 /**

--- a/node/ferromark/index.mjs
+++ b/node/ferromark/index.mjs
@@ -56,6 +56,17 @@ export function toHtml(markdown, options) {
   return loadNative().toHtml(markdown, options)
 }
 
+/**
+ * Render UTF-8 HTML into a Node.js Buffer.
+ * @param {string} markdown
+ * @param {import('./index.mjs').Options} [options]
+ * @returns {import('node:buffer').Buffer}
+ */
+export function toHtmlBuffer(markdown, options) {
+  validateOptions(options)
+  return loadNative().toHtmlBuffer(markdown, options)
+}
+
 /** Reusable Markdown renderer with fixed options. */
 export class Renderer {
   /** @type {NativeRendererSession} */
@@ -71,6 +82,11 @@ export class Renderer {
   /** @param {string} markdown */
   toHtml(markdown) {
     return this.#native.toHtml(markdown)
+  }
+
+  /** @param {string} markdown @returns {import('node:buffer').Buffer} */
+  toHtmlBuffer(markdown) {
+    return this.#native.toHtmlBuffer(markdown)
   }
 }
 
@@ -150,10 +166,17 @@ export function transformWithHighlighter(markdown, highlighter, highlightOptions
 
 /**
  * @typedef {(code: string, language?: string | null, meta?: string | null) => string | null} NativeFencedCodeRenderer
- * @typedef {{ toHtml(markdown: string): string }} NativeRendererSession
+ * @typedef {{
+ *   toHtml(markdown: string): string
+ *   toHtmlBuffer(markdown: string): import('node:buffer').Buffer
+ * }} NativeRendererSession
  * @typedef {{
  *   Renderer: new (options?: import('./index.mjs').Options) => NativeRendererSession
  *   toHtml(markdown: string, options?: import('./index.mjs').Options): string
+ *   toHtmlBuffer(
+ *     markdown: string,
+ *     options?: import('./index.mjs').Options,
+ *   ): import('node:buffer').Buffer
  *   toHtmlWithRenderer(
  *     markdown: string,
  *     options: import('./index.mjs').Options | undefined,

--- a/node/ferromark/native.d.ts
+++ b/node/ferromark/native.d.ts
@@ -6,6 +6,8 @@ export declare class Renderer {
   constructor(options?: Options | undefined | null)
   /** Render one Markdown document and retain scratch allocations for the next. */
   toHtml(markdown: string): string
+  /** Render into a Node.js Buffer and retain parser scratch allocations. */
+  toHtmlBuffer(markdown: string): Buffer
 }
 
 /** One document heading, in source order. */
@@ -45,6 +47,9 @@ export interface Options {
 }
 
 export declare function toHtml(markdown: string, options?: Options | undefined | null): string
+
+/** Render Markdown into a Node.js Buffer without transcoding the HTML to a JS string. */
+export declare function toHtmlBuffer(markdown: string, options?: Options | undefined | null): Buffer
 
 export declare function toHtmlWithRenderer(markdown: string, options: Options | undefined | null, renderer: (arg0: string, arg1?: string | undefined | null, arg2?: string | undefined | null) => string | null): string
 

--- a/node/ferromark/scripts/test-readme-contract.mjs
+++ b/node/ferromark/scripts/test-readme-contract.mjs
@@ -58,8 +58,14 @@ function assertReadmeContract(candidate) {
   assert.match(loader, /export class Renderer/, 'loader must export the reusable Renderer API')
   assert.match(declarations, /export declare class Renderer/, 'declarations must expose Renderer')
 
+  assert.match(candidate, /^## Buffer output$/m, 'README must document Buffer output')
+  assert.match(candidate, /response\.end\(toHtmlBuffer\(/, 'README must show direct Buffer consumption')
+  assert.match(loader, /export function toHtmlBuffer/, 'loader must export Buffer rendering')
+  assert.match(declarations, /function toHtmlBuffer\([^)]*\): Buffer/, 'declarations must expose Buffer rendering')
+  assert.match(declarations, /toHtmlBuffer\(markdown: string\): Buffer/, 'reusable renderer must expose Buffer rendering')
+
   assert.match(candidate, /^## Troubleshooting native loading$/m, 'README must explain lazy loader failures')
-  assert.match(candidate, /constructing `Renderer` or on the first call to\s+`toHtml\(\)`, `transform\(\)`, or a highlighter helper/i)
+  assert.match(candidate, /constructing `Renderer` or on the first call to\s+`toHtml\(\)`, `toHtmlBuffer\(\)`, `transform\(\)`, or a highlighter helper/i)
 
   assert.match(nativeTargets, /linux-arm64-musl/, 'loader must select the arm64 musl package')
   assert.match(nativeTargets, /linux-x64-musl/, 'loader must select the x64 musl package')

--- a/node/ferromark/scripts/verify-package.mjs
+++ b/node/ferromark/scripts/verify-package.mjs
@@ -10,7 +10,7 @@ const [declarations, packageJson, releaseConfig, buildNative] = await Promise.al
   readFile(new URL('../../../release-please-config.json', import.meta.url), 'utf8').then(JSON.parse),
   readFile(new URL('./build-native.mjs', import.meta.url), 'utf8'),
 ])
-for (const name of ['Options', 'toHtml', 'toHtmlWithRenderer']) {
+for (const name of ['Options', 'toHtml', 'toHtmlBuffer', 'toHtmlWithRenderer']) {
   if (!declarations.includes(name)) {
     throw new Error(`Generated native declarations are missing ${name}`)
   }

--- a/node/ferromark/test/index.test.mjs
+++ b/node/ferromark/test/index.test.mjs
@@ -11,6 +11,7 @@ import { fileURLToPath, pathToFileURL } from 'node:url'
 import {
   Renderer,
   toHtml,
+  toHtmlBuffer,
   toHtmlWithHighlighter,
   transform,
   transformWithHighlighter,
@@ -21,12 +22,27 @@ test('renders Markdown through the native binding', () => {
   assert.equal(toHtml('# Hello'), '<h1 id="hello">Hello</h1>\n')
 })
 
+test('renders UTF-8 HTML directly into Node.js Buffers', () => {
+  const expected = '<h1 id="grüße">Grüße</h1>\n'
+  const output = toHtmlBuffer('# Grüße')
+
+  assert.ok(Buffer.isBuffer(output))
+  assert.equal(output.toString('utf8'), expected)
+
+  const renderer = new Renderer({ headingIds: false })
+  const reusedOutput = renderer.toHtmlBuffer('# Grüße')
+  assert.ok(Buffer.isBuffer(reusedOutput))
+  assert.equal(reusedOutput.toString('utf8'), '<h1>Grüße</h1>\n')
+})
+
 test('rejects non-string Markdown across every public render entry point', () => {
   const highlighter = { codeToHtml: () => '<pre><code></code></pre>\n' }
   const calls = [
     () => toHtml(123),
+    () => toHtmlBuffer(123),
     () => transform(null),
     () => new Renderer().toHtml({}),
+    () => new Renderer().toHtmlBuffer({}),
     () => toHtmlWithHighlighter(123, highlighter, { theme: 'dark' }),
     () => transformWithHighlighter(123, highlighter, { theme: 'dark' }),
   ]
@@ -101,6 +117,7 @@ test('rejects unknown option keys across every public render entry point', () =>
   }
   const calls = [
     () => toHtml('text', { taskList: true }),
+    () => toHtmlBuffer('text', { taskList: true }),
     () => transform('text', { footnote: true }),
     () => toHtmlWithHighlighter('text', highlighter, { theme: 'dark' }, { taskList: true }),
     () => transformWithHighlighter('text', highlighter, { theme: 'dark' }, { footnote: true }),

--- a/node/ferromark/test/types.test.mts
+++ b/node/ferromark/test/types.test.mts
@@ -1,5 +1,6 @@
+import type { Buffer } from 'node:buffer'
 import type { CodeHighlighter, Options } from '../index.mjs'
-import { Renderer, toHtml, toHtmlWithHighlighter } from '../index.mjs'
+import { Renderer, toHtml, toHtmlBuffer, toHtmlWithHighlighter } from '../index.mjs'
 
 const options: Options = {
   renderPolicy: 'untrusted',
@@ -16,7 +17,12 @@ const highlighter: CodeHighlighter = {
 }
 
 toHtml('# Typed', options)
-new Renderer(options).toHtml('# Reused')
+const output: Buffer = toHtmlBuffer('# Buffered', options)
+output.toString('utf8')
+const renderer = new Renderer(options)
+renderer.toHtml('# Reused')
+const reusedOutput: Buffer = renderer.toHtmlBuffer('# Buffered and reused')
+reusedOutput.toString('utf8')
 toHtmlWithHighlighter('```ts\nconst typed = true\n```', highlighter, {
   theme: 'github-dark',
   onHighlightError(error, { lang }) {

--- a/node/native/src/lib.rs
+++ b/node/native/src/lib.rs
@@ -2,7 +2,8 @@ use ferromark::{
     FencedCodeBlock, FencedCodeRenderer, InputSizeError, Options as CoreOptions, RenderPolicy,
     Renderer as CoreRenderer, TrustedHtml,
 };
-use napi::bindgen_prelude::{Error, FnArgs, Function, Result, Status};
+use napi::JsValue;
+use napi::bindgen_prelude::{Buffer, Error, FnArgs, FromNapiValue, Function, Result, Status};
 use napi_derive::napi;
 
 #[cfg(feature = "panic-test")]
@@ -102,6 +103,16 @@ pub fn to_html(markdown: String, options: Option<Options>) -> Result<String> {
         .map_err(input_size_error)
 }
 
+/// Render Markdown into a Node.js Buffer without transcoding the HTML to a JS string.
+#[napi(catch_unwind)]
+pub fn to_html_buffer(markdown: String, options: Option<Options>) -> Result<Buffer> {
+    let options = core_options(options)?;
+    let mut output = Vec::new();
+    ferromark::try_to_html_into_with_options(&markdown, &mut output, &options)
+        .map_err(input_size_error)?;
+    Ok(output.into())
+}
+
 /// Reusable Markdown-to-HTML renderer with fixed options.
 #[napi]
 pub struct Renderer {
@@ -122,6 +133,16 @@ impl Renderer {
     #[napi(catch_unwind, js_name = "toHtml")]
     pub fn to_html(&mut self, markdown: String) -> Result<String> {
         self.inner.try_render(&markdown).map_err(input_size_error)
+    }
+
+    /// Render into a Node.js Buffer and retain parser scratch allocations.
+    #[napi(catch_unwind, js_name = "toHtmlBuffer")]
+    pub fn to_html_buffer(&mut self, markdown: String) -> Result<Buffer> {
+        let mut output = Vec::new();
+        self.inner
+            .try_render_into(&markdown, &mut output)
+            .map_err(input_size_error)?;
+        Ok(output.into())
     }
 }
 
@@ -172,6 +193,12 @@ pub fn transform(markdown: String, options: Option<Options>) -> Result<Transform
         .map_err(input_size_error)
 }
 
+type BorrowedCallback<'scope, 'input> = Function<
+    'scope,
+    FnArgs<(&'input str, Option<&'input str>, Option<&'input str>)>,
+    Option<String>,
+>;
+
 #[allow(clippy::type_complexity)]
 struct CallbackRenderer<'scope> {
     callback: Function<'scope, FnArgs<(String, Option<String>, Option<String>)>, Option<String>>,
@@ -182,6 +209,21 @@ impl CallbackRenderer<'_> {
     fn finish<T>(self, result: Result<T>) -> Result<T> {
         self.error.map_or(result, Err)
     }
+
+    fn call(
+        &self,
+        code: &str,
+        language: Option<&str>,
+        meta: Option<&str>,
+    ) -> Result<Option<String>> {
+        let value = self.callback.value();
+        // SAFETY: Function argument types only control Rust-to-JavaScript
+        // conversion. The reborrowed handle is the same validated JS function,
+        // and its shorter lifetime cannot escape this synchronous call.
+        let callback: BorrowedCallback<'_, '_> =
+            unsafe { Function::from_napi_value(value.env, value.value)? };
+        callback.call(FnArgs::from((code, language, meta)))
+    }
 }
 
 impl FencedCodeRenderer for CallbackRenderer<'_> {
@@ -190,11 +232,7 @@ impl FencedCodeRenderer for CallbackRenderer<'_> {
             return None;
         }
 
-        match self.callback.call(FnArgs::from((
-            block.code.to_owned(),
-            block.language.map(str::to_owned),
-            block.meta.map(str::to_owned),
-        ))) {
+        match self.call(block.code, block.language, block.meta) {
             Ok(html) => html.map(TrustedHtml::from_trusted),
             Err(error) => {
                 self.error = Some(error);


### PR DESCRIPTION
## Summary
- add `toHtmlBuffer()` and reusable `Renderer#toHtmlBuffer()` APIs backed by the core byte-output path
- pass borrowed fenced-code slices directly to N-API instead of allocating intermediate Rust strings
- document, type, and test the Buffer API and package contract

## Validation
- `cargo test --workspace --all-targets`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `pnpm run build`
- `pnpm run lint`
- `pnpm run typecheck`
- `pnpm run test`

Closes #189