### PR TITLE
Release: add locked crates.io publish recovery

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,6 +3,7 @@ name: Release
 on:
   push:
     branches: [main]
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -13,6 +14,7 @@ concurrency:
 
 jobs:
   release-please:
+    if: ${{ github.event_name == 'push' }}
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -33,7 +35,18 @@ jobs:
     needs:
       - release-please
       - verify-npm-publish
-    if: ${{ needs.release-please.outputs.releases_created == 'true' }}
+    if: >-
+      ${{
+        always() &&
+        github.ref == 'refs/heads/main' &&
+        (
+          github.event_name == 'workflow_dispatch' ||
+          (
+            needs.release-please.outputs.releases_created == 'true' &&
+            needs.verify-npm-publish.result == 'success'
+          )
+        )
+      }}
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
@@ -45,7 +58,7 @@ jobs:
           toolchain: stable
 
       - name: Publish to crates.io
-        run: cargo publish
+        run: cargo publish --locked
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
 

--- a/scripts/test-publish-verification.mjs
+++ b/scripts/test-publish-verification.mjs
@@ -44,6 +44,20 @@ function assertCratePublicationWaitsForVerification(source) {
   assert.doesNotMatch(crateJob, /- publish-npm/)
 }
 
+function assertCratePublicationCanBeRecovered(source) {
+  const crateJob = source.slice(
+    source.indexOf('\n  publish-crate:\n'),
+    source.indexOf('\n  build-native:\n'),
+  )
+  assert.match(source, /\n  workflow_dispatch:\n/)
+  assert.match(source, /release-please:\n    if: \$\{\{ github\.event_name == 'push' \}\}/)
+  assert.match(crateJob, /always\(\)/, 'manual recovery must run despite skipped npm jobs')
+  assert.match(crateJob, /github\.ref == 'refs\/heads\/main'/)
+  assert.match(crateJob, /github\.event_name == 'workflow_dispatch'/)
+  assert.match(crateJob, /needs\.verify-npm-publish\.result == 'success'/)
+  assert.match(crateJob, /run: cargo publish --locked/)
+}
+
 function assertPlatformPackagesArePublished(source) {
   for (const artifact of [
     'darwin-arm64',
@@ -77,6 +91,7 @@ function assertPlatformPackagesArePublished(source) {
 
 assertValidVerifierJob(workflow)
 assertCratePublicationWaitsForVerification(workflow)
+assertCratePublicationCanBeRecovered(workflow)
 assertPlatformPackagesArePublished(workflow)
 assert.throws(
   () => assertValidVerifierJob(workflow.replace('\n  verify-npm-publish:\n', '\n  npm-check:\n')),
@@ -106,6 +121,17 @@ assert.throws(
       workflow.replace('- verify-npm-publish', '- publish-npm'),
     ),
   /crate publication must wait for successful npm registry verification/,
+)
+assert.throws(
+  () => assertCratePublicationCanBeRecovered(workflow.replace('\n  workflow_dispatch:\n', '\n')),
+  /workflow_dispatch/,
+)
+assert.throws(
+  () =>
+    assertCratePublicationCanBeRecovered(
+      workflow.replace('cargo publish --locked', 'cargo publish'),
+    ),
+  /cargo publish --locked/,
 )
 
 assert.equal(registryVersionUrl('ferromark', '0.7.0'), 'https://registry.npmjs.org/ferromark/0.7.0')


### PR DESCRIPTION
## Summary
- add a manual crate-only recovery path for releases where npm succeeded but crates.io did not
- restrict manual crate publication to the `main` branch
- publish with the tested lockfile via `cargo publish --locked`
- extend the release workflow contract tests for the recovery conditions

This safely completes the repository-only recovery and lockfile parts of #174. The issue intentionally remains open until the crates.io Trusted Publisher is configured externally; switching authentication before that would break the next release.

## Validation
- `node ./scripts/test-publish-verification.mjs`
- `./scripts/test-check-workflow-pins.sh`
- `./scripts/check-workflow-pins.sh`
- YAML parse of `.github/workflows/publish.yml`
- `cargo publish --locked --dry-run --allow-dirty`

Progresses #174