### PR TITLE
Configure Renovate for Cargo and lockfile maintenance

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,4 +1,15 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["github>sebastian-software/renovate-config"]
+  "extends": ["github>sebastian-software/renovate-config"],
+  "lockFileMaintenance": {
+    "enabled": true
+  },
+  "packageRules": [
+    {
+      "description": "Group compatible Rust dependency updates",
+      "matchManagers": ["cargo"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "groupName": "Rust dependencies"
+    }
+  ]
 }


### PR DESCRIPTION
## Summary
- enable Renovate lockfile maintenance for transitive dependency refreshes
- group non-major Cargo dependency updates into reviewable Rust dependency PRs
- keep major Rust updates separate

Renovate is now installed and actively maintains Dependency Dashboard #36; this completes the remaining repository configuration from the issue.

## Validation
- `jq empty renovate.json`
- reviewed the inherited `sebastian-software/renovate-config` preset for rule compatibility

Closes #144